### PR TITLE
feat: label more aws resources

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/resources/karpenter.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/resources/karpenter.ex
@@ -403,8 +403,12 @@ defmodule CommonCore.Resources.Karpenter do
       "role" => battery.config.node_role_name,
       "securityGroupSelectorTerms" => [%{"tags" => %{"karpenter.sh/discovery" => cluster_name}}],
       "subnetSelectorTerms" => [%{"tags" => %{"karpenter.sh/discovery" => cluster_name}}],
-      # TODO(jdt): need to merge in other "default" tags
-      "tags" => %{"karpenter.sh/discovery" => cluster_name}
+      "tags" => %{
+        "karpenter.sh/discovery" => cluster_name,
+        "batteriesincl.com/managed" => "true",
+        "batteriesincl.com/environment" => "organization/bi/#{cluster_name}",
+        "Name" => "#{cluster_name}-fleet"
+      }
     }
 
     :karpenter_ec2node_class


### PR DESCRIPTION
As I was in AWS, I noticed a few things that still aren't tagged well / correctly. We now have the information to get those resources tagged so a quick PR to do just that.

Resources:
1. Karpenter worker nodes
![image](https://github.com/batteries-included/batteries-included/assets/2999202/5c6bf275-4aeb-4300-b4bd-dba1ec5db1f5)

1. AWS load balancer controller created LBs
![image](https://github.com/batteries-included/batteries-included/assets/2999202/288fcfef-a542-4aed-8d96-90ea40d27203)
