### PR TITLE
chore: move knative image tags to battery config

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/knative_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/knative_config.ex
@@ -6,6 +6,15 @@ defmodule CommonCore.Batteries.KnativeConfig do
   alias CommonCore.Defaults
 
   batt_polymorphic_schema type: :knative do
-    defaultable_field :namespace, :string, default: Defaults.Namespaces.knative()
+    field :namespace, :string, default: Defaults.Namespaces.knative()
+
+    defaultable_field :queue_image, :string, default: Defaults.Images.knative_serving_queue_image()
+    defaultable_field :activator_image, :string, default: Defaults.Images.knative_serving_activator_image()
+    defaultable_field :autoscaler_image, :string, default: Defaults.Images.knative_serving_autoscaler_image()
+    defaultable_field :controller_image, :string, default: Defaults.Images.knative_serving_controller_image()
+    defaultable_field :webhook_image, :string, default: Defaults.Images.knative_serving_webhook_image()
+
+    defaultable_field :istio_controller_image, :string, default: Defaults.Images.knative_istio_controller_image()
+    defaultable_field :istio_webhook_image, :string, default: Defaults.Images.knative_istio_webhook_image()
   end
 end

--- a/platform_umbrella/apps/common_core/lib/common_core/defaults/images.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/defaults/images.ex
@@ -44,4 +44,13 @@ defmodule CommonCore.Defaults.Images do
   def trust_manager_image, do: "quay.io/jetstack/trust-manager:v0.9.2"
   def trust_manager_init_image, do: "quay.io/jetstack/cert-manager-package-debian:20210119.0"
   def vm_operator_image, do: "victoriametrics/operator:v0.39.4"
+
+  def knative_serving_queue_image, do: "gcr.io/knative-releases/knative.dev/serving/cmd/queue:v1.14.1"
+  def knative_serving_activator_image, do: "gcr.io/knative-releases/knative.dev/serving/cmd/activator:v1.14.1"
+  def knative_serving_autoscaler_image, do: "gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler:v1.14.1"
+  def knative_serving_controller_image, do: "gcr.io/knative-releases/knative.dev/serving/cmd/controller:v1.14.1"
+  def knative_serving_webhook_image, do: "gcr.io/knative-releases/knative.dev/serving/cmd/webhook:v1.14.1"
+
+  def knative_istio_controller_image, do: "gcr.io/knative-releases/knative.dev/net-istio/cmd/controller:v1.14.1"
+  def knative_istio_webhook_image, do: "gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook:v1.14.1"
 end

--- a/platform_umbrella/apps/common_core/lib/common_core/resources/knative/crds.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/resources/knative/crds.ex
@@ -1,6 +1,5 @@
 defmodule CommonCore.Resources.KnativeServingCRDs do
   @moduledoc false
-
   use CommonCore.IncludeResource,
     certificates_networking_internal_knative_dev:
       "priv/manifests/knative-serving/certificates_networking_internal_knative_dev.yaml",

--- a/platform_umbrella/apps/common_core/lib/common_core/resources/knative/net_istio.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/resources/knative/net_istio.ex
@@ -57,7 +57,7 @@ defmodule CommonCore.Resources.KnativeNetIstio do
                 %{"name" => "ENABLE_SECRET_INFORMER_FILTERING_BY_CERT_UID", "value" => "false"},
                 %{"name" => "METRICS_DOMAIN", "value" => "knative.dev/net-istio"}
               ],
-              "image" => "gcr.io/knative-releases/knative.dev/net-istio/cmd/controller:v1.12.1",
+              "image" => battery.config.istio_controller_image,
               "livenessProbe" => %{
                 "failureThreshold" => 6,
                 "httpGet" => %{"path" => "/health", "port" => "probes", "scheme" => "HTTP"},
@@ -134,8 +134,7 @@ defmodule CommonCore.Resources.KnativeNetIstio do
                 %{"name" => "WEBHOOK_NAME", "value" => "net-istio-webhook"},
                 %{"name" => "WEBHOOK_PORT", "value" => "8443"}
               ],
-              "image" =>
-                "gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook@sha256:90083eb29e6ab29a352fbf606257ca397e4039acb12f7c08152dc1e409e5ce50",
+              "image" => battery.config.istio_webhook_image,
               "livenessProbe" => %{
                 "failureThreshold" => 6,
                 "httpGet" => %{

--- a/platform_umbrella/apps/common_core/lib/common_core/resources/knative/serving.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/resources/knative/serving.ex
@@ -245,10 +245,7 @@ defmodule CommonCore.Resources.KnativeServing do
   end
 
   resource(:config_map_deployment, battery, _state) do
-    data =
-      %{
-        "queue-sidecar-image" => "gcr.io/knative-releases/knative.dev/serving/cmd/queue:v1.12.3"
-      }
+    data = %{"queue-sidecar-image" => battery.config.queue_image}
 
     :config_map
     |> B.build_resource()
@@ -370,7 +367,7 @@ defmodule CommonCore.Resources.KnativeServing do
                 %{"name" => "CONFIG_OBSERVABILITY_NAME", "value" => "config-observability"},
                 %{"name" => "METRICS_DOMAIN", "value" => "knative.dev/internal/serving"}
               ],
-              "image" => "gcr.io/knative-releases/knative.dev/serving/cmd/activator:v1.12.3",
+              "image" => battery.config.activator_image,
               "livenessProbe" => %{
                 "failureThreshold" => 12,
                 "httpGet" => %{
@@ -465,7 +462,7 @@ defmodule CommonCore.Resources.KnativeServing do
                 %{"name" => "CONFIG_OBSERVABILITY_NAME", "value" => "config-observability"},
                 %{"name" => "METRICS_DOMAIN", "value" => "knative.dev/serving"}
               ],
-              "image" => "gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler:v1.12.3",
+              "image" => battery.config.autoscaler_image,
               "livenessProbe" => %{
                 "failureThreshold" => 6,
                 "httpGet" => %{
@@ -557,7 +554,7 @@ defmodule CommonCore.Resources.KnativeServing do
                 %{"name" => "CONFIG_OBSERVABILITY_NAME", "value" => "config-observability"},
                 %{"name" => "METRICS_DOMAIN", "value" => "knative.dev/internal/serving"}
               ],
-              "image" => "gcr.io/knative-releases/knative.dev/serving/cmd/controller:v1.12.3",
+              "image" => battery.config.controller_image,
               "livenessProbe" => %{
                 "failureThreshold" => 6,
                 "httpGet" => %{"path" => "/health", "port" => "probes", "scheme" => "HTTP"},
@@ -644,7 +641,7 @@ defmodule CommonCore.Resources.KnativeServing do
                 %{"name" => "WEBHOOK_PORT", "value" => "8443"},
                 %{"name" => "METRICS_DOMAIN", "value" => "knative.dev/internal/serving"}
               ],
-              "image" => "gcr.io/knative-releases/knative.dev/serving/cmd/webhook:v1.12.3",
+              "image" => battery.config.webhook_image,
               "livenessProbe" => %{
                 "failureThreshold" => 6,
                 "httpGet" => %{
@@ -758,7 +755,7 @@ defmodule CommonCore.Resources.KnativeServing do
 
   resource(:knative_image_queue_proxy, battery, _state) do
     spec =
-      Map.put(%{}, "image", "gcr.io/knative-releases/knative.dev/serving/cmd/queue:v1.12.3")
+      Map.put(%{}, "image", battery.config.queue_image)
 
     :knative_image
     |> B.build_resource()

--- a/platform_umbrella/apps/common_core/priv/manifests/knative-serving/certificates_networking_internal_knative_dev.yaml
+++ b/platform_umbrella/apps/common_core/priv/manifests/knative-serving/certificates_networking_internal_knative_dev.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/component: networking
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: 1.12.3
+    app.kubernetes.io/version: 1.14.1
     knative.dev/crd-install: 'true'
   name: certificates.networking.internal.knative.dev
 spec:
@@ -31,40 +31,37 @@ spec:
       name: v1alpha1
       schema:
         openAPIV3Schema:
-          description:
-            Certificate is responsible for provisioning a SSL certificate for
-            the given hosts. It is a Knative abstraction for various SSL
-            certificate provisioning solutions (such as cert-manager or
-            self-signed SSL certificate).
+          description: |-
+            Certificate is responsible for provisioning a SSL certificate for the
+            given hosts. It is a Knative abstraction for various SSL certificate
+            provisioning solutions (such as cert-manager or self-signed SSL certificate).
           properties:
             apiVersion:
-              description:
-                'APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the
-                latest internal value, and may reject unrecognized values. More
-                info:
-                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description:
-                'Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the
-                client submits requests to. Cannot be updated. In CamelCase.
-                More info:
-                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
             spec:
-              description:
-                'Spec is the desired state of the Certificate. More info:
-                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+              description: |-
+                Spec is the desired state of the Certificate.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
               properties:
                 dnsNames:
-                  description:
-                    DNSNames is a list of DNS names the Certificate could
-                    support. The wildcard format of DNSNames (e.g.
-                    *.default.example.com) is supported.
+                  description: |-
+                    DNSNames is a list of DNS names the Certificate could support.
+                    The wildcard format of DNSNames (e.g. *.default.example.com) is supported.
                   items:
                     type: string
                   type: array
@@ -82,37 +79,33 @@ spec:
                 - secretName
               type: object
             status:
-              description:
-                'Status is the current state of the Certificate. More info:
-                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+              description: |-
+                Status is the current state of the Certificate.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
               properties:
                 annotations:
                   additionalProperties:
                     type: string
-                  description:
-                    Annotations is additional Status fields for the Resource to
-                    save some additional State as well as convey more
-                    information to the user. This is roughly akin to Annotations
-                    on any k8s resource, just the reconciler conveying richer
-                    information outwards.
+                  description: |-
+                    Annotations is additional Status fields for the Resource to save some
+                    additional State as well as convey more information to the user. This is
+                    roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                    richer information outwards.
                   type: object
                 conditions:
                   description:
                     Conditions the latest available observations of a resource's
                     current state.
                   items:
-                    description:
-                      'Condition defines a readiness condition for a Knative
-                      resource. See:
-                      https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                    description: |-
+                      Condition defines a readiness condition for a Knative resource.
+                      See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
                     properties:
                       lastTransitionTime:
-                        description:
-                          LastTransitionTime is the last time the condition
-                          transitioned from one status to another. We use
-                          VolatileTime in place of metav1.Time to exclude this
-                          from creating equality.Semantic differences (all other
-                          things held constant).
+                        description: |-
+                          LastTransitionTime is the last time the condition transitioned from one status to another.
+                          We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                          differences (all other things held constant).
                         type: string
                       message:
                         description:
@@ -124,10 +117,9 @@ spec:
                           The reason for the condition's last transition.
                         type: string
                       severity:
-                        description:
-                          Severity with which to treat failures of this type of
-                          condition. When this is not specified, it defaults to
-                          Error.
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
                         type: string
                       status:
                         description:
@@ -142,13 +134,13 @@ spec:
                     type: object
                   type: array
                 http01Challenges:
-                  description:
-                    HTTP01Challenges is a list of HTTP01 challenges that need to
-                    be fulfilled in order to get the TLS certificate..
+                  description: |-
+                    HTTP01Challenges is a list of HTTP01 challenges that need to be fulfilled
+                    in order to get the TLS certificate..
                   items:
-                    description:
-                      HTTP01Challenge defines the status of a HTTP01 challenge
-                      that a certificate needs to fulfill.
+                    description: |-
+                      HTTP01Challenge defines the status of a HTTP01 challenge that a certificate needs
+                      to fulfill.
                     properties:
                       serviceName:
                         description:
@@ -176,13 +168,13 @@ spec:
                     type: object
                   type: array
                 notAfter:
-                  description:
-                    The expiration time of the TLS certificate stored in the
-                    secret named by this resource in spec.secretName.
+                  description: |-
+                    The expiration time of the TLS certificate stored in the secret named
+                    by this resource in spec.secretName.
                   format: date-time
                   type: string
                 observedGeneration:
-                  description:
+                  description: |-
                     ObservedGeneration is the 'Generation' of the Service that
                     was last processed by the controller.
                   format: int64

--- a/platform_umbrella/apps/common_core/priv/manifests/knative-serving/clusterdomainclaims_networking_internal_knative_dev.yaml
+++ b/platform_umbrella/apps/common_core/priv/manifests/knative-serving/clusterdomainclaims_networking_internal_knative_dev.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/component: networking
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: 1.12.3
+    app.kubernetes.io/version: 1.14.1
     knative.dev/crd-install: 'true'
   name: clusterdomainclaims.networking.internal.knative.dev
 spec:
@@ -29,32 +29,31 @@ spec:
             domain name.
           properties:
             apiVersion:
-              description:
-                'APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the
-                latest internal value, and may reject unrecognized values. More
-                info:
-                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description:
-                'Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the
-                client submits requests to. Cannot be updated. In CamelCase.
-                More info:
-                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
             spec:
-              description:
-                'Spec is the desired state of the ClusterDomainClaim. More info:
-                https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+              description: |-
+                Spec is the desired state of the ClusterDomainClaim.
+                More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
               properties:
                 namespace:
-                  description:
-                    Namespace is the namespace which is allowed to create a
-                    DomainMapping using this ClusterDomainClaim's name.
+                  description: |-
+                    Namespace is the namespace which is allowed to create a DomainMapping
+                    using this ClusterDomainClaim's name.
                   type: string
               required:
                 - namespace

--- a/platform_umbrella/apps/common_core/priv/manifests/knative-serving/configurations_serving_knative_dev.yaml
+++ b/platform_umbrella/apps/common_core/priv/manifests/knative-serving/configurations_serving_knative_dev.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: 1.12.3
+    app.kubernetes.io/version: 1.14.1
     duck.knative.dev/podspecable: 'true'
     knative.dev/crd-install: 'true'
   name: configurations.serving.knative.dev
@@ -30,38 +30,36 @@ spec:
         - jsonPath: .status.latestReadyRevisionName
           name: LatestReady
           type: string
-        - jsonPath: .status.conditions[?(@.type=='Ready')].status
+        - jsonPath: ".status.conditions[?(@.type=='Ready')].status"
           name: Ready
           type: string
-        - jsonPath: .status.conditions[?(@.type=='Ready')].reason
+        - jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
           name: Reason
           type: string
       name: v1
       schema:
         openAPIV3Schema:
-          description:
-            'Configuration represents the "floating HEAD" of a linear history of
-            Revisions. Users create new Revisions by updating the
-            Configuration''s spec. The "latest created" revision''s name is
-            available under status, as is the "latest ready" revision''s name.
-            See also:
-            https://github.com/knative/serving/blob/main/docs/spec/overview.md#configuration'
+          description: |-
+            Configuration represents the "floating HEAD" of a linear history of Revisions.
+            Users create new Revisions by updating the Configuration's spec.
+            The "latest created" revision's name is available under status, as is the
+            "latest ready" revision's name.
+            See also: https://github.com/knative/serving/blob/main/docs/spec/overview.md#configuration
           properties:
             apiVersion:
-              description:
-                'APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the
-                latest internal value, and may reject unrecognized values. More
-                info:
-                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description:
-                'Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the
-                client submits requests to. Cannot be updated. In CamelCase.
-                More info:
-                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -113,66 +111,54 @@ spec:
                             mounted.
                           type: boolean
                         containerConcurrency:
-                          description:
-                            ContainerConcurrency specifies the maximum allowed
-                            in-flight (concurrent) requests per container of the
-                            Revision.  Defaults to `0` which means concurrency
-                            to the application is not limited, and the system
-                            decides the target concurrency for the autoscaler.
+                          description: |-
+                            ContainerConcurrency specifies the maximum allowed in-flight (concurrent)
+                            requests per container of the Revision.  Defaults to `0` which means
+                            concurrency to the application is not limited, and the system decides the
+                            target concurrency for the autoscaler.
                           format: int64
                           type: integer
                         containers:
-                          description:
-                            List of containers belonging to the pod. Containers
-                            cannot currently be added or removed. There must be
-                            at least one container in a Pod. Cannot be updated.
+                          description: |-
+                            List of containers belonging to the pod.
+                            Containers cannot currently be added or removed.
+                            There must be at least one container in a Pod.
+                            Cannot be updated.
                           items:
                             description:
                               A single application container that you want to
                               run within a pod.
                             properties:
                               args:
-                                description:
-                                  'Arguments to the entrypoint. The container
-                                  image''s CMD is used if this is not provided.
-                                  Variable references $(VAR_NAME) are expanded
-                                  using the container''s environment. If a
-                                  variable cannot be resolved, the reference in
-                                  the input string will be unchanged. Double $$
-                                  are reduced to a single $, which allows for
-                                  escaping the $(VAR_NAME) syntax: i.e.
-                                  "$$(VAR_NAME)" will produce the string literal
-                                  "$(VAR_NAME)". Escaped references will never
-                                  be expanded, regardless of whether the
-                                  variable exists or not. Cannot be updated.
-                                  More info:
-                                  https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                description: |-
+                                  Arguments to the entrypoint.
+                                  The container image's CMD is used if this is not provided.
+                                  Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                  cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                  to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                  produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                  of whether the variable exists or not. Cannot be updated.
+                                  More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                 items:
                                   type: string
                                 type: array
                               command:
-                                description:
-                                  'Entrypoint array. Not executed within a
-                                  shell. The container image''s ENTRYPOINT is
-                                  used if this is not provided. Variable
-                                  references $(VAR_NAME) are expanded using the
-                                  container''s environment. If a variable cannot
-                                  be resolved, the reference in the input string
-                                  will be unchanged. Double $$ are reduced to a
-                                  single $, which allows for escaping the
-                                  $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                                  produce the string literal "$(VAR_NAME)".
-                                  Escaped references will never be expanded,
-                                  regardless of whether the variable exists or
-                                  not. Cannot be updated. More info:
-                                  https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                description: |-
+                                  Entrypoint array. Not executed within a shell.
+                                  The container image's ENTRYPOINT is used if this is not provided.
+                                  Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                  cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                  to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                  produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                  of whether the variable exists or not. Cannot be updated.
+                                  More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                 items:
                                   type: string
                                 type: array
                               env:
-                                description:
-                                  List of environment variables to set in the
-                                  container. Cannot be updated.
+                                description: |-
+                                  List of environment variables to set in the container.
+                                  Cannot be updated.
                                 items:
                                   description:
                                     EnvVar represents an environment variable
@@ -184,21 +170,16 @@ spec:
                                         be a C_IDENTIFIER.
                                       type: string
                                     value:
-                                      description:
-                                        'Variable references $(VAR_NAME) are
-                                        expanded using the previously defined
-                                        environment variables in the container
-                                        and any service environment variables.
-                                        If a variable cannot be resolved, the
-                                        reference in the input string will be
-                                        unchanged. Double $$ are reduced to a
-                                        single $, which allows for escaping the
-                                        $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                        will produce the string literal
-                                        "$(VAR_NAME)". Escaped references will
-                                        never be expanded, regardless of whether
-                                        the variable exists or not. Defaults to
-                                        "".'
+                                      description: |-
+                                        Variable references $(VAR_NAME) are expanded
+                                        using the previously defined environment variables in the container and
+                                        any service environment variables. If a variable cannot be resolved,
+                                        the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                        Escaped references will never be expanded, regardless of whether the variable
+                                        exists or not.
+                                        Defaults to "".
                                       type: string
                                     valueFrom:
                                       description:
@@ -214,12 +195,10 @@ spec:
                                               description: The key to select.
                                               type: string
                                             name:
-                                              description:
-                                                'Name of the referent. More
-                                                info:
-                                                https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields.
-                                                apiVersion, kind, uid?'
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description:
@@ -256,12 +235,10 @@ spec:
                                                 key.
                                               type: string
                                             name:
-                                              description:
-                                                'Name of the referent. More
-                                                info:
-                                                https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields.
-                                                apiVersion, kind, uid?'
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description:
@@ -278,16 +255,13 @@ spec:
                                   type: object
                                 type: array
                               envFrom:
-                                description:
-                                  List of sources to populate environment
-                                  variables in the container. The keys defined
-                                  within a source must be a C_IDENTIFIER. All
-                                  invalid keys will be reported as an event when
-                                  the container is starting. When a key exists
-                                  in multiple sources, the value associated with
-                                  the last source will take precedence. Values
-                                  defined by an Env with a duplicate key will
-                                  take precedence. Cannot be updated.
+                                description: |-
+                                  List of sources to populate environment variables in the container.
+                                  The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                  will be reported as an event when the container is starting. When a key exists in multiple
+                                  sources, the value associated with the last source will take precedence.
+                                  Values defined by an Env with a duplicate key will take precedence.
+                                  Cannot be updated.
                                 items:
                                   description:
                                     EnvFromSource represents the source of a set
@@ -297,11 +271,10 @@ spec:
                                       description: The ConfigMap to select from
                                       properties:
                                         name:
-                                          description:
-                                            'Name of the referent. More info:
-                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields.
-                                            apiVersion, kind, uid?'
+                                          description: |-
+                                            Name of the referent.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                           type: string
                                         optional:
                                           description:
@@ -320,11 +293,10 @@ spec:
                                       description: The Secret to select from
                                       properties:
                                         name:
-                                          description:
-                                            'Name of the referent. More info:
-                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields.
-                                            apiVersion, kind, uid?'
+                                          description: |-
+                                            Name of the referent.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                           type: string
                                         optional:
                                           description:
@@ -336,57 +308,46 @@ spec:
                                   type: object
                                 type: array
                               image:
-                                description:
-                                  'Container image name. More info:
-                                  https://kubernetes.io/docs/concepts/containers/images
-                                  This field is optional to allow higher level
-                                  config management to default or override
-                                  container images in workload controllers like
-                                  Deployments and StatefulSets.'
+                                description: |-
+                                  Container image name.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images
+                                  This field is optional to allow higher level config management to default or override
+                                  container images in workload controllers like Deployments and StatefulSets.
                                 type: string
                               imagePullPolicy:
-                                description:
-                                  'Image pull policy. One of Always, Never,
-                                  IfNotPresent. Defaults to Always if :latest
-                                  tag is specified, or IfNotPresent otherwise.
-                                  Cannot be updated. More info:
-                                  https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                description: |-
+                                  Image pull policy.
+                                  One of Always, Never, IfNotPresent.
+                                  Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                                 type: string
                               livenessProbe:
-                                description:
-                                  'Periodic probe of container liveness.
-                                  Container will be restarted if the probe
-                                  fails. Cannot be updated. More info:
-                                  https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                description: |-
+                                  Periodic probe of container liveness.
+                                  Container will be restarted if the probe fails.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                 properties:
                                   exec:
                                     description:
                                       Exec specifies the action to take.
                                     properties:
                                       command:
-                                        description:
-                                          Command is the command line to execute
-                                          inside the container, the working
-                                          directory for the command  is root
-                                          ('/') in the container's filesystem.
-                                          The command is simply exec'd, it is
-                                          not run inside a shell, so traditional
-                                          shell instructions ('|', etc) won't
-                                          work. To use a shell, you need to
-                                          explicitly call out to that shell.
-                                          Exit status of 0 is treated as
-                                          live/healthy and non-zero is
-                                          unhealthy.
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                         items:
                                           type: string
                                         type: array
                                     type: object
                                   failureThreshold:
-                                    description:
-                                      Minimum consecutive failures for the probe
-                                      to be considered failed after having
-                                      succeeded. Defaults to 3. Minimum value is
-                                      1.
+                                    description: |-
+                                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
                                     format: int32
                                     type: integer
                                   grpc:
@@ -403,8 +364,11 @@ spec:
                                         type: integer
                                       service:
                                         description: |-
-                                          Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). 
-                                           If this is not specified, the default behavior is defined by gRPC.
+                                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                          If this is not specified, the default behavior is defined by gRPC.
                                         type: string
                                     required:
                                       - port
@@ -415,9 +379,8 @@ spec:
                                       perform.
                                     properties:
                                       host:
-                                        description:
-                                          Host name to connect to, defaults to
-                                          the pod IP. You probably want to set
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
                                           "Host" in httpHeaders instead.
                                         type: string
                                       httpHeaders:
@@ -430,11 +393,9 @@ spec:
                                             to be used in HTTP probes
                                           properties:
                                             name:
-                                              description:
-                                                The header field name. This will
-                                                be canonicalized upon output, so
-                                                case-variant names will be
-                                                understood as the same header.
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                               type: string
                                             value:
                                               description:
@@ -453,24 +414,21 @@ spec:
                                         anyOf:
                                           - type: integer
                                           - type: string
-                                        description:
-                                          Name or number of the port to access
-                                          on the container. Number must be in
-                                          the range 1 to 65535. Name must be an
-                                          IANA_SVC_NAME.
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
                                         x-kubernetes-int-or-string: true
                                       scheme:
-                                        description:
-                                          Scheme to use for connecting to the
-                                          host. Defaults to HTTP.
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
                                         type: string
                                     type: object
                                   initialDelaySeconds:
-                                    description:
-                                      'Number of seconds after the container has
-                                      started before liveness probes are
-                                      initiated. More info:
-                                      https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: |-
+                                      Number of seconds after the container has started before liveness probes are initiated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     format: int32
                                     type: integer
                                   periodSeconds:
@@ -480,12 +438,9 @@ spec:
                                     format: int32
                                     type: integer
                                   successThreshold:
-                                    description:
-                                      Minimum consecutive successes for the
-                                      probe to be considered successful after
-                                      having failed. Defaults to 1. Must be 1
-                                      for liveness and startup. Minimum value is
-                                      1.
+                                    description: |-
+                                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                     format: int32
                                     type: integer
                                   tcpSocket:
@@ -502,39 +457,34 @@ spec:
                                         anyOf:
                                           - type: integer
                                           - type: string
-                                        description:
-                                          Number or name of the port to access
-                                          on the container. Number must be in
-                                          the range 1 to 65535. Name must be an
-                                          IANA_SVC_NAME.
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
                                         x-kubernetes-int-or-string: true
                                     type: object
                                   timeoutSeconds:
-                                    description:
-                                      'Number of seconds after which the probe
-                                      times out. Defaults to 1 second. Minimum
-                                      value is 1. More info:
-                                      https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: |-
+                                      Number of seconds after which the probe times out.
+                                      Defaults to 1 second. Minimum value is 1.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     format: int32
                                     type: integer
                                 type: object
                               name:
-                                description:
-                                  Name of the container specified as a
-                                  DNS_LABEL. Each container in a pod must have a
-                                  unique name (DNS_LABEL). Cannot be updated.
+                                description: |-
+                                  Name of the container specified as a DNS_LABEL.
+                                  Each container in a pod must have a unique name (DNS_LABEL).
+                                  Cannot be updated.
                                 type: string
                               ports:
-                                description:
-                                  List of ports to expose from the container.
-                                  Not specifying a port here DOES NOT prevent
-                                  that port from being exposed. Any port which
-                                  is listening on the default "0.0.0.0" address
-                                  inside a container will be accessible from the
-                                  network. Modifying this array with strategic
-                                  merge patch may corrupt the data. For more
-                                  information See
-                                  https://github.com/kubernetes/kubernetes/issues/108255.
+                                description: |-
+                                  List of ports to expose from the container. Not specifying a port here
+                                  DOES NOT prevent that port from being exposed. Any port which is
+                                  listening on the default "0.0.0.0" address inside a container will be
+                                  accessible from the network.
+                                  Modifying this array with strategic merge patch may corrupt the data.
+                                  For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                   Cannot be updated.
                                 items:
                                   description:
@@ -542,25 +492,22 @@ spec:
                                     single container.
                                   properties:
                                     containerPort:
-                                      description:
-                                        Number of port to expose on the pod's IP
-                                        address. This must be a valid port
-                                        number, 0 < x < 65536.
+                                      description: |-
+                                        Number of port to expose on the pod's IP address.
+                                        This must be a valid port number, 0 < x < 65536.
                                       format: int32
                                       type: integer
                                     name:
-                                      description:
-                                        If specified, this must be an
-                                        IANA_SVC_NAME and unique within the pod.
-                                        Each named port in a pod must have a
-                                        unique name. Name for the port that can
-                                        be referred to by services.
+                                      description: |-
+                                        If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                        named port in a pod must have a unique name. Name for the port that can be
+                                        referred to by services.
                                       type: string
                                     protocol:
                                       default: TCP
-                                      description:
-                                        Protocol for port. Must be UDP, TCP, or
-                                        SCTP. Defaults to "TCP".
+                                      description: |-
+                                        Protocol for port. Must be UDP, TCP, or SCTP.
+                                        Defaults to "TCP".
                                       type: string
                                   required:
                                     - containerPort
@@ -571,41 +518,31 @@ spec:
                                   - protocol
                                 x-kubernetes-list-type: map
                               readinessProbe:
-                                description:
-                                  'Periodic probe of container service
-                                  readiness. Container will be removed from
-                                  service endpoints if the probe fails. Cannot
-                                  be updated. More info:
-                                  https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                description: |-
+                                  Periodic probe of container service readiness.
+                                  Container will be removed from service endpoints if the probe fails.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                 properties:
                                   exec:
                                     description:
                                       Exec specifies the action to take.
                                     properties:
                                       command:
-                                        description:
-                                          Command is the command line to execute
-                                          inside the container, the working
-                                          directory for the command  is root
-                                          ('/') in the container's filesystem.
-                                          The command is simply exec'd, it is
-                                          not run inside a shell, so traditional
-                                          shell instructions ('|', etc) won't
-                                          work. To use a shell, you need to
-                                          explicitly call out to that shell.
-                                          Exit status of 0 is treated as
-                                          live/healthy and non-zero is
-                                          unhealthy.
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                         items:
                                           type: string
                                         type: array
                                     type: object
                                   failureThreshold:
-                                    description:
-                                      Minimum consecutive failures for the probe
-                                      to be considered failed after having
-                                      succeeded. Defaults to 3. Minimum value is
-                                      1.
+                                    description: |-
+                                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
                                     format: int32
                                     type: integer
                                   grpc:
@@ -622,8 +559,11 @@ spec:
                                         type: integer
                                       service:
                                         description: |-
-                                          Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). 
-                                           If this is not specified, the default behavior is defined by gRPC.
+                                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                          If this is not specified, the default behavior is defined by gRPC.
                                         type: string
                                     required:
                                       - port
@@ -634,9 +574,8 @@ spec:
                                       perform.
                                     properties:
                                       host:
-                                        description:
-                                          Host name to connect to, defaults to
-                                          the pod IP. You probably want to set
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
                                           "Host" in httpHeaders instead.
                                         type: string
                                       httpHeaders:
@@ -649,11 +588,9 @@ spec:
                                             to be used in HTTP probes
                                           properties:
                                             name:
-                                              description:
-                                                The header field name. This will
-                                                be canonicalized upon output, so
-                                                case-variant names will be
-                                                understood as the same header.
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                               type: string
                                             value:
                                               description:
@@ -672,24 +609,21 @@ spec:
                                         anyOf:
                                           - type: integer
                                           - type: string
-                                        description:
-                                          Name or number of the port to access
-                                          on the container. Number must be in
-                                          the range 1 to 65535. Name must be an
-                                          IANA_SVC_NAME.
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
                                         x-kubernetes-int-or-string: true
                                       scheme:
-                                        description:
-                                          Scheme to use for connecting to the
-                                          host. Defaults to HTTP.
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
                                         type: string
                                     type: object
                                   initialDelaySeconds:
-                                    description:
-                                      'Number of seconds after the container has
-                                      started before liveness probes are
-                                      initiated. More info:
-                                      https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: |-
+                                      Number of seconds after the container has started before liveness probes are initiated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     format: int32
                                     type: integer
                                   periodSeconds:
@@ -699,12 +633,9 @@ spec:
                                     format: int32
                                     type: integer
                                   successThreshold:
-                                    description:
-                                      Minimum consecutive successes for the
-                                      probe to be considered successful after
-                                      having failed. Defaults to 1. Must be 1
-                                      for liveness and startup. Minimum value is
-                                      1.
+                                    description: |-
+                                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                     format: int32
                                     type: integer
                                   tcpSocket:
@@ -721,45 +652,47 @@ spec:
                                         anyOf:
                                           - type: integer
                                           - type: string
-                                        description:
-                                          Number or name of the port to access
-                                          on the container. Number must be in
-                                          the range 1 to 65535. Name must be an
-                                          IANA_SVC_NAME.
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
                                         x-kubernetes-int-or-string: true
                                     type: object
                                   timeoutSeconds:
-                                    description:
-                                      'Number of seconds after which the probe
-                                      times out. Defaults to 1 second. Minimum
-                                      value is 1. More info:
-                                      https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: |-
+                                      Number of seconds after which the probe times out.
+                                      Defaults to 1 second. Minimum value is 1.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     format: int32
                                     type: integer
                                 type: object
                               resources:
-                                description:
-                                  'Compute Resources required by this container.
-                                  Cannot be updated. More info:
-                                  https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                description: |-
+                                  Compute Resources required by this container.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 properties:
                                   claims:
                                     description: |-
-                                      Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. 
-                                       This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. 
-                                       This field is immutable. It can only be set for containers.
+                                      Claims lists the names of resources, defined in spec.resourceClaims,
+                                      that are used by this container.
+
+
+                                      This is an alpha field and requires enabling the
+                                      DynamicResourceAllocation feature gate.
+
+
+                                      This field is immutable. It can only be set for containers.
                                     items:
                                       description:
                                         ResourceClaim references one entry in
                                         PodSpec.ResourceClaims.
                                       properties:
                                         name:
-                                          description:
-                                            Name must match the name of one
-                                            entry in pod.spec.resourceClaims of
-                                            the Pod where this field is used. It
-                                            makes that resource available inside
-                                            a container.
+                                          description: |-
+                                            Name must match the name of one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used. It makes that resource available
+                                            inside a container.
                                           type: string
                                       required:
                                         - name
@@ -775,10 +708,9 @@ spec:
                                         - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
-                                    description:
-                                      'Limits describes the maximum amount of
-                                      compute resources allowed. More info:
-                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    description: |-
+                                      Limits describes the maximum amount of compute resources allowed.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                     type: object
                                   requests:
                                     additionalProperties:
@@ -787,46 +719,34 @@ spec:
                                         - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
-                                    description:
-                                      'Requests describes the minimum amount of
-                                      compute resources required. If Requests is
-                                      omitted for a container, it defaults to
-                                      Limits if that is explicitly specified,
-                                      otherwise to an implementation-defined
-                                      value. Requests cannot exceed Limits. More
-                                      info:
-                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    description: |-
+                                      Requests describes the minimum amount of compute resources required.
+                                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                     type: object
                                 type: object
                               securityContext:
-                                description:
-                                  'SecurityContext defines the security options
-                                  the container should be run with. If set, the
-                                  fields of SecurityContext override the
-                                  equivalent fields of PodSecurityContext. More
-                                  info:
-                                  https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                description: |-
+                                  SecurityContext defines the security options the container should be run with.
+                                  If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                  More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                                 properties:
                                   allowPrivilegeEscalation:
-                                    description:
-                                      'AllowPrivilegeEscalation controls whether
-                                      a process can gain more privileges than
-                                      its parent process. This bool directly
-                                      controls if the no_new_privs flag will be
-                                      set on the container process.
-                                      AllowPrivilegeEscalation is true always
-                                      when the container is: 1) run as
-                                      Privileged 2) has CAP_SYS_ADMIN Note that
-                                      this field cannot be set when spec.os.name
-                                      is windows.'
+                                    description: |-
+                                      AllowPrivilegeEscalation controls whether a process can gain more
+                                      privileges than its parent process. This bool directly controls if
+                                      the no_new_privs flag will be set on the container process.
+                                      AllowPrivilegeEscalation is true always when the container is:
+                                      1) run as Privileged
+                                      2) has CAP_SYS_ADMIN
+                                      Note that this field cannot be set when spec.os.name is windows.
                                     type: boolean
                                   capabilities:
-                                    description:
-                                      The capabilities to add/drop when running
-                                      containers. Defaults to the default set of
-                                      capabilities granted by the container
-                                      runtime. Note that this field cannot be
-                                      set when spec.os.name is windows.
+                                    description: |-
+                                      The capabilities to add/drop when running containers.
+                                      Defaults to the default set of capabilities granted by the container runtime.
+                                      Note that this field cannot be set when spec.os.name is windows.
                                     properties:
                                       add:
                                         description:
@@ -849,138 +769,112 @@ spec:
                                         type: array
                                     type: object
                                   readOnlyRootFilesystem:
-                                    description:
-                                      Whether this container has a read-only
-                                      root filesystem. Default is false. Note
-                                      that this field cannot be set when
-                                      spec.os.name is windows.
+                                    description: |-
+                                      Whether this container has a read-only root filesystem.
+                                      Default is false.
+                                      Note that this field cannot be set when spec.os.name is windows.
                                     type: boolean
                                   runAsGroup:
-                                    description:
-                                      The GID to run the entrypoint of the
-                                      container process. Uses runtime default if
-                                      unset. May also be set in
-                                      PodSecurityContext.  If set in both
-                                      SecurityContext and PodSecurityContext,
-                                      the value specified in SecurityContext
-                                      takes precedence. Note that this field
-                                      cannot be set when spec.os.name is
-                                      windows.
+                                    description: |-
+                                      The GID to run the entrypoint of the container process.
+                                      Uses runtime default if unset.
+                                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is windows.
                                     format: int64
                                     type: integer
                                   runAsNonRoot:
-                                    description:
-                                      Indicates that the container must run as a
-                                      non-root user. If true, the Kubelet will
-                                      validate the image at runtime to ensure
-                                      that it does not run as UID 0 (root) and
-                                      fail to start the container if it does. If
-                                      unset or false, no such validation will be
-                                      performed. May also be set in
-                                      PodSecurityContext.  If set in both
-                                      SecurityContext and PodSecurityContext,
-                                      the value specified in SecurityContext
-                                      takes precedence.
+                                    description: |-
+                                      Indicates that the container must run as a non-root user.
+                                      If true, the Kubelet will validate the image at runtime to ensure that it
+                                      does not run as UID 0 (root) and fail to start the container if it does.
+                                      If unset or false, no such validation will be performed.
+                                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
                                     type: boolean
                                   runAsUser:
-                                    description:
-                                      The UID to run the entrypoint of the
-                                      container process. Defaults to user
-                                      specified in image metadata if
-                                      unspecified. May also be set in
-                                      PodSecurityContext.  If set in both
-                                      SecurityContext and PodSecurityContext,
-                                      the value specified in SecurityContext
-                                      takes precedence. Note that this field
-                                      cannot be set when spec.os.name is
-                                      windows.
+                                    description: |-
+                                      The UID to run the entrypoint of the container process.
+                                      Defaults to user specified in image metadata if unspecified.
+                                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is windows.
                                     format: int64
                                     type: integer
                                   seccompProfile:
-                                    description:
-                                      The seccomp options to use by this
-                                      container. If seccomp options are provided
-                                      at both the pod & container level, the
-                                      container options override the pod
-                                      options. Note that this field cannot be
-                                      set when spec.os.name is windows.
+                                    description: |-
+                                      The seccomp options to use by this container. If seccomp options are
+                                      provided at both the pod & container level, the container options
+                                      override the pod options.
+                                      Note that this field cannot be set when spec.os.name is windows.
                                     properties:
                                       localhostProfile:
-                                        description:
-                                          localhostProfile indicates a profile
-                                          defined in a file on the node should
-                                          be used. The profile must be
-                                          preconfigured on the node to work.
-                                          Must be a descending path, relative to
-                                          the kubelet's configured seccomp
-                                          profile location. Must only be set if
-                                          type is "Localhost".
+                                        description: |-
+                                          localhostProfile indicates a profile defined in a file on the node should be used.
+                                          The profile must be preconfigured on the node to work.
+                                          Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                          Must be set if type is "Localhost". Must NOT be set for any other type.
                                         type: string
                                       type:
                                         description: |-
-                                          type indicates which kind of seccomp profile will be applied. Valid options are: 
-                                           Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+                                          type indicates which kind of seccomp profile will be applied.
+                                          Valid options are:
+
+
+                                          Localhost - a profile defined in a file on the node should be used.
+                                          RuntimeDefault - the container runtime default profile should be used.
+                                          Unconfined - no profile should be applied.
                                         type: string
                                     required:
                                       - type
                                     type: object
                                 type: object
                               terminationMessagePath:
-                                description:
-                                  "Optional: Path at which the file to which the
-                                  container's termination message will be
-                                  written is mounted into the container's
-                                  filesystem. Message written is intended to be
-                                  brief final status, such as an assertion
-                                  failure message. Will be truncated by the node
-                                  if greater than 4096 bytes. The total message
-                                  length across all containers will be limited
-                                  to 12kb. Defaults to /dev/termination-log.
-                                  Cannot be updated."
+                                description: |-
+                                  Optional: Path at which the file to which the container's termination message
+                                  will be written is mounted into the container's filesystem.
+                                  Message written is intended to be brief final status, such as an assertion failure message.
+                                  Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                  all containers will be limited to 12kb.
+                                  Defaults to /dev/termination-log.
+                                  Cannot be updated.
                                 type: string
                               terminationMessagePolicy:
-                                description:
-                                  Indicate how the termination message should be
-                                  populated. File will use the contents of
-                                  terminationMessagePath to populate the
-                                  container status message on both success and
-                                  failure. FallbackToLogsOnError will use the
-                                  last chunk of container log output if the
-                                  termination message file is empty and the
-                                  container exited with an error. The log output
-                                  is limited to 2048 bytes or 80 lines,
-                                  whichever is smaller. Defaults to File. Cannot
-                                  be updated.
+                                description: |-
+                                  Indicate how the termination message should be populated. File will use the contents of
+                                  terminationMessagePath to populate the container status message on both success and failure.
+                                  FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                  message file is empty and the container exited with an error.
+                                  The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                  Defaults to File.
+                                  Cannot be updated.
                                 type: string
                               volumeMounts:
-                                description:
-                                  Pod volumes to mount into the container's
-                                  filesystem. Cannot be updated.
+                                description: |-
+                                  Pod volumes to mount into the container's filesystem.
+                                  Cannot be updated.
                                 items:
                                   description:
                                     VolumeMount describes a mounting of a Volume
                                     within a container.
                                   properties:
                                     mountPath:
-                                      description:
-                                        Path within the container at which the
-                                        volume should be mounted.  Must not
-                                        contain ':'.
+                                      description: |-
+                                        Path within the container at which the volume should be mounted.  Must
+                                        not contain ':'.
                                       type: string
                                     name:
                                       description:
                                         This must match the Name of a Volume.
                                       type: string
                                     readOnly:
-                                      description:
-                                        Mounted read-only if true, read-write
-                                        otherwise (false or unspecified).
+                                      description: |-
+                                        Mounted read-only if true, read-write otherwise (false or unspecified).
                                         Defaults to false.
                                       type: boolean
                                     subPath:
-                                      description:
-                                        Path within the volume from which the
-                                        container's volume should be mounted.
+                                      description: |-
+                                        Path within the volume from which the container's volume should be mounted.
                                         Defaults to "" (volume's root).
                                       type: string
                                   required:
@@ -989,11 +883,11 @@ spec:
                                   type: object
                                 type: array
                               workingDir:
-                                description:
-                                  Container's working directory. If not
-                                  specified, the container runtime's default
-                                  will be used, which might be configured in the
-                                  container image. Cannot be updated.
+                                description: |-
+                                  Container's working directory.
+                                  If not specified, the container runtime's default will be used, which
+                                  might be configured in the container image.
+                                  Cannot be updated.
                                 type: string
                             type: object
                           type: array
@@ -1027,57 +921,46 @@ spec:
                             x-kubernetes-preserve-unknown-fields: true
                           type: array
                         idleTimeoutSeconds:
-                          description:
-                            IdleTimeoutSeconds is the maximum duration in
-                            seconds a request will be allowed to stay open while
-                            not receiving any bytes from the user's application.
-                            If unspecified, a system default will be provided.
+                          description: |-
+                            IdleTimeoutSeconds is the maximum duration in seconds a request will be allowed
+                            to stay open while not receiving any bytes from the user's application. If
+                            unspecified, a system default will be provided.
                           format: int64
                           type: integer
                         imagePullSecrets:
-                          description:
-                            'ImagePullSecrets is an optional list of references
-                            to secrets in the same namespace to use for pulling
-                            any of the images used by this PodSpec. If
-                            specified, these secrets will be passed to
-                            individual puller implementations for them to use.
-                            More info:
-                            https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                          description: |-
+                            ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+                            If specified, these secrets will be passed to individual puller implementations for them to use.
+                            More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
                           items:
-                            description:
-                              LocalObjectReference contains enough information
-                              to let you locate the referenced object inside the
-                              same namespace.
+                            description: |-
+                              LocalObjectReference contains enough information to let you locate the
+                              referenced object inside the same namespace.
                             properties:
                               name:
-                                description:
-                                  'Name of the referent. More info:
-                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion,
-                                  kind, uid?'
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
                           type: array
                         initContainers:
-                          description:
-                            'List of initialization containers belonging to the
-                            pod. Init containers are executed in order prior to
-                            containers being started. If any init container
-                            fails, the pod is considered to have failed and is
-                            handled according to its restartPolicy. The name for
-                            an init container or normal container must be unique
-                            among all containers. Init containers may not have
-                            Lifecycle actions, Readiness probes, Liveness
-                            probes, or Startup probes. The resourceRequirements
-                            of an init container are taken into account during
-                            scheduling by finding the highest request/limit for
-                            each resource type, and then using the max of of
-                            that value or the sum of the normal containers.
-                            Limits are applied to init containers in a similar
-                            fashion. Init containers cannot currently be added
-                            or removed. Cannot be updated. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                          description: |-
+                            List of initialization containers belonging to the pod.
+                            Init containers are executed in order prior to containers being started. If any
+                            init container fails, the pod is considered to have failed and is handled according
+                            to its restartPolicy. The name for an init container or normal container must be
+                            unique among all containers.
+                            Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+                            The resourceRequirements of an init container are taken into account during scheduling
+                            by finding the highest request/limit for each resource type, and then using the max of
+                            of that value or the sum of the normal containers. Limits are applied to init containers
+                            in a similar fashion.
+                            Init containers cannot currently be added or removed.
+                            Cannot be updated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
                           items:
                             description:
                               This is accessible behind a feature flag -
@@ -1099,10 +982,9 @@ spec:
                           type: string
                           x-kubernetes-preserve-unknown-fields: true
                         responseStartTimeoutSeconds:
-                          description:
-                            ResponseStartTimeoutSeconds is the maximum duration
-                            in seconds that the request routing layer will wait
-                            for a request delivered to a container to begin
+                          description: |-
+                            ResponseStartTimeoutSeconds is the maximum duration in seconds that the request
+                            routing layer will wait for a request delivered to a container to begin
                             sending any network traffic.
                           format: int64
                           type: integer
@@ -1125,10 +1007,9 @@ spec:
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
                         serviceAccountName:
-                          description:
-                            'ServiceAccountName is the name of the
-                            ServiceAccount to use to run this pod. More info:
-                            https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                          description: |-
+                            ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+                            More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
                           type: string
                         shareProcessNamespace:
                           description:
@@ -1137,11 +1018,10 @@ spec:
                           type: boolean
                           x-kubernetes-preserve-unknown-fields: true
                         timeoutSeconds:
-                          description:
-                            TimeoutSeconds is the maximum duration in seconds
-                            that the request instance is allowed to respond to a
-                            request. If unspecified, a system default will be
-                            provided.
+                          description: |-
+                            TimeoutSeconds is the maximum duration in seconds that the request instance
+                            is allowed to respond to a request. If unspecified, a system default will
+                            be provided.
                           format: int64
                           type: integer
                         tolerations:
@@ -1167,10 +1047,9 @@ spec:
                             x-kubernetes-preserve-unknown-fields: true
                           type: array
                         volumes:
-                          description:
-                            'List of volumes that can be mounted by containers
-                            belonging to the pod. More info:
-                            https://kubernetes.io/docs/concepts/storage/volumes'
+                          description: |-
+                            List of volumes that can be mounted by containers belonging to the pod.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes
                           items:
                             description:
                               Volume represents a named volume in a pod that may
@@ -1182,36 +1061,25 @@ spec:
                                   populate this volume
                                 properties:
                                   defaultMode:
-                                    description:
-                                      'defaultMode is optional: mode bits used
-                                      to set permissions on created files by
-                                      default. Must be an octal value between
-                                      0000 and 0777 or a decimal value between 0
-                                      and 511. YAML accepts both octal and
-                                      decimal values, JSON requires decimal
-                                      values for mode bits. Defaults to 0644.
-                                      Directories within the path are not
-                                      affected by this setting. This might be in
-                                      conflict with other options that affect
-                                      the file mode, like fsGroup, and the
-                                      result can be other mode bits set.'
+                                    description: |-
+                                      defaultMode is optional: mode bits used to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      Defaults to 0644.
+                                      Directories within the path are not affected by this setting.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
                                     format: int32
                                     type: integer
                                   items:
-                                    description:
-                                      items if unspecified, each key-value pair
-                                      in the Data field of the referenced
-                                      ConfigMap will be projected into the
-                                      volume as a file whose name is the key and
-                                      content is the value. If specified, the
-                                      listed keys will be projected into the
-                                      specified paths, and unlisted keys will
-                                      not be present. If a key is specified
-                                      which is not present in the ConfigMap, the
-                                      volume setup will error unless it is
-                                      marked optional. Paths must be relative
-                                      and may not contain the '..' path or start
-                                      with '..'.
+                                    description: |-
+                                      items if unspecified, each key-value pair in the Data field of the referenced
+                                      ConfigMap will be projected into the volume as a file whose name is the
+                                      key and content is the value. If specified, the listed keys will be
+                                      projected into the specified paths, and unlisted keys will not be
+                                      present. If a key is specified which is not present in the ConfigMap,
+                                      the volume setup will error unless it is marked optional. Paths must be
+                                      relative and may not contain the '..' path or start with '..'.
                                     items:
                                       description:
                                         Maps a string key to a path within a
@@ -1222,29 +1090,21 @@ spec:
                                             key is the key to project.
                                           type: string
                                         mode:
-                                          description:
-                                            'mode is Optional: mode bits used to
-                                            set permissions on this file. Must
-                                            be an octal value between 0000 and
-                                            0777 or a decimal value between 0
-                                            and 511. YAML accepts both octal and
-                                            decimal values, JSON requires
-                                            decimal values for mode bits. If not
-                                            specified, the volume defaultMode
-                                            will be used. This might be in
-                                            conflict with other options that
-                                            affect the file mode, like fsGroup,
-                                            and the result can be other mode
-                                            bits set.'
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description:
-                                            path is the relative path of the
-                                            file to map the key to. May not be
-                                            an absolute path. May not contain
-                                            the path element '..'. May not start
-                                            with the string '..'.
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
                                           type: string
                                       required:
                                         - key
@@ -1252,11 +1112,10 @@ spec:
                                       type: object
                                     type: array
                                   name:
-                                    description:
-                                      'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion,
-                                      kind, uid?'
+                                    description: |-
+                                      Name of the referent.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                   optional:
                                     description:
@@ -1272,10 +1131,10 @@ spec:
                                 type: object
                                 x-kubernetes-preserve-unknown-fields: true
                               name:
-                                description:
-                                  'name of the volume. Must be a DNS_LABEL and
-                                  unique within the pod. More info:
-                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                description: |-
+                                  name of the volume.
+                                  Must be a DNS_LABEL and unique within the pod.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                 type: string
                               persistentVolumeClaim:
                                 description:
@@ -1289,18 +1148,13 @@ spec:
                                   secrets, configmaps, and downward API
                                 properties:
                                   defaultMode:
-                                    description:
-                                      defaultMode are the mode bits used to set
-                                      permissions on created files by default.
-                                      Must be an octal value between 0000 and
-                                      0777 or a decimal value between 0 and 511.
-                                      YAML accepts both octal and decimal
-                                      values, JSON requires decimal values for
-                                      mode bits. Directories within the path are
-                                      not affected by this setting. This might
-                                      be in conflict with other options that
-                                      affect the file mode, like fsGroup, and
-                                      the result can be other mode bits set.
+                                    description: |-
+                                      defaultMode are the mode bits used to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      Directories within the path are not affected by this setting.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
                                     format: int32
                                     type: integer
                                   sources:
@@ -1317,23 +1171,14 @@ spec:
                                             configMap data to project
                                           properties:
                                             items:
-                                              description:
-                                                items if unspecified, each
-                                                key-value pair in the Data field
-                                                of the referenced ConfigMap will
-                                                be projected into the volume as
-                                                a file whose name is the key and
-                                                content is the value. If
-                                                specified, the listed keys will
-                                                be projected into the specified
-                                                paths, and unlisted keys will
-                                                not be present. If a key is
-                                                specified which is not present
-                                                in the ConfigMap, the volume
-                                                setup will error unless it is
-                                                marked optional. Paths must be
-                                                relative and may not contain the
-                                                '..' path or start with '..'.
+                                              description: |-
+                                                items if unspecified, each key-value pair in the Data field of the referenced
+                                                ConfigMap will be projected into the volume as a file whose name is the
+                                                key and content is the value. If specified, the listed keys will be
+                                                projected into the specified paths, and unlisted keys will not be
+                                                present. If a key is specified which is not present in the ConfigMap,
+                                                the volume setup will error unless it is marked optional. Paths must be
+                                                relative and may not contain the '..' path or start with '..'.
                                               items:
                                                 description:
                                                   Maps a string key to a path
@@ -1344,36 +1189,21 @@ spec:
                                                       key is the key to project.
                                                     type: string
                                                   mode:
-                                                    description:
-                                                      'mode is Optional: mode
-                                                      bits used to set
-                                                      permissions on this file.
-                                                      Must be an octal value
-                                                      between 0000 and 0777 or a
-                                                      decimal value between 0
-                                                      and 511. YAML accepts both
-                                                      octal and decimal values,
-                                                      JSON requires decimal
-                                                      values for mode bits. If
-                                                      not specified, the volume
-                                                      defaultMode will be used.
-                                                      This might be in conflict
-                                                      with other options that
-                                                      affect the file mode, like
-                                                      fsGroup, and the result
-                                                      can be other mode bits
-                                                      set.'
+                                                    description: |-
+                                                      mode is Optional: mode bits used to set permissions on this file.
+                                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                      If not specified, the volume defaultMode will be used.
+                                                      This might be in conflict with other options that affect the file
+                                                      mode, like fsGroup, and the result can be other mode bits set.
                                                     format: int32
                                                     type: integer
                                                   path:
-                                                    description:
-                                                      path is the relative path
-                                                      of the file to map the key
-                                                      to. May not be an absolute
-                                                      path. May not contain the
-                                                      path element '..'. May not
-                                                      start with the string
-                                                      '..'.
+                                                    description: |-
+                                                      path is the relative path of the file to map the key to.
+                                                      May not be an absolute path.
+                                                      May not contain the path element '..'.
+                                                      May not start with the string '..'.
                                                     type: string
                                                 required:
                                                   - key
@@ -1381,12 +1211,10 @@ spec:
                                                 type: object
                                               type: array
                                             name:
-                                              description:
-                                                'Name of the referent. More
-                                                info:
-                                                https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields.
-                                                apiVersion, kind, uid?'
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description:
@@ -1438,25 +1266,13 @@ spec:
                                                     type: object
                                                     x-kubernetes-map-type: atomic
                                                   mode:
-                                                    description:
-                                                      'Optional: mode bits used
-                                                      to set permissions on this
-                                                      file, must be an octal
-                                                      value between 0000 and
-                                                      0777 or a decimal value
-                                                      between 0 and 511. YAML
-                                                      accepts both octal and
-                                                      decimal values, JSON
-                                                      requires decimal values
-                                                      for mode bits. If not
-                                                      specified, the volume
-                                                      defaultMode will be used.
-                                                      This might be in conflict
-                                                      with other options that
-                                                      affect the file mode, like
-                                                      fsGroup, and the result
-                                                      can be other mode bits
-                                                      set.'
+                                                    description: |-
+                                                      Optional: mode bits used to set permissions on this file, must be an octal value
+                                                      between 0000 and 0777 or a decimal value between 0 and 511.
+                                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                      If not specified, the volume defaultMode will be used.
+                                                      This might be in conflict with other options that affect the file
+                                                      mode, like fsGroup, and the result can be other mode bits set.
                                                     format: int32
                                                     type: integer
                                                   path:
@@ -1471,15 +1287,9 @@ spec:
                                                       must not start with '..'"
                                                     type: string
                                                   resourceFieldRef:
-                                                    description:
-                                                      'Selects a resource of the
-                                                      container: only resources
-                                                      limits and requests
-                                                      (limits.cpu,
-                                                      limits.memory,
-                                                      requests.cpu and
-                                                      requests.memory) are
-                                                      currently supported.'
+                                                    description: |-
+                                                      Selects a resource of the container: only resources limits and requests
+                                                      (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                     properties:
                                                       containerName:
                                                         description:
@@ -1518,23 +1328,14 @@ spec:
                                             data to project
                                           properties:
                                             items:
-                                              description:
-                                                items if unspecified, each
-                                                key-value pair in the Data field
-                                                of the referenced Secret will be
-                                                projected into the volume as a
-                                                file whose name is the key and
-                                                content is the value. If
-                                                specified, the listed keys will
-                                                be projected into the specified
-                                                paths, and unlisted keys will
-                                                not be present. If a key is
-                                                specified which is not present
-                                                in the Secret, the volume setup
-                                                will error unless it is marked
-                                                optional. Paths must be relative
-                                                and may not contain the '..'
-                                                path or start with '..'.
+                                              description: |-
+                                                items if unspecified, each key-value pair in the Data field of the referenced
+                                                Secret will be projected into the volume as a file whose name is the
+                                                key and content is the value. If specified, the listed keys will be
+                                                projected into the specified paths, and unlisted keys will not be
+                                                present. If a key is specified which is not present in the Secret,
+                                                the volume setup will error unless it is marked optional. Paths must be
+                                                relative and may not contain the '..' path or start with '..'.
                                               items:
                                                 description:
                                                   Maps a string key to a path
@@ -1545,36 +1346,21 @@ spec:
                                                       key is the key to project.
                                                     type: string
                                                   mode:
-                                                    description:
-                                                      'mode is Optional: mode
-                                                      bits used to set
-                                                      permissions on this file.
-                                                      Must be an octal value
-                                                      between 0000 and 0777 or a
-                                                      decimal value between 0
-                                                      and 511. YAML accepts both
-                                                      octal and decimal values,
-                                                      JSON requires decimal
-                                                      values for mode bits. If
-                                                      not specified, the volume
-                                                      defaultMode will be used.
-                                                      This might be in conflict
-                                                      with other options that
-                                                      affect the file mode, like
-                                                      fsGroup, and the result
-                                                      can be other mode bits
-                                                      set.'
+                                                    description: |-
+                                                      mode is Optional: mode bits used to set permissions on this file.
+                                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                      If not specified, the volume defaultMode will be used.
+                                                      This might be in conflict with other options that affect the file
+                                                      mode, like fsGroup, and the result can be other mode bits set.
                                                     format: int32
                                                     type: integer
                                                   path:
-                                                    description:
-                                                      path is the relative path
-                                                      of the file to map the key
-                                                      to. May not be an absolute
-                                                      path. May not contain the
-                                                      path element '..'. May not
-                                                      start with the string
-                                                      '..'.
+                                                    description: |-
+                                                      path is the relative path of the file to map the key to.
+                                                      May not be an absolute path.
+                                                      May not contain the path element '..'.
+                                                      May not start with the string '..'.
                                                     type: string
                                                 required:
                                                   - key
@@ -1582,12 +1368,10 @@ spec:
                                                 type: object
                                               type: array
                                             name:
-                                              description:
-                                                'Name of the referent. More
-                                                info:
-                                                https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields.
-                                                apiVersion, kind, uid?'
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description:
@@ -1604,39 +1388,26 @@ spec:
                                             to project
                                           properties:
                                             audience:
-                                              description:
-                                                audience is the intended
-                                                audience of the token. A
-                                                recipient of a token must
-                                                identify itself with an
-                                                identifier specified in the
-                                                audience of the token, and
-                                                otherwise should reject the
-                                                token. The audience defaults to
-                                                the identifier of the apiserver.
+                                              description: |-
+                                                audience is the intended audience of the token. A recipient of a token
+                                                must identify itself with an identifier specified in the audience of the
+                                                token, and otherwise should reject the token. The audience defaults to the
+                                                identifier of the apiserver.
                                               type: string
                                             expirationSeconds:
-                                              description:
-                                                expirationSeconds is the
-                                                requested duration of validity
-                                                of the service account token. As
-                                                the token approaches expiration,
-                                                the kubelet volume plugin will
-                                                proactively rotate the service
-                                                account token. The kubelet will
-                                                start trying to rotate the token
-                                                if the token is older than 80
-                                                percent of its time to live or
-                                                if the token is older than 24
-                                                hours.Defaults to 1 hour and
-                                                must be at least 10 minutes.
+                                              description: |-
+                                                expirationSeconds is the requested duration of validity of the service
+                                                account token. As the token approaches expiration, the kubelet volume
+                                                plugin will proactively rotate the service account token. The kubelet will
+                                                start trying to rotate the token if the token is older than 80 percent of
+                                                its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                                and must be at least 10 minutes.
                                               format: int64
                                               type: integer
                                             path:
-                                              description:
-                                                path is the path relative to the
-                                                mount point of the file to
-                                                project the token into.
+                                              description: |-
+                                                path is the path relative to the mount point of the file to project the
+                                                token into.
                                               type: string
                                           required:
                                             - path
@@ -1645,42 +1416,30 @@ spec:
                                     type: array
                                 type: object
                               secret:
-                                description:
-                                  'secret represents a secret that should
-                                  populate this volume. More info:
-                                  https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                description: |-
+                                  secret represents a secret that should populate this volume.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                 properties:
                                   defaultMode:
-                                    description:
-                                      'defaultMode is Optional: mode bits used
-                                      to set permissions on created files by
-                                      default. Must be an octal value between
-                                      0000 and 0777 or a decimal value between 0
-                                      and 511. YAML accepts both octal and
-                                      decimal values, JSON requires decimal
-                                      values for mode bits. Defaults to 0644.
-                                      Directories within the path are not
-                                      affected by this setting. This might be in
-                                      conflict with other options that affect
-                                      the file mode, like fsGroup, and the
-                                      result can be other mode bits set.'
+                                    description: |-
+                                      defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values
+                                      for mode bits. Defaults to 0644.
+                                      Directories within the path are not affected by this setting.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
                                     format: int32
                                     type: integer
                                   items:
-                                    description:
-                                      items If unspecified, each key-value pair
-                                      in the Data field of the referenced Secret
-                                      will be projected into the volume as a
-                                      file whose name is the key and content is
-                                      the value. If specified, the listed keys
-                                      will be projected into the specified
-                                      paths, and unlisted keys will not be
-                                      present. If a key is specified which is
-                                      not present in the Secret, the volume
-                                      setup will error unless it is marked
-                                      optional. Paths must be relative and may
-                                      not contain the '..' path or start with
-                                      '..'.
+                                    description: |-
+                                      items If unspecified, each key-value pair in the Data field of the referenced
+                                      Secret will be projected into the volume as a file whose name is the
+                                      key and content is the value. If specified, the listed keys will be
+                                      projected into the specified paths, and unlisted keys will not be
+                                      present. If a key is specified which is not present in the Secret,
+                                      the volume setup will error unless it is marked optional. Paths must be
+                                      relative and may not contain the '..' path or start with '..'.
                                     items:
                                       description:
                                         Maps a string key to a path within a
@@ -1691,29 +1450,21 @@ spec:
                                             key is the key to project.
                                           type: string
                                         mode:
-                                          description:
-                                            'mode is Optional: mode bits used to
-                                            set permissions on this file. Must
-                                            be an octal value between 0000 and
-                                            0777 or a decimal value between 0
-                                            and 511. YAML accepts both octal and
-                                            decimal values, JSON requires
-                                            decimal values for mode bits. If not
-                                            specified, the volume defaultMode
-                                            will be used. This might be in
-                                            conflict with other options that
-                                            affect the file mode, like fsGroup,
-                                            and the result can be other mode
-                                            bits set.'
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description:
-                                            path is the relative path of the
-                                            file to map the key to. May not be
-                                            an absolute path. May not contain
-                                            the path element '..'. May not start
-                                            with the string '..'.
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
                                           type: string
                                       required:
                                         - key
@@ -1726,10 +1477,9 @@ spec:
                                       or its keys must be defined
                                     type: boolean
                                   secretName:
-                                    description:
-                                      "secretName is the name of the secret in
-                                      the pod's namespace to use. More info:
-                                      https://kubernetes.io/docs/concepts/storage/volumes#secret"
+                                    description: |-
+                                      secretName is the name of the secret in the pod's namespace to use.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                     type: string
                                 type: object
                             required:
@@ -1749,30 +1499,26 @@ spec:
                 annotations:
                   additionalProperties:
                     type: string
-                  description:
-                    Annotations is additional Status fields for the Resource to
-                    save some additional State as well as convey more
-                    information to the user. This is roughly akin to Annotations
-                    on any k8s resource, just the reconciler conveying richer
-                    information outwards.
+                  description: |-
+                    Annotations is additional Status fields for the Resource to save some
+                    additional State as well as convey more information to the user. This is
+                    roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                    richer information outwards.
                   type: object
                 conditions:
                   description:
                     Conditions the latest available observations of a resource's
                     current state.
                   items:
-                    description:
-                      'Condition defines a readiness condition for a Knative
-                      resource. See:
-                      https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                    description: |-
+                      Condition defines a readiness condition for a Knative resource.
+                      See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
                     properties:
                       lastTransitionTime:
-                        description:
-                          LastTransitionTime is the last time the condition
-                          transitioned from one status to another. We use
-                          VolatileTime in place of metav1.Time to exclude this
-                          from creating equality.Semantic differences (all other
-                          things held constant).
+                        description: |-
+                          LastTransitionTime is the last time the condition transitioned from one status to another.
+                          We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                          differences (all other things held constant).
                         type: string
                       message:
                         description:
@@ -1784,10 +1530,9 @@ spec:
                           The reason for the condition's last transition.
                         type: string
                       severity:
-                        description:
-                          Severity with which to treat failures of this type of
-                          condition. When this is not specified, it defaults to
-                          Error.
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
                         type: string
                       status:
                         description:
@@ -1802,19 +1547,17 @@ spec:
                     type: object
                   type: array
                 latestCreatedRevisionName:
-                  description:
-                    LatestCreatedRevisionName is the last revision that was
-                    created from this Configuration. It might not be ready yet,
-                    for that use LatestReadyRevisionName.
+                  description: |-
+                    LatestCreatedRevisionName is the last revision that was created from this
+                    Configuration. It might not be ready yet, for that use LatestReadyRevisionName.
                   type: string
                 latestReadyRevisionName:
-                  description:
-                    LatestReadyRevisionName holds the name of the latest
-                    Revision stamped out from this Configuration that has had
-                    its "Ready" condition become "True".
+                  description: |-
+                    LatestReadyRevisionName holds the name of the latest Revision stamped out
+                    from this Configuration that has had its "Ready" condition become "True".
                   type: string
                 observedGeneration:
-                  description:
+                  description: |-
                     ObservedGeneration is the 'Generation' of the Service that
                     was last processed by the controller.
                   format: int64

--- a/platform_umbrella/apps/common_core/priv/manifests/knative-serving/domainmappings_serving_knative_dev.yaml
+++ b/platform_umbrella/apps/common_core/priv/manifests/knative-serving/domainmappings_serving_knative_dev.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: 1.12.3
+    app.kubernetes.io/version: 1.14.1
     knative.dev/crd-install: 'true'
   name: domainmappings.serving.knative.dev
 spec:
@@ -25,10 +25,10 @@ spec:
         - jsonPath: .status.url
           name: URL
           type: string
-        - jsonPath: .status.conditions[?(@.type=='Ready')].status
+        - jsonPath: ".status.conditions[?(@.type=='Ready')].status"
           name: Ready
           type: string
-        - jsonPath: .status.conditions[?(@.type=='Ready')].reason
+        - jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
           name: Reason
           type: string
       name: v1beta1
@@ -38,33 +38,40 @@ spec:
             DomainMapping is a mapping from a custom hostname to an Addressable.
           properties:
             apiVersion:
-              description:
-                'APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the
-                latest internal value, and may reject unrecognized values. More
-                info:
-                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description:
-                'Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the
-                client submits requests to. Cannot be updated. In CamelCase.
-                More info:
-                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
             spec:
-              description:
-                'Spec is the desired state of the DomainMapping. More info:
-                https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+              description: |-
+                Spec is the desired state of the DomainMapping.
+                More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
               properties:
                 ref:
                   description: |-
-                    Ref specifies the target of the Domain Mapping. 
-                     The object identified by the Ref must be an Addressable with a URL of the form `{name}.{namespace}.{domain}` where `{domain}` is the cluster domain, and `{name}` and `{namespace}` are the name and namespace of a Kubernetes Service. 
-                     This contract is satisfied by Knative types such as Knative Services and Knative Routes, and by Kubernetes Services.
+                    Ref specifies the target of the Domain Mapping.
+
+
+                    The object identified by the Ref must be an Addressable with a URL of the
+                    form `{name}.{namespace}.{domain}` where `{domain}` is the cluster domain,
+                    and `{name}` and `{namespace}` are the name and namespace of a Kubernetes
+                    Service.
+
+
+                    This contract is satisfied by Knative types such as Knative Services and
+                    Knative Routes, and by Kubernetes Services.
                   properties:
                     address:
                       description: Address points to a specific Address Name.
@@ -73,29 +80,25 @@ spec:
                       description: API version of the referent.
                       type: string
                     group:
-                      description:
-                        'Group of the API, without the version of the group.
-                        This can be used as an alternative to the APIVersion,
-                        and then resolved using ResolveGroup. Note: This API is
-                        EXPERIMENTAL and might break anytime. For more details:
-                        https://github.com/knative/eventing/issues/5086'
+                      description: |-
+                        Group of the API, without the version of the group. This can be used as an alternative to the APIVersion, and then resolved using ResolveGroup.
+                        Note: This API is EXPERIMENTAL and might break anytime. For more details: https://github.com/knative/eventing/issues/5086
                       type: string
                     kind:
-                      description:
-                        'Kind of the referent. More info:
-                        https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      description: |-
+                        Kind of the referent.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                       type: string
                     name:
-                      description:
-                        'Name of the referent. More info:
-                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       type: string
                     namespace:
-                      description:
-                        'Namespace of the referent. More info:
-                        https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
-                        This is optional field, it gets defaulted to the object
-                        holding it if left out.'
+                      description: |-
+                        Namespace of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        This is optional field, it gets defaulted to the object holding it if left out.
                       type: string
                   required:
                     - kind
@@ -118,9 +121,9 @@ spec:
                 - ref
               type: object
             status:
-              description:
-                'Status is the current state of the DomainMapping. More info:
-                https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+              description: |-
+                Status is the current state of the DomainMapping.
+                More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
               properties:
                 address:
                   description:
@@ -128,10 +131,9 @@ spec:
                     be the target of an event.
                   properties:
                     CACerts:
-                      description:
-                        CACerts is the Certification Authority (CA) certificates
-                        in PEM format according to
-                        https://www.rfc-editor.org/rfc/rfc7468.
+                      description: |-
+                        CACerts is the Certification Authority (CA) certificates in PEM format
+                        according to https://www.rfc-editor.org/rfc/rfc7468.
                       type: string
                     audience:
                       description:
@@ -146,30 +148,26 @@ spec:
                 annotations:
                   additionalProperties:
                     type: string
-                  description:
-                    Annotations is additional Status fields for the Resource to
-                    save some additional State as well as convey more
-                    information to the user. This is roughly akin to Annotations
-                    on any k8s resource, just the reconciler conveying richer
-                    information outwards.
+                  description: |-
+                    Annotations is additional Status fields for the Resource to save some
+                    additional State as well as convey more information to the user. This is
+                    roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                    richer information outwards.
                   type: object
                 conditions:
                   description:
                     Conditions the latest available observations of a resource's
                     current state.
                   items:
-                    description:
-                      'Condition defines a readiness condition for a Knative
-                      resource. See:
-                      https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                    description: |-
+                      Condition defines a readiness condition for a Knative resource.
+                      See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
                     properties:
                       lastTransitionTime:
-                        description:
-                          LastTransitionTime is the last time the condition
-                          transitioned from one status to another. We use
-                          VolatileTime in place of metav1.Time to exclude this
-                          from creating equality.Semantic differences (all other
-                          things held constant).
+                        description: |-
+                          LastTransitionTime is the last time the condition transitioned from one status to another.
+                          We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                          differences (all other things held constant).
                         type: string
                       message:
                         description:
@@ -181,10 +179,9 @@ spec:
                           The reason for the condition's last transition.
                         type: string
                       severity:
-                        description:
-                          Severity with which to treat failures of this type of
-                          condition. When this is not specified, it defaults to
-                          Error.
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
                         type: string
                       status:
                         description:
@@ -199,7 +196,7 @@ spec:
                     type: object
                   type: array
                 observedGeneration:
-                  description:
+                  description: |-
                     ObservedGeneration is the 'Generation' of the Service that
                     was last processed by the controller.
                   format: int64

--- a/platform_umbrella/apps/common_core/priv/manifests/knative-serving/images_caching_internal_knative_dev.yaml
+++ b/platform_umbrella/apps/common_core/priv/manifests/knative-serving/images_caching_internal_knative_dev.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: 1.12.3
+    app.kubernetes.io/version: 1.14.1
     knative.dev/crd-install: 'true'
   name: images.caching.internal.knative.dev
 spec:
@@ -25,26 +25,24 @@ spec:
       name: v1alpha1
       schema:
         openAPIV3Schema:
-          description:
-            Image is a Knative abstraction that encapsulates the interface by
-            which Knative components express a desire to have a particular image
-            cached.
+          description: |-
+            Image is a Knative abstraction that encapsulates the interface by which Knative
+            components express a desire to have a particular image cached.
           properties:
             apiVersion:
-              description:
-                'APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the
-                latest internal value, and may reject unrecognized values. More
-                info:
-                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description:
-                'Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the
-                client submits requests to. Cannot be updated. In CamelCase.
-                More info:
-                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -58,33 +56,29 @@ spec:
                     the cluster.
                   type: string
                 imagePullSecrets:
-                  description:
-                    ImagePullSecrets contains the names of the Kubernetes
-                    Secrets containing login information used by the Pods which
-                    will run this container.
+                  description: |-
+                    ImagePullSecrets contains the names of the Kubernetes Secrets containing login
+                    information used by the Pods which will run this container.
                   items:
-                    description:
-                      LocalObjectReference contains enough information to let
-                      you locate the referenced object inside the same
-                      namespace.
+                    description: |-
+                      LocalObjectReference contains enough information to let you locate the
+                      referenced object inside the same namespace.
                     properties:
                       name:
-                        description:
-                          'Name of the referent. More info:
-                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?
                         type: string
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
                 serviceAccountName:
-                  description:
-                    'ServiceAccountName is the name of the Kubernetes
-                    ServiceAccount as which the Pods will run this
-                    container.  This is potentially used to authenticate the
-                    image pull if the service account has attached pull
-                    secrets.  For more information:
-                    https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account'
+                  description: |-
+                    ServiceAccountName is the name of the Kubernetes ServiceAccount as which the Pods
+                    will run this container.  This is potentially used to authenticate the image pull
+                    if the service account has attached pull secrets.  For more information:
+                    https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account
                   type: string
               required:
                 - image
@@ -97,30 +91,26 @@ spec:
                 annotations:
                   additionalProperties:
                     type: string
-                  description:
-                    Annotations is additional Status fields for the Resource to
-                    save some additional State as well as convey more
-                    information to the user. This is roughly akin to Annotations
-                    on any k8s resource, just the reconciler conveying richer
-                    information outwards.
+                  description: |-
+                    Annotations is additional Status fields for the Resource to save some
+                    additional State as well as convey more information to the user. This is
+                    roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                    richer information outwards.
                   type: object
                 conditions:
                   description:
                     Conditions the latest available observations of a resource's
                     current state.
                   items:
-                    description:
-                      'Condition defines a readiness condition for a Knative
-                      resource. See:
-                      https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                    description: |-
+                      Condition defines a readiness condition for a Knative resource.
+                      See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
                     properties:
                       lastTransitionTime:
-                        description:
-                          LastTransitionTime is the last time the condition
-                          transitioned from one status to another. We use
-                          VolatileTime in place of metav1.Time to exclude this
-                          from creating equality.Semantic differences (all other
-                          things held constant).
+                        description: |-
+                          LastTransitionTime is the last time the condition transitioned from one status to another.
+                          We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                          differences (all other things held constant).
                         type: string
                       message:
                         description:
@@ -132,10 +122,9 @@ spec:
                           The reason for the condition's last transition.
                         type: string
                       severity:
-                        description:
-                          Severity with which to treat failures of this type of
-                          condition. When this is not specified, it defaults to
-                          Error.
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
                         type: string
                       status:
                         description:
@@ -150,7 +139,7 @@ spec:
                     type: object
                   type: array
                 observedGeneration:
-                  description:
+                  description: |-
                     ObservedGeneration is the 'Generation' of the Service that
                     was last processed by the controller.
                   format: int64

--- a/platform_umbrella/apps/common_core/priv/manifests/knative-serving/ingresses_networking_internal_knative_dev.yaml
+++ b/platform_umbrella/apps/common_core/priv/manifests/knative-serving/ingresses_networking_internal_knative_dev.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/component: networking
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: 1.12.3
+    app.kubernetes.io/version: 1.14.1
     knative.dev/crd-install: 'true'
   name: ingresses.networking.internal.knative.dev
 spec:
@@ -23,140 +23,141 @@ spec:
   scope: Namespaced
   versions:
     - additionalPrinterColumns:
-        - jsonPath: .status.conditions[?(@.type=='Ready')].status
+        - jsonPath: ".status.conditions[?(@.type=='Ready')].status"
           name: Ready
           type: string
-        - jsonPath: .status.conditions[?(@.type=='Ready')].reason
+        - jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
           name: Reason
           type: string
       name: v1alpha1
       schema:
         openAPIV3Schema:
           description: |-
-            Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable URLs, load balance traffic, offer name based virtual hosting, etc. 
-             This is heavily based on K8s Ingress https://godoc.org/k8s.io/api/networking/v1beta1#Ingress which some highlighted modifications.
+            Ingress is a collection of rules that allow inbound connections to reach the endpoints defined
+            by a backend. An Ingress can be configured to give services externally-reachable URLs, load
+            balance traffic, offer name based virtual hosting, etc.
+
+
+            This is heavily based on K8s Ingress https://godoc.org/k8s.io/api/networking/v1beta1#Ingress
+            which some highlighted modifications.
           properties:
             apiVersion:
-              description:
-                'APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the
-                latest internal value, and may reject unrecognized values. More
-                info:
-                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description:
-                'Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the
-                client submits requests to. Cannot be updated. In CamelCase.
-                More info:
-                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
             spec:
-              description:
-                'Spec is the desired state of the Ingress. More info:
-                https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+              description: |-
+                Spec is the desired state of the Ingress.
+                More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
               properties:
                 httpOption:
-                  description:
-                    'HTTPOption is the option of HTTP. It has the following two
-                    values: `HTTPOptionEnabled`, `HTTPOptionRedirected`'
+                  description: |-
+                    HTTPOption is the option of HTTP. It has the following two values:
+                    `HTTPOptionEnabled`, `HTTPOptionRedirected`
                   type: string
                 rules:
                   description:
                     A list of host rules used to configure the Ingress.
                   items:
-                    description:
-                      IngressRule represents the rules mapping the paths under a
-                      specified host to the related backend services. Incoming
-                      requests are first evaluated for a host match, then routed
-                      to the backend associated with the matching
-                      IngressRuleValue.
+                    description: |-
+                      IngressRule represents the rules mapping the paths under a specified host to
+                      the related backend services. Incoming requests are first evaluated for a host
+                      match, then routed to the backend associated with the matching IngressRuleValue.
                     properties:
                       hosts:
-                        description:
-                          'Host is the fully qualified domain name of a network
-                          host, as defined by RFC 3986. Note the following
-                          deviations from the "host" part of the URI as defined
-                          in the RFC: 1. IPs are not allowed. Currently a rule
-                          value can only apply to the IP in the Spec of the
-                          parent . 2. The `:` delimiter is not respected because
-                          ports are not allowed. Currently the port of an
-                          Ingress is implicitly :80 for http and :443 for https.
-                          Both these may change in the future. If the host is
-                          unspecified, the Ingress routes all traffic based on
-                          the specified IngressRuleValue. If multiple matching
-                          Hosts were provided, the first rule will take
-                          precedent.'
+                        description: |-
+                          Host is the fully qualified domain name of a network host, as defined
+                          by RFC 3986. Note the following deviations from the "host" part of the
+                          URI as defined in the RFC:
+                          1. IPs are not allowed. Currently a rule value can only apply to the
+                          	  IP in the Spec of the parent .
+                          2. The `:` delimiter is not respected because ports are not allowed.
+                          	  Currently the port of an Ingress is implicitly :80 for http and
+                          	  :443 for https.
+                          Both these may change in the future.
+                          If the host is unspecified, the Ingress routes all traffic based on the
+                          specified IngressRuleValue.
+                          If multiple matching Hosts were provided, the first rule will take precedent.
                         items:
                           type: string
                         type: array
                       http:
-                        description:
-                          HTTP represents a rule to apply against incoming
-                          requests. If the rule is satisfied, the request is
-                          routed to the specified backend.
+                        description: |-
+                          HTTP represents a rule to apply against incoming requests. If the
+                          rule is satisfied, the request is routed to the specified backend.
                         properties:
                           paths:
                             description: |-
-                              A collection of paths that map requests to backends. 
-                               If they are multiple matching paths, the first match takes precedence.
+                              A collection of paths that map requests to backends.
+
+
+                              If they are multiple matching paths, the first match takes precedence.
                             items:
-                              description:
-                                HTTPIngressPath associates a path regex with a
-                                backend. Incoming URLs matching the path are
-                                forwarded to the backend.
+                              description: |-
+                                HTTPIngressPath associates a path regex with a backend. Incoming URLs matching
+                                the path are forwarded to the backend.
                               properties:
                                 appendHeaders:
                                   additionalProperties:
                                     type: string
                                   description: |-
-                                    AppendHeaders allow specifying additional HTTP headers to add before forwarding a request to the destination service. 
-                                     NOTE: This differs from K8s Ingress which doesn't allow header appending.
+                                    AppendHeaders allow specifying additional HTTP headers to add
+                                    before forwarding a request to the destination service.
+
+
+                                    NOTE: This differs from K8s Ingress which doesn't allow header appending.
                                   type: object
                                 headers:
                                   additionalProperties:
-                                    description:
-                                      HeaderMatch represents a matching value of
-                                      Headers in HTTPIngressPath. Currently,
-                                      only the exact matching is supported.
+                                    description: |-
+                                      HeaderMatch represents a matching value of Headers in HTTPIngressPath.
+                                      Currently, only the exact matching is supported.
                                     properties:
                                       exact:
                                         type: string
                                     required:
                                       - exact
                                     type: object
-                                  description:
-                                    Headers defines header matching rules which
-                                    is a map from a header name to HeaderMatch
-                                    which specify a matching condition. When a
-                                    request matched with all the header matching
-                                    rules, the request is routed by the
-                                    corresponding ingress rule. If it is empty,
-                                    the headers are not used for matching
+                                  description: |-
+                                    Headers defines header matching rules which is a map from a header name
+                                    to HeaderMatch which specify a matching condition.
+                                    When a request matched with all the header matching rules,
+                                    the request is routed by the corresponding ingress rule.
+                                    If it is empty, the headers are not used for matching
                                   type: object
                                 path:
-                                  description:
-                                    Path represents a literal prefix to which
-                                    this rule should apply. Currently it can
-                                    contain characters disallowed from the
-                                    conventional "path" part of a URL as defined
-                                    by RFC 3986. Paths must begin with a '/'. If
-                                    unspecified, the path defaults to a catch
-                                    all sending traffic to the backend.
+                                  description: |-
+                                    Path represents a literal prefix to which this rule should apply.
+                                    Currently it can contain characters disallowed from the conventional
+                                    "path" part of a URL as defined by RFC 3986. Paths must begin with
+                                    a '/'. If unspecified, the path defaults to a catch all sending
+                                    traffic to the backend.
                                   type: string
                                 rewriteHost:
                                   description: |-
-                                    RewriteHost rewrites the incoming request's host header. 
-                                     This field is currently experimental and not supported by all Ingress implementations.
+                                    RewriteHost rewrites the incoming request's host header.
+
+
+                                    This field is currently experimental and not supported by all Ingress
+                                    implementations.
                                   type: string
                                 splits:
-                                  description:
-                                    Splits defines the referenced service
-                                    endpoints to which the traffic will be
-                                    forwarded to.
+                                  description: |-
+                                    Splits defines the referenced service endpoints to which the traffic
+                                    will be forwarded to.
                                   items:
                                     description:
                                       IngressBackendSplit describes all
@@ -166,13 +167,19 @@ spec:
                                         additionalProperties:
                                           type: string
                                         description: |-
-                                          AppendHeaders allow specifying additional HTTP headers to add before forwarding a request to the destination service. 
-                                           NOTE: This differs from K8s Ingress which doesn't allow header appending.
+                                          AppendHeaders allow specifying additional HTTP headers to add
+                                          before forwarding a request to the destination service.
+
+
+                                          NOTE: This differs from K8s Ingress which doesn't allow header appending.
                                         type: object
                                       percent:
                                         description: |-
-                                          Specifies the split percentage, a number between 0 and 100.  If only one split is specified, we default to 100. 
-                                           NOTE: This differs from K8s Ingress to allow percentage split.
+                                          Specifies the split percentage, a number between 0 and 100.  If
+                                          only one split is specified, we default to 100.
+
+
+                                          NOTE: This differs from K8s Ingress to allow percentage split.
                                         type: integer
                                       serviceName:
                                         description:
@@ -181,8 +188,10 @@ spec:
                                         type: string
                                       serviceNamespace:
                                         description: |-
-                                          Specifies the namespace of the referenced service. 
-                                           NOTE: This differs from K8s Ingress to allow routing to different namespaces.
+                                          Specifies the namespace of the referenced service.
+
+
+                                          NOTE: This differs from K8s Ingress to allow routing to different namespaces.
                                         type: string
                                       servicePort:
                                         anyOf:
@@ -206,33 +215,30 @@ spec:
                           - paths
                         type: object
                       visibility:
-                        description:
-                          Visibility signifies whether this rule should
-                          `ClusterLocal`. If it's not specified then it defaults
-                          to `ExternalIP`.
+                        description: |-
+                          Visibility signifies whether this rule should `ClusterLocal`. If it's not
+                          specified then it defaults to `ExternalIP`.
                         type: string
                     type: object
                   type: array
                 tls:
-                  description:
-                    'TLS configuration. Currently Ingress only supports a single
-                    TLS port: 443. If multiple members of this list specify
-                    different hosts, they will be multiplexed on the same port
-                    according to the hostname specified through the SNI TLS
-                    extension, if the ingress controller fulfilling the ingress
-                    supports SNI.'
+                  description: |-
+                    TLS configuration. Currently Ingress only supports a single TLS
+                    port: 443. If multiple members of this list specify different hosts, they
+                    will be multiplexed on the same port according to the hostname specified
+                    through the SNI TLS extension, if the ingress controller fulfilling the
+                    ingress supports SNI.
                   items:
                     description:
                       IngressTLS describes the transport layer security
                       associated with an Ingress.
                     properties:
                       hosts:
-                        description:
-                          Hosts is a list of hosts included in the TLS
-                          certificate. The values in this list must match the
-                          name/s used in the tlsSecret. Defaults to the wildcard
-                          host setting for the loadbalancer controller
-                          fulfilling this Ingress, if left unspecified.
+                        description: |-
+                          Hosts is a list of hosts included in the TLS certificate. The values in
+                          this list must match the name/s used in the tlsSecret. Defaults to the
+                          wildcard host setting for the loadbalancer controller fulfilling this
+                          Ingress, if left unspecified.
                         items:
                           type: string
                         type: array
@@ -242,49 +248,43 @@ spec:
                           SSL traffic.
                         type: string
                       secretNamespace:
-                        description:
-                          SecretNamespace is the namespace of the secret used to
-                          terminate SSL traffic. If not set the namespace should
-                          be assumed to be the same as the Ingress. If set the
-                          secret should have the same namespace as the Ingress
-                          otherwise the behaviour is undefined and not
-                          supported.
+                        description: |-
+                          SecretNamespace is the namespace of the secret used to terminate SSL traffic.
+                          If not set the namespace should be assumed to be the same as the Ingress.
+                          If set the secret should have the same namespace as the Ingress otherwise
+                          the behaviour is undefined and not supported.
                         type: string
                     type: object
                   type: array
               type: object
             status:
-              description:
-                'Status is the current state of the Ingress. More info:
-                https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+              description: |-
+                Status is the current state of the Ingress.
+                More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
               properties:
                 annotations:
                   additionalProperties:
                     type: string
-                  description:
-                    Annotations is additional Status fields for the Resource to
-                    save some additional State as well as convey more
-                    information to the user. This is roughly akin to Annotations
-                    on any k8s resource, just the reconciler conveying richer
-                    information outwards.
+                  description: |-
+                    Annotations is additional Status fields for the Resource to save some
+                    additional State as well as convey more information to the user. This is
+                    roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                    richer information outwards.
                   type: object
                 conditions:
                   description:
                     Conditions the latest available observations of a resource's
                     current state.
                   items:
-                    description:
-                      'Condition defines a readiness condition for a Knative
-                      resource. See:
-                      https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                    description: |-
+                      Condition defines a readiness condition for a Knative resource.
+                      See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
                     properties:
                       lastTransitionTime:
-                        description:
-                          LastTransitionTime is the last time the condition
-                          transitioned from one status to another. We use
-                          VolatileTime in place of metav1.Time to exclude this
-                          from creating equality.Semantic differences (all other
-                          things held constant).
+                        description: |-
+                          LastTransitionTime is the last time the condition transitioned from one status to another.
+                          We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                          differences (all other things held constant).
                         type: string
                       message:
                         description:
@@ -296,10 +296,9 @@ spec:
                           The reason for the condition's last transition.
                         type: string
                       severity:
-                        description:
-                          Severity with which to treat failures of this type of
-                          condition. When this is not specified, it defaults to
-                          Error.
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
                         type: string
                       status:
                         description:
@@ -314,7 +313,7 @@ spec:
                     type: object
                   type: array
                 observedGeneration:
-                  description:
+                  description: |-
                     ObservedGeneration is the 'Generation' of the Service that
                     was last processed by the controller.
                   format: int64
@@ -325,31 +324,31 @@ spec:
                     load-balancer.
                   properties:
                     ingress:
-                      description:
-                        Ingress is a list containing ingress points for the
-                        load-balancer. Traffic intended for the service should
-                        be sent to these ingress points.
+                      description: |-
+                        Ingress is a list containing ingress points for the load-balancer.
+                        Traffic intended for the service should be sent to these ingress points.
                       items:
-                        description:
-                          'LoadBalancerIngressStatus represents the status of a
-                          load-balancer ingress point: traffic intended for the
-                          service should be sent to an ingress point.'
+                        description: |-
+                          LoadBalancerIngressStatus represents the status of a load-balancer ingress point:
+                          traffic intended for the service should be sent to an ingress point.
                         properties:
                           domain:
-                            description:
-                              Domain is set for load-balancer ingress points
-                              that are DNS based (typically AWS load-balancers)
+                            description: |-
+                              Domain is set for load-balancer ingress points that are DNS based
+                              (typically AWS load-balancers)
                             type: string
                           domainInternal:
                             description: |-
-                              DomainInternal is set if there is a cluster-local DNS name to access the Ingress. 
-                               NOTE: This differs from K8s Ingress, since we also desire to have a cluster-local DNS name to allow routing in case of not having a mesh.
+                              DomainInternal is set if there is a cluster-local DNS name to access the Ingress.
+
+
+                              NOTE: This differs from K8s Ingress, since we also desire to have a cluster-local
+                                    DNS name to allow routing in case of not having a mesh.
                             type: string
                           ip:
-                            description:
-                              IP is set for load-balancer ingress points that
-                              are IP based (typically GCE or OpenStack
-                              load-balancers)
+                            description: |-
+                              IP is set for load-balancer ingress points that are IP based
+                              (typically GCE or OpenStack load-balancers)
                             type: string
                           meshOnly:
                             description:
@@ -365,31 +364,31 @@ spec:
                     load-balancer.
                   properties:
                     ingress:
-                      description:
-                        Ingress is a list containing ingress points for the
-                        load-balancer. Traffic intended for the service should
-                        be sent to these ingress points.
+                      description: |-
+                        Ingress is a list containing ingress points for the load-balancer.
+                        Traffic intended for the service should be sent to these ingress points.
                       items:
-                        description:
-                          'LoadBalancerIngressStatus represents the status of a
-                          load-balancer ingress point: traffic intended for the
-                          service should be sent to an ingress point.'
+                        description: |-
+                          LoadBalancerIngressStatus represents the status of a load-balancer ingress point:
+                          traffic intended for the service should be sent to an ingress point.
                         properties:
                           domain:
-                            description:
-                              Domain is set for load-balancer ingress points
-                              that are DNS based (typically AWS load-balancers)
+                            description: |-
+                              Domain is set for load-balancer ingress points that are DNS based
+                              (typically AWS load-balancers)
                             type: string
                           domainInternal:
                             description: |-
-                              DomainInternal is set if there is a cluster-local DNS name to access the Ingress. 
-                               NOTE: This differs from K8s Ingress, since we also desire to have a cluster-local DNS name to allow routing in case of not having a mesh.
+                              DomainInternal is set if there is a cluster-local DNS name to access the Ingress.
+
+
+                              NOTE: This differs from K8s Ingress, since we also desire to have a cluster-local
+                                    DNS name to allow routing in case of not having a mesh.
                             type: string
                           ip:
-                            description:
-                              IP is set for load-balancer ingress points that
-                              are IP based (typically GCE or OpenStack
-                              load-balancers)
+                            description: |-
+                              IP is set for load-balancer ingress points that are IP based
+                              (typically GCE or OpenStack load-balancers)
                             type: string
                           meshOnly:
                             description:

--- a/platform_umbrella/apps/common_core/priv/manifests/knative-serving/metrics_autoscaling_internal_knative_dev.yaml
+++ b/platform_umbrella/apps/common_core/priv/manifests/knative-serving/metrics_autoscaling_internal_knative_dev.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: 1.12.3
+    app.kubernetes.io/version: 1.14.1
     knative.dev/crd-install: 'true'
   name: metrics.autoscaling.internal.knative.dev
 spec:
@@ -19,10 +19,10 @@ spec:
   scope: Namespaced
   versions:
     - additionalPrinterColumns:
-        - jsonPath: .status.conditions[?(@.type=='Ready')].status
+        - jsonPath: ".status.conditions[?(@.type=='Ready')].status"
           name: Ready
           type: string
-        - jsonPath: .status.conditions[?(@.type=='Ready')].reason
+        - jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
           name: Reason
           type: string
       name: v1alpha1
@@ -32,20 +32,19 @@ spec:
             Metric represents a resource to configure the metric collector with.
           properties:
             apiVersion:
-              description:
-                'APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the
-                latest internal value, and may reject unrecognized values. More
-                info:
-                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description:
-                'Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the
-                client submits requests to. Cannot be updated. In CamelCase.
-                More info:
-                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -83,30 +82,26 @@ spec:
                 annotations:
                   additionalProperties:
                     type: string
-                  description:
-                    Annotations is additional Status fields for the Resource to
-                    save some additional State as well as convey more
-                    information to the user. This is roughly akin to Annotations
-                    on any k8s resource, just the reconciler conveying richer
-                    information outwards.
+                  description: |-
+                    Annotations is additional Status fields for the Resource to save some
+                    additional State as well as convey more information to the user. This is
+                    roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                    richer information outwards.
                   type: object
                 conditions:
                   description:
                     Conditions the latest available observations of a resource's
                     current state.
                   items:
-                    description:
-                      'Condition defines a readiness condition for a Knative
-                      resource. See:
-                      https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                    description: |-
+                      Condition defines a readiness condition for a Knative resource.
+                      See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
                     properties:
                       lastTransitionTime:
-                        description:
-                          LastTransitionTime is the last time the condition
-                          transitioned from one status to another. We use
-                          VolatileTime in place of metav1.Time to exclude this
-                          from creating equality.Semantic differences (all other
-                          things held constant).
+                        description: |-
+                          LastTransitionTime is the last time the condition transitioned from one status to another.
+                          We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                          differences (all other things held constant).
                         type: string
                       message:
                         description:
@@ -118,10 +113,9 @@ spec:
                           The reason for the condition's last transition.
                         type: string
                       severity:
-                        description:
-                          Severity with which to treat failures of this type of
-                          condition. When this is not specified, it defaults to
-                          Error.
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
                         type: string
                       status:
                         description:
@@ -136,7 +130,7 @@ spec:
                     type: object
                   type: array
                 observedGeneration:
-                  description:
+                  description: |-
                     ObservedGeneration is the 'Generation' of the Service that
                     was last processed by the controller.
                   format: int64

--- a/platform_umbrella/apps/common_core/priv/manifests/knative-serving/podautoscalers_autoscaling_internal_knative_dev.yaml
+++ b/platform_umbrella/apps/common_core/priv/manifests/knative-serving/podautoscalers_autoscaling_internal_knative_dev.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: 1.12.3
+    app.kubernetes.io/version: 1.14.1
     knative.dev/crd-install: 'true'
   name: podautoscalers.autoscaling.internal.knative.dev
 spec:
@@ -28,38 +28,35 @@ spec:
         - jsonPath: .status.actualScale
           name: ActualScale
           type: integer
-        - jsonPath: .status.conditions[?(@.type=='Ready')].status
+        - jsonPath: ".status.conditions[?(@.type=='Ready')].status"
           name: Ready
           type: string
-        - jsonPath: .status.conditions[?(@.type=='Ready')].reason
+        - jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
           name: Reason
           type: string
       name: v1alpha1
       schema:
         openAPIV3Schema:
-          description:
-            'PodAutoscaler is a Knative abstraction that encapsulates the
-            interface by which Knative components instantiate autoscalers.  This
-            definition is an abstraction that may be backed by multiple
-            definitions.  For more information, see the Knative Pluggability
-            presentation:
-            https://docs.google.com/presentation/d/19vW9HFZ6Puxt31biNZF3uLRejDmu82rxJIk1cWmxF7w/edit'
+          description: |-
+            PodAutoscaler is a Knative abstraction that encapsulates the interface by which Knative
+            components instantiate autoscalers.  This definition is an abstraction that may be backed
+            by multiple definitions.  For more information, see the Knative Pluggability presentation:
+            https://docs.google.com/presentation/d/19vW9HFZ6Puxt31biNZF3uLRejDmu82rxJIk1cWmxF7w/edit
           properties:
             apiVersion:
-              description:
-                'APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the
-                latest internal value, and may reject unrecognized values. More
-                info:
-                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description:
-                'Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the
-                client submits requests to. Cannot be updated. In CamelCase.
-                More info:
-                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -69,9 +66,9 @@ spec:
                 client).
               properties:
                 containerConcurrency:
-                  description:
-                    ContainerConcurrency specifies the maximum allowed in-flight
-                    (concurrent) requests per container of the Revision.
+                  description: |-
+                    ContainerConcurrency specifies the maximum allowed
+                    in-flight (concurrent) requests per container of the Revision.
                     Defaults to `0` which means unlimited concurrency.
                   format: int64
                   type: integer
@@ -81,28 +78,27 @@ spec:
                     inferred from the revision spec.
                   type: string
                 reachability:
-                  description:
-                    Reachability specifies whether or not the `ScaleTargetRef`
-                    can be reached (ie. has a route). Defaults to
-                    `ReachabilityUnknown`
+                  description: |-
+                    Reachability specifies whether or not the `ScaleTargetRef` can be reached (ie. has a route).
+                    Defaults to `ReachabilityUnknown`
                   type: string
                 scaleTargetRef:
-                  description:
-                    ScaleTargetRef defines the /scale-able resource that this
-                    PodAutoscaler is responsible for quickly right-sizing.
+                  description: |-
+                    ScaleTargetRef defines the /scale-able resource that this PodAutoscaler
+                    is responsible for quickly right-sizing.
                   properties:
                     apiVersion:
                       description: API version of the referent.
                       type: string
                     kind:
-                      description:
-                        'Kind of the referent. More info:
-                        https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      description: |-
+                        Kind of the referent.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                       type: string
                     name:
-                      description:
-                        'Name of the referent. More info:
-                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic
@@ -124,30 +120,26 @@ spec:
                 annotations:
                   additionalProperties:
                     type: string
-                  description:
-                    Annotations is additional Status fields for the Resource to
-                    save some additional State as well as convey more
-                    information to the user. This is roughly akin to Annotations
-                    on any k8s resource, just the reconciler conveying richer
-                    information outwards.
+                  description: |-
+                    Annotations is additional Status fields for the Resource to save some
+                    additional State as well as convey more information to the user. This is
+                    roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                    richer information outwards.
                   type: object
                 conditions:
                   description:
                     Conditions the latest available observations of a resource's
                     current state.
                   items:
-                    description:
-                      'Condition defines a readiness condition for a Knative
-                      resource. See:
-                      https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                    description: |-
+                      Condition defines a readiness condition for a Knative resource.
+                      See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
                     properties:
                       lastTransitionTime:
-                        description:
-                          LastTransitionTime is the last time the condition
-                          transitioned from one status to another. We use
-                          VolatileTime in place of metav1.Time to exclude this
-                          from creating equality.Semantic differences (all other
-                          things held constant).
+                        description: |-
+                          LastTransitionTime is the last time the condition transitioned from one status to another.
+                          We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                          differences (all other things held constant).
                         type: string
                       message:
                         description:
@@ -159,10 +151,9 @@ spec:
                           The reason for the condition's last transition.
                         type: string
                       severity:
-                        description:
-                          Severity with which to treat failures of this type of
-                          condition. When this is not specified, it defaults to
-                          Error.
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
                         type: string
                       status:
                         description:
@@ -183,21 +174,20 @@ spec:
                   format: int32
                   type: integer
                 metricsServiceName:
-                  description:
-                    MetricsServiceName is the K8s Service name that provides
-                    revision metrics. The service is managed by the PA object.
+                  description: |-
+                    MetricsServiceName is the K8s Service name that provides revision metrics.
+                    The service is managed by the PA object.
                   type: string
                 observedGeneration:
-                  description:
+                  description: |-
                     ObservedGeneration is the 'Generation' of the Service that
                     was last processed by the controller.
                   format: int64
                   type: integer
                 serviceName:
-                  description:
-                    ServiceName is the K8s Service name that serves the
-                    revision, scaled by this PA. The service is created and
-                    owned by the ServerlessService object owned by this PA.
+                  description: |-
+                    ServiceName is the K8s Service name that serves the revision, scaled by this PA.
+                    The service is created and owned by the ServerlessService object owned by this PA.
                   type: string
               required:
                 - metricsServiceName

--- a/platform_umbrella/apps/common_core/priv/manifests/knative-serving/revisions_serving_knative_dev.yaml
+++ b/platform_umbrella/apps/common_core/priv/manifests/knative-serving/revisions_serving_knative_dev.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: 1.12.3
+    app.kubernetes.io/version: 1.14.1
     knative.dev/crd-install: 'true'
   name: revisions.serving.knative.dev
 spec:
@@ -22,19 +22,16 @@ spec:
   scope: Namespaced
   versions:
     - additionalPrinterColumns:
-        - jsonPath: .metadata.labels['serving\.knative\.dev/configuration']
+        - jsonPath: ".metadata.labels['serving\\.knative\\.dev/configuration']"
           name: Config Name
           type: string
-        - jsonPath: .status.serviceName
-          name: K8s Service Name
-          type: string
-        - jsonPath: .metadata.labels['serving\.knative\.dev/configurationGeneration']
+        - jsonPath: ".metadata.labels['serving\\.knative\\.dev/configurationGeneration']"
           name: Generation
           type: string
-        - jsonPath: .status.conditions[?(@.type=='Ready')].status
+        - jsonPath: ".status.conditions[?(@.type=='Ready')].status"
           name: Ready
           type: string
-        - jsonPath: .status.conditions[?(@.type=='Ready')].reason
+        - jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
           name: Reason
           type: string
         - jsonPath: .status.actualReplicas
@@ -47,24 +44,27 @@ spec:
       schema:
         openAPIV3Schema:
           description: |-
-            Revision is an immutable snapshot of code and configuration.  A revision references a container image. Revisions are created by updates to a Configuration. 
-             See also: https://github.com/knative/serving/blob/main/docs/spec/overview.md#revision
+            Revision is an immutable snapshot of code and configuration.  A revision
+            references a container image. Revisions are created by updates to a
+            Configuration.
+
+
+            See also: https://github.com/knative/serving/blob/main/docs/spec/overview.md#revision
           properties:
             apiVersion:
-              description:
-                'APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the
-                latest internal value, and may reject unrecognized values. More
-                info:
-                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description:
-                'Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the
-                client submits requests to. Cannot be updated. In CamelCase.
-                More info:
-                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -85,60 +85,52 @@ spec:
                     account token should be automatically mounted.
                   type: boolean
                 containerConcurrency:
-                  description:
-                    ContainerConcurrency specifies the maximum allowed in-flight
-                    (concurrent) requests per container of the
-                    Revision.  Defaults to `0` which means concurrency to the
-                    application is not limited, and the system decides the
+                  description: |-
+                    ContainerConcurrency specifies the maximum allowed in-flight (concurrent)
+                    requests per container of the Revision.  Defaults to `0` which means
+                    concurrency to the application is not limited, and the system decides the
                     target concurrency for the autoscaler.
                   format: int64
                   type: integer
                 containers:
-                  description:
-                    List of containers belonging to the pod. Containers cannot
-                    currently be added or removed. There must be at least one
-                    container in a Pod. Cannot be updated.
+                  description: |-
+                    List of containers belonging to the pod.
+                    Containers cannot currently be added or removed.
+                    There must be at least one container in a Pod.
+                    Cannot be updated.
                   items:
                     description:
                       A single application container that you want to run within
                       a pod.
                     properties:
                       args:
-                        description:
-                          'Arguments to the entrypoint. The container image''s
-                          CMD is used if this is not provided. Variable
-                          references $(VAR_NAME) are expanded using the
-                          container''s environment. If a variable cannot be
-                          resolved, the reference in the input string will be
-                          unchanged. Double $$ are reduced to a single $, which
-                          allows for escaping the $(VAR_NAME) syntax: i.e.
-                          "$$(VAR_NAME)" will produce the string literal
-                          "$(VAR_NAME)". Escaped references will never be
-                          expanded, regardless of whether the variable exists or
-                          not. Cannot be updated. More info:
-                          https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                        description: |-
+                          Arguments to the entrypoint.
+                          The container image's CMD is used if this is not provided.
+                          Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                          cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                          produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                          of whether the variable exists or not. Cannot be updated.
+                          More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                         items:
                           type: string
                         type: array
                       command:
-                        description:
-                          'Entrypoint array. Not executed within a shell. The
-                          container image''s ENTRYPOINT is used if this is not
-                          provided. Variable references $(VAR_NAME) are expanded
-                          using the container''s environment. If a variable
-                          cannot be resolved, the reference in the input string
-                          will be unchanged. Double $$ are reduced to a single
-                          $, which allows for escaping the $(VAR_NAME) syntax:
-                          i.e. "$$(VAR_NAME)" will produce the string literal
-                          "$(VAR_NAME)". Escaped references will never be
-                          expanded, regardless of whether the variable exists or
-                          not. Cannot be updated. More info:
-                          https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                        description: |-
+                          Entrypoint array. Not executed within a shell.
+                          The container image's ENTRYPOINT is used if this is not provided.
+                          Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                          cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                          produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                          of whether the variable exists or not. Cannot be updated.
+                          More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                         items:
                           type: string
                         type: array
                       env:
-                        description:
+                        description: |-
                           List of environment variables to set in the container.
                           Cannot be updated.
                         items:
@@ -152,18 +144,16 @@ spec:
                                 C_IDENTIFIER.
                               type: string
                             value:
-                              description:
-                                'Variable references $(VAR_NAME) are expanded
-                                using the previously defined environment
-                                variables in the container and any service
-                                environment variables. If a variable cannot be
-                                resolved, the reference in the input string will
-                                be unchanged. Double $$ are reduced to a single
-                                $, which allows for escaping the $(VAR_NAME)
-                                syntax: i.e. "$$(VAR_NAME)" will produce the
-                                string literal "$(VAR_NAME)". Escaped references
-                                will never be expanded, regardless of whether
-                                the variable exists or not. Defaults to "".'
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
                               type: string
                             valueFrom:
                               description:
@@ -177,11 +167,10 @@ spec:
                                       description: The key to select.
                                       type: string
                                     name:
-                                      description:
-                                        'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields.
-                                        apiVersion, kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                     optional:
                                       description:
@@ -217,11 +206,10 @@ spec:
                                         from.  Must be a valid secret key.
                                       type: string
                                     name:
-                                      description:
-                                        'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields.
-                                        apiVersion, kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                     optional:
                                       description:
@@ -238,14 +226,12 @@ spec:
                           type: object
                         type: array
                       envFrom:
-                        description:
-                          List of sources to populate environment variables in
-                          the container. The keys defined within a source must
-                          be a C_IDENTIFIER. All invalid keys will be reported
-                          as an event when the container is starting. When a key
-                          exists in multiple sources, the value associated with
-                          the last source will take precedence. Values defined
-                          by an Env with a duplicate key will take precedence.
+                        description: |-
+                          List of sources to populate environment variables in the container.
+                          The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                          will be reported as an event when the container is starting. When a key exists in multiple
+                          sources, the value associated with the last source will take precedence.
+                          Values defined by an Env with a duplicate key will take precedence.
                           Cannot be updated.
                         items:
                           description:
@@ -256,11 +242,10 @@ spec:
                               description: The ConfigMap to select from
                               properties:
                                 name:
-                                  description:
-                                    'Name of the referent. More info:
-                                    https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion,
-                                    kind, uid?'
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
                                   description:
@@ -278,11 +263,10 @@ spec:
                               description: The Secret to select from
                               properties:
                                 name:
-                                  description:
-                                    'Name of the referent. More info:
-                                    https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion,
-                                    kind, uid?'
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
                                   description:
@@ -293,52 +277,45 @@ spec:
                           type: object
                         type: array
                       image:
-                        description:
-                          'Container image name. More info:
-                          https://kubernetes.io/docs/concepts/containers/images
-                          This field is optional to allow higher level config
-                          management to default or override container images in
-                          workload controllers like Deployments and
-                          StatefulSets.'
+                        description: |-
+                          Container image name.
+                          More info: https://kubernetes.io/docs/concepts/containers/images
+                          This field is optional to allow higher level config management to default or override
+                          container images in workload controllers like Deployments and StatefulSets.
                         type: string
                       imagePullPolicy:
-                        description:
-                          'Image pull policy. One of Always, Never,
-                          IfNotPresent. Defaults to Always if :latest tag is
-                          specified, or IfNotPresent otherwise. Cannot be
-                          updated. More info:
-                          https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                        description: |-
+                          Image pull policy.
+                          One of Always, Never, IfNotPresent.
+                          Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                         type: string
                       livenessProbe:
-                        description:
-                          'Periodic probe of container liveness. Container will
-                          be restarted if the probe fails. Cannot be updated.
-                          More info:
-                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        description: |-
+                          Periodic probe of container liveness.
+                          Container will be restarted if the probe fails.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         properties:
                           exec:
                             description: Exec specifies the action to take.
                             properties:
                               command:
-                                description:
-                                  Command is the command line to execute inside
-                                  the container, the working directory for the
-                                  command  is root ('/') in the container's
-                                  filesystem. The command is simply exec'd, it
-                                  is not run inside a shell, so traditional
-                                  shell instructions ('|', etc) won't work. To
-                                  use a shell, you need to explicitly call out
-                                  to that shell. Exit status of 0 is treated as
-                                  live/healthy and non-zero is unhealthy.
+                                description: |-
+                                  Command is the command line to execute inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                  a shell, you need to explicitly call out to that shell.
+                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                 items:
                                   type: string
                                 type: array
                             type: object
                           failureThreshold:
-                            description:
-                              Minimum consecutive failures for the probe to be
-                              considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
+                            description: |-
+                              Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                              Defaults to 3. Minimum value is 1.
                             format: int32
                             type: integer
                           grpc:
@@ -353,8 +330,11 @@ spec:
                                 type: integer
                               service:
                                 description: |-
-                                  Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). 
-                                   If this is not specified, the default behavior is defined by gRPC.
+                                  Service is the name of the service to place in the gRPC HealthCheckRequest
+                                  (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                  If this is not specified, the default behavior is defined by gRPC.
                                 type: string
                             required:
                               - port
@@ -364,10 +344,9 @@ spec:
                               HTTPGet specifies the http request to perform.
                             properties:
                               host:
-                                description:
-                                  Host name to connect to, defaults to the pod
-                                  IP. You probably want to set "Host" in
-                                  httpHeaders instead.
+                                description: |-
+                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                  "Host" in httpHeaders instead.
                                 type: string
                               httpHeaders:
                                 description:
@@ -379,11 +358,9 @@ spec:
                                     used in HTTP probes
                                   properties:
                                     name:
-                                      description:
-                                        The header field name. This will be
-                                        canonicalized upon output, so
-                                        case-variant names will be understood as
-                                        the same header.
+                                      description: |-
+                                        The header field name.
+                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                       type: string
                                     value:
                                       description: The header field value
@@ -400,22 +377,21 @@ spec:
                                 anyOf:
                                   - type: integer
                                   - type: string
-                                description:
-                                  Name or number of the port to access on the
-                                  container. Number must be in the range 1 to
-                                  65535. Name must be an IANA_SVC_NAME.
+                                description: |-
+                                  Name or number of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                               scheme:
-                                description:
+                                description: |-
                                   Scheme to use for connecting to the host.
                                   Defaults to HTTP.
                                 type: string
                             type: object
                           initialDelaySeconds:
-                            description:
-                              'Number of seconds after the container has started
-                              before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            description: |-
+                              Number of seconds after the container has started before liveness probes are initiated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                             format: int32
                             type: integer
                           periodSeconds:
@@ -424,11 +400,9 @@ spec:
                             format: int32
                             type: integer
                           successThreshold:
-                            description:
-                              Minimum consecutive successes for the probe to be
-                              considered successful after having failed.
-                              Defaults to 1. Must be 1 for liveness and startup.
-                              Minimum value is 1.
+                            description: |-
+                              Minimum consecutive successes for the probe to be considered successful after having failed.
+                              Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                             format: int32
                             type: integer
                           tcpSocket:
@@ -445,37 +419,34 @@ spec:
                                 anyOf:
                                   - type: integer
                                   - type: string
-                                description:
-                                  Number or name of the port to access on the
-                                  container. Number must be in the range 1 to
-                                  65535. Name must be an IANA_SVC_NAME.
+                                description: |-
+                                  Number or name of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                             type: object
                           timeoutSeconds:
-                            description:
-                              'Number of seconds after which the probe times
-                              out. Defaults to 1 second. Minimum value is 1.
-                              More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            description: |-
+                              Number of seconds after which the probe times out.
+                              Defaults to 1 second. Minimum value is 1.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                             format: int32
                             type: integer
                         type: object
                       name:
-                        description:
-                          Name of the container specified as a DNS_LABEL. Each
-                          container in a pod must have a unique name
-                          (DNS_LABEL). Cannot be updated.
+                        description: |-
+                          Name of the container specified as a DNS_LABEL.
+                          Each container in a pod must have a unique name (DNS_LABEL).
+                          Cannot be updated.
                         type: string
                       ports:
-                        description:
-                          List of ports to expose from the container. Not
-                          specifying a port here DOES NOT prevent that port from
-                          being exposed. Any port which is listening on the
-                          default "0.0.0.0" address inside a container will be
-                          accessible from the network. Modifying this array with
-                          strategic merge patch may corrupt the data. For more
-                          information See
-                          https://github.com/kubernetes/kubernetes/issues/108255.
+                        description: |-
+                          List of ports to expose from the container. Not specifying a port here
+                          DOES NOT prevent that port from being exposed. Any port which is
+                          listening on the default "0.0.0.0" address inside a container will be
+                          accessible from the network.
+                          Modifying this array with strategic merge patch may corrupt the data.
+                          For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                           Cannot be updated.
                         items:
                           description:
@@ -483,22 +454,20 @@ spec:
                             container.
                           properties:
                             containerPort:
-                              description:
-                                Number of port to expose on the pod's IP
-                                address. This must be a valid port number, 0 < x
-                                < 65536.
+                              description: |-
+                                Number of port to expose on the pod's IP address.
+                                This must be a valid port number, 0 < x < 65536.
                               format: int32
                               type: integer
                             name:
-                              description:
-                                If specified, this must be an IANA_SVC_NAME and
-                                unique within the pod. Each named port in a pod
-                                must have a unique name. Name for the port that
-                                can be referred to by services.
+                              description: |-
+                                If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                named port in a pod must have a unique name. Name for the port that can be
+                                referred to by services.
                               type: string
                             protocol:
                               default: TCP
-                              description:
+                              description: |-
                                 Protocol for port. Must be UDP, TCP, or SCTP.
                                 Defaults to "TCP".
                               type: string
@@ -511,35 +480,30 @@ spec:
                           - protocol
                         x-kubernetes-list-type: map
                       readinessProbe:
-                        description:
-                          'Periodic probe of container service readiness.
-                          Container will be removed from service endpoints if
-                          the probe fails. Cannot be updated. More info:
-                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        description: |-
+                          Periodic probe of container service readiness.
+                          Container will be removed from service endpoints if the probe fails.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         properties:
                           exec:
                             description: Exec specifies the action to take.
                             properties:
                               command:
-                                description:
-                                  Command is the command line to execute inside
-                                  the container, the working directory for the
-                                  command  is root ('/') in the container's
-                                  filesystem. The command is simply exec'd, it
-                                  is not run inside a shell, so traditional
-                                  shell instructions ('|', etc) won't work. To
-                                  use a shell, you need to explicitly call out
-                                  to that shell. Exit status of 0 is treated as
-                                  live/healthy and non-zero is unhealthy.
+                                description: |-
+                                  Command is the command line to execute inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                  a shell, you need to explicitly call out to that shell.
+                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                 items:
                                   type: string
                                 type: array
                             type: object
                           failureThreshold:
-                            description:
-                              Minimum consecutive failures for the probe to be
-                              considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
+                            description: |-
+                              Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                              Defaults to 3. Minimum value is 1.
                             format: int32
                             type: integer
                           grpc:
@@ -554,8 +518,11 @@ spec:
                                 type: integer
                               service:
                                 description: |-
-                                  Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). 
-                                   If this is not specified, the default behavior is defined by gRPC.
+                                  Service is the name of the service to place in the gRPC HealthCheckRequest
+                                  (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                  If this is not specified, the default behavior is defined by gRPC.
                                 type: string
                             required:
                               - port
@@ -565,10 +532,9 @@ spec:
                               HTTPGet specifies the http request to perform.
                             properties:
                               host:
-                                description:
-                                  Host name to connect to, defaults to the pod
-                                  IP. You probably want to set "Host" in
-                                  httpHeaders instead.
+                                description: |-
+                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                  "Host" in httpHeaders instead.
                                 type: string
                               httpHeaders:
                                 description:
@@ -580,11 +546,9 @@ spec:
                                     used in HTTP probes
                                   properties:
                                     name:
-                                      description:
-                                        The header field name. This will be
-                                        canonicalized upon output, so
-                                        case-variant names will be understood as
-                                        the same header.
+                                      description: |-
+                                        The header field name.
+                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                       type: string
                                     value:
                                       description: The header field value
@@ -601,22 +565,21 @@ spec:
                                 anyOf:
                                   - type: integer
                                   - type: string
-                                description:
-                                  Name or number of the port to access on the
-                                  container. Number must be in the range 1 to
-                                  65535. Name must be an IANA_SVC_NAME.
+                                description: |-
+                                  Name or number of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                               scheme:
-                                description:
+                                description: |-
                                   Scheme to use for connecting to the host.
                                   Defaults to HTTP.
                                 type: string
                             type: object
                           initialDelaySeconds:
-                            description:
-                              'Number of seconds after the container has started
-                              before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            description: |-
+                              Number of seconds after the container has started before liveness probes are initiated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                             format: int32
                             type: integer
                           periodSeconds:
@@ -625,11 +588,9 @@ spec:
                             format: int32
                             type: integer
                           successThreshold:
-                            description:
-                              Minimum consecutive successes for the probe to be
-                              considered successful after having failed.
-                              Defaults to 1. Must be 1 for liveness and startup.
-                              Minimum value is 1.
+                            description: |-
+                              Minimum consecutive successes for the probe to be considered successful after having failed.
+                              Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                             format: int32
                             type: integer
                           tcpSocket:
@@ -646,43 +607,47 @@ spec:
                                 anyOf:
                                   - type: integer
                                   - type: string
-                                description:
-                                  Number or name of the port to access on the
-                                  container. Number must be in the range 1 to
-                                  65535. Name must be an IANA_SVC_NAME.
+                                description: |-
+                                  Number or name of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
+                                  Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                             type: object
                           timeoutSeconds:
-                            description:
-                              'Number of seconds after which the probe times
-                              out. Defaults to 1 second. Minimum value is 1.
-                              More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            description: |-
+                              Number of seconds after which the probe times out.
+                              Defaults to 1 second. Minimum value is 1.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                             format: int32
                             type: integer
                         type: object
                       resources:
-                        description:
-                          'Compute Resources required by this container. Cannot
-                          be updated. More info:
-                          https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        description: |-
+                          Compute Resources required by this container.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         properties:
                           claims:
                             description: |-
-                              Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. 
-                               This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. 
-                               This field is immutable. It can only be set for containers.
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+
+                              This field is immutable. It can only be set for containers.
                             items:
                               description:
                                 ResourceClaim references one entry in
                                 PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description:
-                                    Name must match the name of one entry in
-                                    pod.spec.resourceClaims of the Pod where
-                                    this field is used. It makes that resource
-                                    available inside a container.
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
                                   type: string
                               required:
                                 - name
@@ -698,10 +663,9 @@ spec:
                                 - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description:
-                              'Limits describes the maximum amount of compute
-                              resources allowed. More info:
-                              https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -710,42 +674,34 @@ spec:
                                 - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description:
-                              'Requests describes the minimum amount of compute
-                              resources required. If Requests is omitted for a
-                              container, it defaults to Limits if that is
-                              explicitly specified, otherwise to an
-                              implementation-defined value. Requests cannot
-                              exceed Limits. More info:
-                              https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       securityContext:
-                        description:
-                          'SecurityContext defines the security options the
-                          container should be run with. If set, the fields of
-                          SecurityContext override the equivalent fields of
-                          PodSecurityContext. More info:
-                          https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                        description: |-
+                          SecurityContext defines the security options the container should be run with.
+                          If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                          More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                         properties:
                           allowPrivilegeEscalation:
-                            description:
-                              'AllowPrivilegeEscalation controls whether a
-                              process can gain more privileges than its parent
-                              process. This bool directly controls if the
-                              no_new_privs flag will be set on the container
-                              process. AllowPrivilegeEscalation is true always
-                              when the container is: 1) run as Privileged 2) has
-                              CAP_SYS_ADMIN Note that this field cannot be set
-                              when spec.os.name is windows.'
+                            description: |-
+                              AllowPrivilegeEscalation controls whether a process can gain more
+                              privileges than its parent process. This bool directly controls if
+                              the no_new_privs flag will be set on the container process.
+                              AllowPrivilegeEscalation is true always when the container is:
+                              1) run as Privileged
+                              2) has CAP_SYS_ADMIN
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: boolean
                           capabilities:
-                            description:
-                              The capabilities to add/drop when running
-                              containers. Defaults to the default set of
-                              capabilities granted by the container runtime.
-                              Note that this field cannot be set when
-                              spec.os.name is windows.
+                            description: |-
+                              The capabilities to add/drop when running containers.
+                              Defaults to the default set of capabilities granted by the container runtime.
+                              Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               add:
                                 description:
@@ -765,99 +721,88 @@ spec:
                                 type: array
                             type: object
                           readOnlyRootFilesystem:
-                            description:
-                              Whether this container has a read-only root
-                              filesystem. Default is false. Note that this field
-                              cannot be set when spec.os.name is windows.
+                            description: |-
+                              Whether this container has a read-only root filesystem.
+                              Default is false.
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: boolean
                           runAsGroup:
-                            description:
-                              The GID to run the entrypoint of the container
-                              process. Uses runtime default if unset. May also
-                              be set in PodSecurityContext.  If set in both
-                              SecurityContext and PodSecurityContext, the value
-                              specified in SecurityContext takes precedence.
-                              Note that this field cannot be set when
-                              spec.os.name is windows.
+                            description: |-
+                              The GID to run the entrypoint of the container process.
+                              Uses runtime default if unset.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
                             format: int64
                             type: integer
                           runAsNonRoot:
-                            description:
-                              Indicates that the container must run as a
-                              non-root user. If true, the Kubelet will validate
-                              the image at runtime to ensure that it does not
-                              run as UID 0 (root) and fail to start the
-                              container if it does. If unset or false, no such
-                              validation will be performed. May also be set in
-                              PodSecurityContext.  If set in both
-                              SecurityContext and PodSecurityContext, the value
-                              specified in SecurityContext takes precedence.
+                            description: |-
+                              Indicates that the container must run as a non-root user.
+                              If true, the Kubelet will validate the image at runtime to ensure that it
+                              does not run as UID 0 (root) and fail to start the container if it does.
+                              If unset or false, no such validation will be performed.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
                             type: boolean
                           runAsUser:
-                            description:
-                              The UID to run the entrypoint of the container
-                              process. Defaults to user specified in image
-                              metadata if unspecified. May also be set in
-                              PodSecurityContext.  If set in both
-                              SecurityContext and PodSecurityContext, the value
-                              specified in SecurityContext takes precedence.
-                              Note that this field cannot be set when
-                              spec.os.name is windows.
+                            description: |-
+                              The UID to run the entrypoint of the container process.
+                              Defaults to user specified in image metadata if unspecified.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
                             format: int64
                             type: integer
                           seccompProfile:
-                            description:
-                              The seccomp options to use by this container. If
-                              seccomp options are provided at both the pod &
-                              container level, the container options override
-                              the pod options. Note that this field cannot be
-                              set when spec.os.name is windows.
+                            description: |-
+                              The seccomp options to use by this container. If seccomp options are
+                              provided at both the pod & container level, the container options
+                              override the pod options.
+                              Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               localhostProfile:
-                                description:
-                                  localhostProfile indicates a profile defined
-                                  in a file on the node should be used. The
-                                  profile must be preconfigured on the node to
-                                  work. Must be a descending path, relative to
-                                  the kubelet's configured seccomp profile
-                                  location. Must only be set if type is
-                                  "Localhost".
+                                description: |-
+                                  localhostProfile indicates a profile defined in a file on the node should be used.
+                                  The profile must be preconfigured on the node to work.
+                                  Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                  Must be set if type is "Localhost". Must NOT be set for any other type.
                                 type: string
                               type:
                                 description: |-
-                                  type indicates which kind of seccomp profile will be applied. Valid options are: 
-                                   Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+                                  type indicates which kind of seccomp profile will be applied.
+                                  Valid options are:
+
+
+                                  Localhost - a profile defined in a file on the node should be used.
+                                  RuntimeDefault - the container runtime default profile should be used.
+                                  Unconfined - no profile should be applied.
                                 type: string
                             required:
                               - type
                             type: object
                         type: object
                       terminationMessagePath:
-                        description:
-                          "Optional: Path at which the file to which the
-                          container's termination message will be written is
-                          mounted into the container's filesystem. Message
-                          written is intended to be brief final status, such as
-                          an assertion failure message. Will be truncated by the
-                          node if greater than 4096 bytes. The total message
-                          length across all containers will be limited to 12kb.
-                          Defaults to /dev/termination-log. Cannot be updated."
+                        description: |-
+                          Optional: Path at which the file to which the container's termination message
+                          will be written is mounted into the container's filesystem.
+                          Message written is intended to be brief final status, such as an assertion failure message.
+                          Will be truncated by the node if greater than 4096 bytes. The total message length across
+                          all containers will be limited to 12kb.
+                          Defaults to /dev/termination-log.
+                          Cannot be updated.
                         type: string
                       terminationMessagePolicy:
-                        description:
-                          Indicate how the termination message should be
-                          populated. File will use the contents of
-                          terminationMessagePath to populate the container
-                          status message on both success and failure.
-                          FallbackToLogsOnError will use the last chunk of
-                          container log output if the termination message file
-                          is empty and the container exited with an error. The
-                          log output is limited to 2048 bytes or 80 lines,
-                          whichever is smaller. Defaults to File. Cannot be
-                          updated.
+                        description: |-
+                          Indicate how the termination message should be populated. File will use the contents of
+                          terminationMessagePath to populate the container status message on both success and failure.
+                          FallbackToLogsOnError will use the last chunk of container log output if the termination
+                          message file is empty and the container exited with an error.
+                          The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                          Defaults to File.
+                          Cannot be updated.
                         type: string
                       volumeMounts:
-                        description:
+                        description: |-
                           Pod volumes to mount into the container's filesystem.
                           Cannot be updated.
                         items:
@@ -866,23 +811,22 @@ spec:
                             a container.
                           properties:
                             mountPath:
-                              description:
-                                Path within the container at which the volume
-                                should be mounted.  Must not contain ':'.
+                              description: |-
+                                Path within the container at which the volume should be mounted.  Must
+                                not contain ':'.
                               type: string
                             name:
                               description: This must match the Name of a Volume.
                               type: string
                             readOnly:
-                              description:
-                                Mounted read-only if true, read-write otherwise
-                                (false or unspecified). Defaults to false.
+                              description: |-
+                                Mounted read-only if true, read-write otherwise (false or unspecified).
+                                Defaults to false.
                               type: boolean
                             subPath:
-                              description:
-                                Path within the volume from which the
-                                container's volume should be mounted. Defaults
-                                to "" (volume's root).
+                              description: |-
+                                Path within the volume from which the container's volume should be mounted.
+                                Defaults to "" (volume's root).
                               type: string
                           required:
                             - mountPath
@@ -890,11 +834,11 @@ spec:
                           type: object
                         type: array
                       workingDir:
-                        description:
-                          Container's working directory. If not specified, the
-                          container runtime's default will be used, which might
-                          be configured in the container image. Cannot be
-                          updated.
+                        description: |-
+                          Container's working directory.
+                          If not specified, the container runtime's default will be used, which
+                          might be configured in the container image.
+                          Cannot be updated.
                         type: string
                     type: object
                   type: array
@@ -928,53 +872,46 @@ spec:
                     x-kubernetes-preserve-unknown-fields: true
                   type: array
                 idleTimeoutSeconds:
-                  description:
-                    IdleTimeoutSeconds is the maximum duration in seconds a
-                    request will be allowed to stay open while not receiving any
-                    bytes from the user's application. If unspecified, a system
-                    default will be provided.
+                  description: |-
+                    IdleTimeoutSeconds is the maximum duration in seconds a request will be allowed
+                    to stay open while not receiving any bytes from the user's application. If
+                    unspecified, a system default will be provided.
                   format: int64
                   type: integer
                 imagePullSecrets:
-                  description:
-                    'ImagePullSecrets is an optional list of references to
-                    secrets in the same namespace to use for pulling any of the
-                    images used by this PodSpec. If specified, these secrets
-                    will be passed to individual puller implementations for them
-                    to use. More info:
-                    https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                  description: |-
+                    ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+                    If specified, these secrets will be passed to individual puller implementations for them to use.
+                    More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
                   items:
-                    description:
-                      LocalObjectReference contains enough information to let
-                      you locate the referenced object inside the same
-                      namespace.
+                    description: |-
+                      LocalObjectReference contains enough information to let you locate the
+                      referenced object inside the same namespace.
                     properties:
                       name:
-                        description:
-                          'Name of the referent. More info:
-                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?
                         type: string
                     type: object
                     x-kubernetes-map-type: atomic
                   type: array
                 initContainers:
-                  description:
-                    'List of initialization containers belonging to the pod.
-                    Init containers are executed in order prior to containers
-                    being started. If any init container fails, the pod is
-                    considered to have failed and is handled according to its
-                    restartPolicy. The name for an init container or normal
-                    container must be unique among all containers. Init
-                    containers may not have Lifecycle actions, Readiness probes,
-                    Liveness probes, or Startup probes. The resourceRequirements
-                    of an init container are taken into account during
-                    scheduling by finding the highest request/limit for each
-                    resource type, and then using the max of of that value or
-                    the sum of the normal containers. Limits are applied to init
-                    containers in a similar fashion. Init containers cannot
-                    currently be added or removed. Cannot be updated. More info:
-                    https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                  description: |-
+                    List of initialization containers belonging to the pod.
+                    Init containers are executed in order prior to containers being started. If any
+                    init container fails, the pod is considered to have failed and is handled according
+                    to its restartPolicy. The name for an init container or normal container must be
+                    unique among all containers.
+                    Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+                    The resourceRequirements of an init container are taken into account during scheduling
+                    by finding the highest request/limit for each resource type, and then using the max of
+                    of that value or the sum of the normal containers. Limits are applied to init containers
+                    in a similar fashion.
+                    Init containers cannot currently be added or removed.
+                    Cannot be updated.
+                    More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
                   items:
                     description:
                       This is accessible behind a feature flag -
@@ -996,11 +933,10 @@ spec:
                   type: string
                   x-kubernetes-preserve-unknown-fields: true
                 responseStartTimeoutSeconds:
-                  description:
-                    ResponseStartTimeoutSeconds is the maximum duration in
-                    seconds that the request routing layer will wait for a
-                    request delivered to a container to begin sending any
-                    network traffic.
+                  description: |-
+                    ResponseStartTimeoutSeconds is the maximum duration in seconds that the request
+                    routing layer will wait for a request delivered to a container to begin
+                    sending any network traffic.
                   format: int64
                   type: integer
                 runtimeClassName:
@@ -1022,10 +958,9 @@ spec:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 serviceAccountName:
-                  description:
-                    'ServiceAccountName is the name of the ServiceAccount to use
-                    to run this pod. More info:
-                    https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                  description: |-
+                    ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+                    More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
                   type: string
                 shareProcessNamespace:
                   description:
@@ -1034,10 +969,10 @@ spec:
                   type: boolean
                   x-kubernetes-preserve-unknown-fields: true
                 timeoutSeconds:
-                  description:
-                    TimeoutSeconds is the maximum duration in seconds that the
-                    request instance is allowed to respond to a request. If
-                    unspecified, a system default will be provided.
+                  description: |-
+                    TimeoutSeconds is the maximum duration in seconds that the request instance
+                    is allowed to respond to a request. If unspecified, a system default will
+                    be provided.
                   format: int64
                   type: integer
                 tolerations:
@@ -1063,10 +998,9 @@ spec:
                     x-kubernetes-preserve-unknown-fields: true
                   type: array
                 volumes:
-                  description:
-                    'List of volumes that can be mounted by containers belonging
-                    to the pod. More info:
-                    https://kubernetes.io/docs/concepts/storage/volumes'
+                  description: |-
+                    List of volumes that can be mounted by containers belonging to the pod.
+                    More info: https://kubernetes.io/docs/concepts/storage/volumes
                   items:
                     description:
                       Volume represents a named volume in a pod that may be
@@ -1078,32 +1012,25 @@ spec:
                           this volume
                         properties:
                           defaultMode:
-                            description:
-                              'defaultMode is optional: mode bits used to set
-                              permissions on created files by default. Must be
-                              an octal value between 0000 and 0777 or a decimal
-                              value between 0 and 511. YAML accepts both octal
-                              and decimal values, JSON requires decimal values
-                              for mode bits. Defaults to 0644. Directories
-                              within the path are not affected by this setting.
-                              This might be in conflict with other options that
-                              affect the file mode, like fsGroup, and the result
-                              can be other mode bits set.'
+                            description: |-
+                              defaultMode is optional: mode bits used to set permissions on created files by default.
+                              Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                              Defaults to 0644.
+                              Directories within the path are not affected by this setting.
+                              This might be in conflict with other options that affect the file
+                              mode, like fsGroup, and the result can be other mode bits set.
                             format: int32
                             type: integer
                           items:
-                            description:
-                              items if unspecified, each key-value pair in the
-                              Data field of the referenced ConfigMap will be
-                              projected into the volume as a file whose name is
-                              the key and content is the value. If specified,
-                              the listed keys will be projected into the
-                              specified paths, and unlisted keys will not be
-                              present. If a key is specified which is not
-                              present in the ConfigMap, the volume setup will
-                              error unless it is marked optional. Paths must be
-                              relative and may not contain the '..' path or
-                              start with '..'.
+                            description: |-
+                              items if unspecified, each key-value pair in the Data field of the referenced
+                              ConfigMap will be projected into the volume as a file whose name is the
+                              key and content is the value. If specified, the listed keys will be
+                              projected into the specified paths, and unlisted keys will not be
+                              present. If a key is specified which is not present in the ConfigMap,
+                              the volume setup will error unless it is marked optional. Paths must be
+                              relative and may not contain the '..' path or start with '..'.
                             items:
                               description:
                                 Maps a string key to a path within a volume.
@@ -1112,26 +1039,21 @@ spec:
                                   description: key is the key to project.
                                   type: string
                                 mode:
-                                  description:
-                                    'mode is Optional: mode bits used to set
-                                    permissions on this file. Must be an octal
-                                    value between 0000 and 0777 or a decimal
-                                    value between 0 and 511. YAML accepts both
-                                    octal and decimal values, JSON requires
-                                    decimal values for mode bits. If not
-                                    specified, the volume defaultMode will be
-                                    used. This might be in conflict with other
-                                    options that affect the file mode, like
-                                    fsGroup, and the result can be other mode
-                                    bits set.'
+                                  description: |-
+                                    mode is Optional: mode bits used to set permissions on this file.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                    If not specified, the volume defaultMode will be used.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 path:
-                                  description:
-                                    path is the relative path of the file to map
-                                    the key to. May not be an absolute path. May
-                                    not contain the path element '..'. May not
-                                    start with the string '..'.
+                                  description: |-
+                                    path is the relative path of the file to map the key to.
+                                    May not be an absolute path.
+                                    May not contain the path element '..'.
+                                    May not start with the string '..'.
                                   type: string
                               required:
                                 - key
@@ -1139,11 +1061,10 @@ spec:
                               type: object
                             type: array
                           name:
-                            description:
-                              'Name of the referent. More info:
-                              https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind,
-                              uid?'
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?
                             type: string
                           optional:
                             description:
@@ -1159,10 +1080,10 @@ spec:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                       name:
-                        description:
-                          'name of the volume. Must be a DNS_LABEL and unique
-                          within the pod. More info:
-                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        description: |-
+                          name of the volume.
+                          Must be a DNS_LABEL and unique within the pod.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                         type: string
                       persistentVolumeClaim:
                         description:
@@ -1176,17 +1097,13 @@ spec:
                           configmaps, and downward API
                         properties:
                           defaultMode:
-                            description:
-                              defaultMode are the mode bits used to set
-                              permissions on created files by default. Must be
-                              an octal value between 0000 and 0777 or a decimal
-                              value between 0 and 511. YAML accepts both octal
-                              and decimal values, JSON requires decimal values
-                              for mode bits. Directories within the path are not
-                              affected by this setting. This might be in
-                              conflict with other options that affect the file
-                              mode, like fsGroup, and the result can be other
-                              mode bits set.
+                            description: |-
+                              defaultMode are the mode bits used to set permissions on created files by default.
+                              Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                              Directories within the path are not affected by this setting.
+                              This might be in conflict with other options that affect the file
+                              mode, like fsGroup, and the result can be other mode bits set.
                             format: int32
                             type: integer
                           sources:
@@ -1203,20 +1120,14 @@ spec:
                                     data to project
                                   properties:
                                     items:
-                                      description:
-                                        items if unspecified, each key-value
-                                        pair in the Data field of the referenced
-                                        ConfigMap will be projected into the
-                                        volume as a file whose name is the key
-                                        and content is the value. If specified,
-                                        the listed keys will be projected into
-                                        the specified paths, and unlisted keys
-                                        will not be present. If a key is
-                                        specified which is not present in the
-                                        ConfigMap, the volume setup will error
-                                        unless it is marked optional. Paths must
-                                        be relative and may not contain the '..'
-                                        path or start with '..'.
+                                      description: |-
+                                        items if unspecified, each key-value pair in the Data field of the referenced
+                                        ConfigMap will be projected into the volume as a file whose name is the
+                                        key and content is the value. If specified, the listed keys will be
+                                        projected into the specified paths, and unlisted keys will not be
+                                        present. If a key is specified which is not present in the ConfigMap,
+                                        the volume setup will error unless it is marked optional. Paths must be
+                                        relative and may not contain the '..' path or start with '..'.
                                       items:
                                         description:
                                           Maps a string key to a path within a
@@ -1227,29 +1138,21 @@ spec:
                                               key is the key to project.
                                             type: string
                                           mode:
-                                            description:
-                                              'mode is Optional: mode bits used
-                                              to set permissions on this file.
-                                              Must be an octal value between
-                                              0000 and 0777 or a decimal value
-                                              between 0 and 511. YAML accepts
-                                              both octal and decimal values,
-                                              JSON requires decimal values for
-                                              mode bits. If not specified, the
-                                              volume defaultMode will be used.
-                                              This might be in conflict with
-                                              other options that affect the file
-                                              mode, like fsGroup, and the result
-                                              can be other mode bits set.'
+                                            description: |-
+                                              mode is Optional: mode bits used to set permissions on this file.
+                                              Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                              If not specified, the volume defaultMode will be used.
+                                              This might be in conflict with other options that affect the file
+                                              mode, like fsGroup, and the result can be other mode bits set.
                                             format: int32
                                             type: integer
                                           path:
-                                            description:
-                                              path is the relative path of the
-                                              file to map the key to. May not be
-                                              an absolute path. May not contain
-                                              the path element '..'. May not
-                                              start with the string '..'.
+                                            description: |-
+                                              path is the relative path of the file to map the key to.
+                                              May not be an absolute path.
+                                              May not contain the path element '..'.
+                                              May not start with the string '..'.
                                             type: string
                                         required:
                                           - key
@@ -1257,11 +1160,10 @@ spec:
                                         type: object
                                       type: array
                                     name:
-                                      description:
-                                        'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields.
-                                        apiVersion, kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                     optional:
                                       description:
@@ -1307,20 +1209,13 @@ spec:
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           mode:
-                                            description:
-                                              'Optional: mode bits used to set
-                                              permissions on this file, must be
-                                              an octal value between 0000 and
-                                              0777 or a decimal value between 0
-                                              and 511. YAML accepts both octal
-                                              and decimal values, JSON requires
-                                              decimal values for mode bits. If
-                                              not specified, the volume
-                                              defaultMode will be used. This
-                                              might be in conflict with other
-                                              options that affect the file mode,
-                                              like fsGroup, and the result can
-                                              be other mode bits set.'
+                                            description: |-
+                                              Optional: mode bits used to set permissions on this file, must be an octal value
+                                              between 0000 and 0777 or a decimal value between 0 and 511.
+                                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                              If not specified, the volume defaultMode will be used.
+                                              This might be in conflict with other options that affect the file
+                                              mode, like fsGroup, and the result can be other mode bits set.
                                             format: int32
                                             type: integer
                                           path:
@@ -1334,13 +1229,9 @@ spec:
                                               with '..'"
                                             type: string
                                           resourceFieldRef:
-                                            description:
-                                              'Selects a resource of the
-                                              container: only resources limits
-                                              and requests (limits.cpu,
-                                              limits.memory, requests.cpu and
-                                              requests.memory) are currently
-                                              supported.'
+                                            description: |-
+                                              Selects a resource of the container: only resources limits and requests
+                                              (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                             properties:
                                               containerName:
                                                 description:
@@ -1376,20 +1267,14 @@ spec:
                                     project
                                   properties:
                                     items:
-                                      description:
-                                        items if unspecified, each key-value
-                                        pair in the Data field of the referenced
-                                        Secret will be projected into the volume
-                                        as a file whose name is the key and
-                                        content is the value. If specified, the
-                                        listed keys will be projected into the
-                                        specified paths, and unlisted keys will
-                                        not be present. If a key is specified
-                                        which is not present in the Secret, the
-                                        volume setup will error unless it is
-                                        marked optional. Paths must be relative
-                                        and may not contain the '..' path or
-                                        start with '..'.
+                                      description: |-
+                                        items if unspecified, each key-value pair in the Data field of the referenced
+                                        Secret will be projected into the volume as a file whose name is the
+                                        key and content is the value. If specified, the listed keys will be
+                                        projected into the specified paths, and unlisted keys will not be
+                                        present. If a key is specified which is not present in the Secret,
+                                        the volume setup will error unless it is marked optional. Paths must be
+                                        relative and may not contain the '..' path or start with '..'.
                                       items:
                                         description:
                                           Maps a string key to a path within a
@@ -1400,29 +1285,21 @@ spec:
                                               key is the key to project.
                                             type: string
                                           mode:
-                                            description:
-                                              'mode is Optional: mode bits used
-                                              to set permissions on this file.
-                                              Must be an octal value between
-                                              0000 and 0777 or a decimal value
-                                              between 0 and 511. YAML accepts
-                                              both octal and decimal values,
-                                              JSON requires decimal values for
-                                              mode bits. If not specified, the
-                                              volume defaultMode will be used.
-                                              This might be in conflict with
-                                              other options that affect the file
-                                              mode, like fsGroup, and the result
-                                              can be other mode bits set.'
+                                            description: |-
+                                              mode is Optional: mode bits used to set permissions on this file.
+                                              Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                              If not specified, the volume defaultMode will be used.
+                                              This might be in conflict with other options that affect the file
+                                              mode, like fsGroup, and the result can be other mode bits set.
                                             format: int32
                                             type: integer
                                           path:
-                                            description:
-                                              path is the relative path of the
-                                              file to map the key to. May not be
-                                              an absolute path. May not contain
-                                              the path element '..'. May not
-                                              start with the string '..'.
+                                            description: |-
+                                              path is the relative path of the file to map the key to.
+                                              May not be an absolute path.
+                                              May not contain the path element '..'.
+                                              May not start with the string '..'.
                                             type: string
                                         required:
                                           - key
@@ -1430,11 +1307,10 @@ spec:
                                         type: object
                                       type: array
                                     name:
-                                      description:
-                                        'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields.
-                                        apiVersion, kind, uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                     optional:
                                       description:
@@ -1449,35 +1325,26 @@ spec:
                                     serviceAccountToken data to project
                                   properties:
                                     audience:
-                                      description:
-                                        audience is the intended audience of the
-                                        token. A recipient of a token must
-                                        identify itself with an identifier
-                                        specified in the audience of the token,
-                                        and otherwise should reject the token.
-                                        The audience defaults to the identifier
-                                        of the apiserver.
+                                      description: |-
+                                        audience is the intended audience of the token. A recipient of a token
+                                        must identify itself with an identifier specified in the audience of the
+                                        token, and otherwise should reject the token. The audience defaults to the
+                                        identifier of the apiserver.
                                       type: string
                                     expirationSeconds:
-                                      description:
-                                        expirationSeconds is the requested
-                                        duration of validity of the service
-                                        account token. As the token approaches
-                                        expiration, the kubelet volume plugin
-                                        will proactively rotate the service
-                                        account token. The kubelet will start
-                                        trying to rotate the token if the token
-                                        is older than 80 percent of its time to
-                                        live or if the token is older than 24
-                                        hours.Defaults to 1 hour and must be at
-                                        least 10 minutes.
+                                      description: |-
+                                        expirationSeconds is the requested duration of validity of the service
+                                        account token. As the token approaches expiration, the kubelet volume
+                                        plugin will proactively rotate the service account token. The kubelet will
+                                        start trying to rotate the token if the token is older than 80 percent of
+                                        its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                        and must be at least 10 minutes.
                                       format: int64
                                       type: integer
                                     path:
-                                      description:
-                                        path is the path relative to the mount
-                                        point of the file to project the token
-                                        into.
+                                      description: |-
+                                        path is the path relative to the mount point of the file to project the
+                                        token into.
                                       type: string
                                   required:
                                     - path
@@ -1486,38 +1353,30 @@ spec:
                             type: array
                         type: object
                       secret:
-                        description:
-                          'secret represents a secret that should populate this
-                          volume. More info:
-                          https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                        description: |-
+                          secret represents a secret that should populate this volume.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                         properties:
                           defaultMode:
-                            description:
-                              'defaultMode is Optional: mode bits used to set
-                              permissions on created files by default. Must be
-                              an octal value between 0000 and 0777 or a decimal
-                              value between 0 and 511. YAML accepts both octal
-                              and decimal values, JSON requires decimal values
-                              for mode bits. Defaults to 0644. Directories
-                              within the path are not affected by this setting.
-                              This might be in conflict with other options that
-                              affect the file mode, like fsGroup, and the result
-                              can be other mode bits set.'
+                            description: |-
+                              defaultMode is Optional: mode bits used to set permissions on created files by default.
+                              Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                              YAML accepts both octal and decimal values, JSON requires decimal values
+                              for mode bits. Defaults to 0644.
+                              Directories within the path are not affected by this setting.
+                              This might be in conflict with other options that affect the file
+                              mode, like fsGroup, and the result can be other mode bits set.
                             format: int32
                             type: integer
                           items:
-                            description:
-                              items If unspecified, each key-value pair in the
-                              Data field of the referenced Secret will be
-                              projected into the volume as a file whose name is
-                              the key and content is the value. If specified,
-                              the listed keys will be projected into the
-                              specified paths, and unlisted keys will not be
-                              present. If a key is specified which is not
-                              present in the Secret, the volume setup will error
-                              unless it is marked optional. Paths must be
-                              relative and may not contain the '..' path or
-                              start with '..'.
+                            description: |-
+                              items If unspecified, each key-value pair in the Data field of the referenced
+                              Secret will be projected into the volume as a file whose name is the
+                              key and content is the value. If specified, the listed keys will be
+                              projected into the specified paths, and unlisted keys will not be
+                              present. If a key is specified which is not present in the Secret,
+                              the volume setup will error unless it is marked optional. Paths must be
+                              relative and may not contain the '..' path or start with '..'.
                             items:
                               description:
                                 Maps a string key to a path within a volume.
@@ -1526,26 +1385,21 @@ spec:
                                   description: key is the key to project.
                                   type: string
                                 mode:
-                                  description:
-                                    'mode is Optional: mode bits used to set
-                                    permissions on this file. Must be an octal
-                                    value between 0000 and 0777 or a decimal
-                                    value between 0 and 511. YAML accepts both
-                                    octal and decimal values, JSON requires
-                                    decimal values for mode bits. If not
-                                    specified, the volume defaultMode will be
-                                    used. This might be in conflict with other
-                                    options that affect the file mode, like
-                                    fsGroup, and the result can be other mode
-                                    bits set.'
+                                  description: |-
+                                    mode is Optional: mode bits used to set permissions on this file.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                    If not specified, the volume defaultMode will be used.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 path:
-                                  description:
-                                    path is the relative path of the file to map
-                                    the key to. May not be an absolute path. May
-                                    not contain the path element '..'. May not
-                                    start with the string '..'.
+                                  description: |-
+                                    path is the relative path of the file to map the key to.
+                                    May not be an absolute path.
+                                    May not contain the path element '..'.
+                                    May not start with the string '..'.
                                   type: string
                               required:
                                 - key
@@ -1558,10 +1412,9 @@ spec:
                               keys must be defined
                             type: boolean
                           secretName:
-                            description:
-                              "secretName is the name of the secret in the pod's
-                              namespace to use. More info:
-                              https://kubernetes.io/docs/concepts/storage/volumes#secret"
+                            description: |-
+                              secretName is the name of the secret in the pod's namespace to use.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                             type: string
                         type: object
                     required:
@@ -1585,30 +1438,26 @@ spec:
                 annotations:
                   additionalProperties:
                     type: string
-                  description:
-                    Annotations is additional Status fields for the Resource to
-                    save some additional State as well as convey more
-                    information to the user. This is roughly akin to Annotations
-                    on any k8s resource, just the reconciler conveying richer
-                    information outwards.
+                  description: |-
+                    Annotations is additional Status fields for the Resource to save some
+                    additional State as well as convey more information to the user. This is
+                    roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                    richer information outwards.
                   type: object
                 conditions:
                   description:
                     Conditions the latest available observations of a resource's
                     current state.
                   items:
-                    description:
-                      'Condition defines a readiness condition for a Knative
-                      resource. See:
-                      https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                    description: |-
+                      Condition defines a readiness condition for a Knative resource.
+                      See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
                     properties:
                       lastTransitionTime:
-                        description:
-                          LastTransitionTime is the last time the condition
-                          transitioned from one status to another. We use
-                          VolatileTime in place of metav1.Time to exclude this
-                          from creating equality.Semantic differences (all other
-                          things held constant).
+                        description: |-
+                          LastTransitionTime is the last time the condition transitioned from one status to another.
+                          We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                          differences (all other things held constant).
                         type: string
                       message:
                         description:
@@ -1620,10 +1469,9 @@ spec:
                           The reason for the condition's last transition.
                         type: string
                       severity:
-                        description:
-                          Severity with which to treat failures of this type of
-                          condition. When this is not specified, it defaults to
-                          Error.
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
                         type: string
                       status:
                         description:
@@ -1638,13 +1486,13 @@ spec:
                     type: object
                   type: array
                 containerStatuses:
-                  description:
-                    'ContainerStatuses is a slice of images present in
-                    .Spec.Container[*].Image to their respective digests and
-                    their container name. The digests are resolved during the
-                    creation of Revision. ContainerStatuses holds the container
-                    name and image digests for both serving and non serving
-                    containers. ref: http://bit.ly/image-digests'
+                  description: |-
+                    ContainerStatuses is a slice of images present in .Spec.Container[*].Image
+                    to their respective digests and their container name.
+                    The digests are resolved during the creation of Revision.
+                    ContainerStatuses holds the container name and image digests
+                    for both serving and non serving containers.
+                    ref: http://bit.ly/image-digests
                   items:
                     description:
                       ContainerStatus holds the information of container name
@@ -1663,13 +1511,13 @@ spec:
                   format: int32
                   type: integer
                 initContainerStatuses:
-                  description:
-                    'InitContainerStatuses is a slice of images present in
-                    .Spec.InitContainer[*].Image to their respective digests and
-                    their container name. The digests are resolved during the
-                    creation of Revision. ContainerStatuses holds the container
-                    name and image digests for both serving and non serving
-                    containers. ref: http://bit.ly/image-digests'
+                  description: |-
+                    InitContainerStatuses is a slice of images present in .Spec.InitContainer[*].Image
+                    to their respective digests and their container name.
+                    The digests are resolved during the creation of Revision.
+                    ContainerStatuses holds the container name and image digests
+                    for both serving and non serving containers.
+                    ref: http://bit.ly/image-digests
                   items:
                     description:
                       ContainerStatus holds the information of container name
@@ -1682,13 +1530,12 @@ spec:
                     type: object
                   type: array
                 logUrl:
-                  description:
-                    LogURL specifies the generated logging url for this
-                    particular revision based on the revision url template
-                    specified in the controller's config.
+                  description: |-
+                    LogURL specifies the generated logging url for this particular revision
+                    based on the revision url template specified in the controller's config.
                   type: string
                 observedGeneration:
-                  description:
+                  description: |-
                     ObservedGeneration is the 'Generation' of the Service that
                     was last processed by the controller.
                   format: int64

--- a/platform_umbrella/apps/common_core/priv/manifests/knative-serving/routes_serving_knative_dev.yaml
+++ b/platform_umbrella/apps/common_core/priv/manifests/knative-serving/routes_serving_knative_dev.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: 1.12.3
+    app.kubernetes.io/version: 1.14.1
     duck.knative.dev/addressable: 'true'
     knative.dev/crd-install: 'true'
   name: routes.serving.knative.dev
@@ -26,39 +26,37 @@ spec:
         - jsonPath: .status.url
           name: URL
           type: string
-        - jsonPath: .status.conditions[?(@.type=='Ready')].status
+        - jsonPath: ".status.conditions[?(@.type=='Ready')].status"
           name: Ready
           type: string
-        - jsonPath: .status.conditions[?(@.type=='Ready')].reason
+        - jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
           name: Reason
           type: string
       name: v1
       schema:
         openAPIV3Schema:
-          description:
-            'Route is responsible for configuring ingress over a collection of
-            Revisions. Some of the Revisions a Route distributes traffic over
-            may be specified by referencing the Configuration responsible for
-            creating them; in these cases the Route is additionally responsible
-            for monitoring the Configuration for "latest ready revision"
-            changes, and smoothly rolling out latest revisions. See also:
-            https://github.com/knative/serving/blob/main/docs/spec/overview.md#route'
+          description: |-
+            Route is responsible for configuring ingress over a collection of Revisions.
+            Some of the Revisions a Route distributes traffic over may be specified by
+            referencing the Configuration responsible for creating them; in these cases
+            the Route is additionally responsible for monitoring the Configuration for
+            "latest ready revision" changes, and smoothly rolling out latest revisions.
+            See also: https://github.com/knative/serving/blob/main/docs/spec/overview.md#route
           properties:
             apiVersion:
-              description:
-                'APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the
-                latest internal value, and may reject unrecognized values. More
-                info:
-                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description:
-                'Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the
-                client submits requests to. Cannot be updated. In CamelCase.
-                More info:
-                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -67,64 +65,57 @@ spec:
                 Spec holds the desired state of the Route (from the client).
               properties:
                 traffic:
-                  description:
-                    Traffic specifies how to distribute traffic over a
-                    collection of revisions and configurations.
+                  description: |-
+                    Traffic specifies how to distribute traffic over a collection of
+                    revisions and configurations.
                   items:
                     description:
                       TrafficTarget holds a single entry of the routing table
                       for a Route.
                     properties:
                       configurationName:
-                        description:
-                          ConfigurationName of a configuration to whose latest
-                          revision we will send this portion of traffic. When
-                          the "status.latestReadyRevisionName" of the referenced
-                          configuration changes, we will automatically migrate
-                          traffic from the prior "latest ready" revision to the
-                          new one.  This field is never set in Route's status,
-                          only its spec.  This is mutually exclusive with
+                        description: |-
+                          ConfigurationName of a configuration to whose latest revision we will send
+                          this portion of traffic. When the "status.latestReadyRevisionName" of the
+                          referenced configuration changes, we will automatically migrate traffic
+                          from the prior "latest ready" revision to the new one.  This field is never
+                          set in Route's status, only its spec.  This is mutually exclusive with
                           RevisionName.
                         type: string
                       latestRevision:
-                        description:
-                          LatestRevision may be optionally provided to indicate
-                          that the latest ready Revision of the Configuration
-                          should be used for this traffic target.  When provided
-                          LatestRevision must be true if RevisionName is empty;
-                          it must be false when RevisionName is non-empty.
+                        description: |-
+                          LatestRevision may be optionally provided to indicate that the latest
+                          ready Revision of the Configuration should be used for this traffic
+                          target.  When provided LatestRevision must be true if RevisionName is
+                          empty; it must be false when RevisionName is non-empty.
                         type: boolean
                       percent:
-                        description:
-                          'Percent indicates that percentage based routing
-                          should be used and the value indicates the percent of
-                          traffic that is be routed to this Revision or
-                          Configuration. `0` (zero) mean no traffic, `100` means
-                          all traffic. When percentage based routing is being
-                          used the follow rules apply: - the sum of all percent
-                          values must equal 100 - when not specified, the
-                          implied value for `percent` is zero for that
-                          particular Revision or Configuration'
+                        description: |-
+                          Percent indicates that percentage based routing should be used and
+                          the value indicates the percent of traffic that is be routed to this
+                          Revision or Configuration. `0` (zero) mean no traffic, `100` means all
+                          traffic.
+                          When percentage based routing is being used the follow rules apply:
+                          - the sum of all percent values must equal 100
+                          - when not specified, the implied value for `percent` is zero for
+                            that particular Revision or Configuration
                         format: int64
                         type: integer
                       revisionName:
-                        description:
-                          RevisionName of a specific revision to which to send
-                          this portion of traffic.  This is mutually exclusive
-                          with ConfigurationName.
+                        description: |-
+                          RevisionName of a specific revision to which to send this portion of
+                          traffic.  This is mutually exclusive with ConfigurationName.
                         type: string
                       tag:
-                        description:
-                          Tag is optionally used to expose a dedicated url for
-                          referencing this target exclusively.
+                        description: |-
+                          Tag is optionally used to expose a dedicated url for referencing
+                          this target exclusively.
                         type: string
                       url:
-                        description:
-                          URL displays the URL for accessing named traffic
-                          targets. URL is displayed in status, and is disallowed
-                          on spec. URL must contain a scheme (e.g. http://) and
-                          a hostname, but may not contain anything else (e.g.
-                          basic auth, url path, etc.)
+                        description: |-
+                          URL displays the URL for accessing named traffic targets. URL is displayed in
+                          status, and is disallowed on spec. URL must contain a scheme (e.g. http://) and
+                          a hostname, but may not contain anything else (e.g. basic auth, url path, etc.)
                         type: string
                     type: object
                   type: array
@@ -140,10 +131,9 @@ spec:
                     target of an event.
                   properties:
                     CACerts:
-                      description:
-                        CACerts is the Certification Authority (CA) certificates
-                        in PEM format according to
-                        https://www.rfc-editor.org/rfc/rfc7468.
+                      description: |-
+                        CACerts is the Certification Authority (CA) certificates in PEM format
+                        according to https://www.rfc-editor.org/rfc/rfc7468.
                       type: string
                     audience:
                       description:
@@ -158,30 +148,26 @@ spec:
                 annotations:
                   additionalProperties:
                     type: string
-                  description:
-                    Annotations is additional Status fields for the Resource to
-                    save some additional State as well as convey more
-                    information to the user. This is roughly akin to Annotations
-                    on any k8s resource, just the reconciler conveying richer
-                    information outwards.
+                  description: |-
+                    Annotations is additional Status fields for the Resource to save some
+                    additional State as well as convey more information to the user. This is
+                    roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                    richer information outwards.
                   type: object
                 conditions:
                   description:
                     Conditions the latest available observations of a resource's
                     current state.
                   items:
-                    description:
-                      'Condition defines a readiness condition for a Knative
-                      resource. See:
-                      https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                    description: |-
+                      Condition defines a readiness condition for a Knative resource.
+                      See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
                     properties:
                       lastTransitionTime:
-                        description:
-                          LastTransitionTime is the last time the condition
-                          transitioned from one status to another. We use
-                          VolatileTime in place of metav1.Time to exclude this
-                          from creating equality.Semantic differences (all other
-                          things held constant).
+                        description: |-
+                          LastTransitionTime is the last time the condition transitioned from one status to another.
+                          We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                          differences (all other things held constant).
                         type: string
                       message:
                         description:
@@ -193,10 +179,9 @@ spec:
                           The reason for the condition's last transition.
                         type: string
                       severity:
-                        description:
-                          Severity with which to treat failures of this type of
-                          condition. When this is not specified, it defaults to
-                          Error.
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
                         type: string
                       status:
                         description:
@@ -211,16 +196,16 @@ spec:
                     type: object
                   type: array
                 observedGeneration:
-                  description:
+                  description: |-
                     ObservedGeneration is the 'Generation' of the Service that
                     was last processed by the controller.
                   format: int64
                   type: integer
                 traffic:
-                  description:
-                    Traffic holds the configured traffic distribution. These
-                    entries will always contain RevisionName references. When
-                    ConfigurationName appears in the spec, this will hold the
+                  description: |-
+                    Traffic holds the configured traffic distribution.
+                    These entries will always contain RevisionName references.
+                    When ConfigurationName appears in the spec, this will hold the
                     LatestReadyRevisionName that we last observed.
                   items:
                     description:
@@ -228,63 +213,55 @@ spec:
                       for a Route.
                     properties:
                       configurationName:
-                        description:
-                          ConfigurationName of a configuration to whose latest
-                          revision we will send this portion of traffic. When
-                          the "status.latestReadyRevisionName" of the referenced
-                          configuration changes, we will automatically migrate
-                          traffic from the prior "latest ready" revision to the
-                          new one.  This field is never set in Route's status,
-                          only its spec.  This is mutually exclusive with
+                        description: |-
+                          ConfigurationName of a configuration to whose latest revision we will send
+                          this portion of traffic. When the "status.latestReadyRevisionName" of the
+                          referenced configuration changes, we will automatically migrate traffic
+                          from the prior "latest ready" revision to the new one.  This field is never
+                          set in Route's status, only its spec.  This is mutually exclusive with
                           RevisionName.
                         type: string
                       latestRevision:
-                        description:
-                          LatestRevision may be optionally provided to indicate
-                          that the latest ready Revision of the Configuration
-                          should be used for this traffic target.  When provided
-                          LatestRevision must be true if RevisionName is empty;
-                          it must be false when RevisionName is non-empty.
+                        description: |-
+                          LatestRevision may be optionally provided to indicate that the latest
+                          ready Revision of the Configuration should be used for this traffic
+                          target.  When provided LatestRevision must be true if RevisionName is
+                          empty; it must be false when RevisionName is non-empty.
                         type: boolean
                       percent:
-                        description:
-                          'Percent indicates that percentage based routing
-                          should be used and the value indicates the percent of
-                          traffic that is be routed to this Revision or
-                          Configuration. `0` (zero) mean no traffic, `100` means
-                          all traffic. When percentage based routing is being
-                          used the follow rules apply: - the sum of all percent
-                          values must equal 100 - when not specified, the
-                          implied value for `percent` is zero for that
-                          particular Revision or Configuration'
+                        description: |-
+                          Percent indicates that percentage based routing should be used and
+                          the value indicates the percent of traffic that is be routed to this
+                          Revision or Configuration. `0` (zero) mean no traffic, `100` means all
+                          traffic.
+                          When percentage based routing is being used the follow rules apply:
+                          - the sum of all percent values must equal 100
+                          - when not specified, the implied value for `percent` is zero for
+                            that particular Revision or Configuration
                         format: int64
                         type: integer
                       revisionName:
-                        description:
-                          RevisionName of a specific revision to which to send
-                          this portion of traffic.  This is mutually exclusive
-                          with ConfigurationName.
+                        description: |-
+                          RevisionName of a specific revision to which to send this portion of
+                          traffic.  This is mutually exclusive with ConfigurationName.
                         type: string
                       tag:
-                        description:
-                          Tag is optionally used to expose a dedicated url for
-                          referencing this target exclusively.
+                        description: |-
+                          Tag is optionally used to expose a dedicated url for referencing
+                          this target exclusively.
                         type: string
                       url:
-                        description:
-                          URL displays the URL for accessing named traffic
-                          targets. URL is displayed in status, and is disallowed
-                          on spec. URL must contain a scheme (e.g. http://) and
-                          a hostname, but may not contain anything else (e.g.
-                          basic auth, url path, etc.)
+                        description: |-
+                          URL displays the URL for accessing named traffic targets. URL is displayed in
+                          status, and is disallowed on spec. URL must contain a scheme (e.g. http://) and
+                          a hostname, but may not contain anything else (e.g. basic auth, url path, etc.)
                         type: string
                     type: object
                   type: array
                 url:
-                  description:
-                    URL holds the url that will distribute traffic over the
-                    provided traffic targets. It generally has the form
-                    http[s]://{route-name}.{route-namespace}.{cluster-level-suffix}
+                  description: |-
+                    URL holds the url that will distribute traffic over the provided traffic targets.
+                    It generally has the form http[s]://{route-name}.{route-namespace}.{cluster-level-suffix}
                   type: string
               type: object
           type: object

--- a/platform_umbrella/apps/common_core/priv/manifests/knative-serving/serverlessservices_networking_internal_knative_dev.yaml
+++ b/platform_umbrella/apps/common_core/priv/manifests/knative-serving/serverlessservices_networking_internal_knative_dev.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/component: networking
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: 1.12.3
+    app.kubernetes.io/version: 1.14.1
     knative.dev/crd-install: 'true'
   name: serverlessservices.networking.internal.knative.dev
 spec:
@@ -34,43 +34,42 @@ spec:
         - jsonPath: .status.privateServiceName
           name: PrivateServiceName
           type: string
-        - jsonPath: .status.conditions[?(@.type=='Ready')].status
+        - jsonPath: ".status.conditions[?(@.type=='Ready')].status"
           name: Ready
           type: string
-        - jsonPath: .status.conditions[?(@.type=='Ready')].reason
+        - jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
           name: Reason
           type: string
       name: v1alpha1
       schema:
         openAPIV3Schema:
-          description:
-            'ServerlessService is a proxy for the K8s service objects containing
-            the endpoints for the revision, whether those are endpoints of the
-            activator or revision pods. See: https://knative.page.link/naxz for
-            details.'
+          description: |-
+            ServerlessService is a proxy for the K8s service objects containing the
+            endpoints for the revision, whether those are endpoints of the activator or
+            revision pods.
+            See: https://knative.page.link/naxz for details.
           properties:
             apiVersion:
-              description:
-                'APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the
-                latest internal value, and may reject unrecognized values. More
-                info:
-                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description:
-                'Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the
-                client submits requests to. Cannot be updated. In CamelCase.
-                More info:
-                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
             spec:
-              description:
-                'Spec is the desired state of the ServerlessService. More info:
-                https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+              description: |-
+                Spec is the desired state of the ServerlessService.
+                More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
               properties:
                 mode:
                   description:
@@ -78,13 +77,14 @@ spec:
                     ServerlessService.
                   type: string
                 numActivators:
-                  description:
-                    NumActivators contains number of Activators that this
-                    revision should be assigned. O means — assign all.
+                  description: |-
+                    NumActivators contains number of Activators that this revision should be
+                    assigned.
+                    O means — assign all.
                   format: int32
                   type: integer
                 objectRef:
-                  description:
+                  description: |-
                     ObjectRef defines the resource that this ServerlessService
                     is responsible for making "serverless".
                   properties:
@@ -92,53 +92,46 @@ spec:
                       description: API version of the referent.
                       type: string
                     fieldPath:
-                      description:
-                        'If referring to a piece of an object instead of an
-                        entire object, this string should contain a valid
-                        JSON/Go field access statement, such as
-                        desiredState.manifest.containers[2]. For example, if the
-                        object reference is to a container within a pod, this
-                        would take on a value like: "spec.containers{name}"
-                        (where "name" refers to the name of the container that
-                        triggered the event) or if no container name is
-                        specified "spec.containers[2]" (container with index 2
-                        in this pod). This syntax is chosen only to have some
-                        well-defined way of referencing a part of an object.
-                        TODO: this design is not final and this field is subject
-                        to change in the future.'
+                      description: |-
+                        If referring to a piece of an object instead of an entire object, this string
+                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]" (container with
+                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                        referencing a part of an object.
+                        TODO: this design is not final and this field is subject to change in the future.
                       type: string
                     kind:
-                      description:
-                        'Kind of the referent. More info:
-                        https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      description: |-
+                        Kind of the referent.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                       type: string
                     name:
-                      description:
-                        'Name of the referent. More info:
-                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                       type: string
                     namespace:
-                      description:
-                        'Namespace of the referent. More info:
-                        https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      description: |-
+                        Namespace of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
                       type: string
                     resourceVersion:
-                      description:
-                        'Specific resourceVersion to which this reference is
-                        made, if any. More info:
-                        https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      description: |-
+                        Specific resourceVersion to which this reference is made, if any.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
                       type: string
                     uid:
-                      description:
-                        'UID of the referent. More info:
-                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      description: |-
+                        UID of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic
                 protocolType:
-                  description:
-                    The application-layer protocol. Matches
-                    `RevisionProtocolType` set on the owning pa/revision.
+                  description: |-
+                    The application-layer protocol. Matches `RevisionProtocolType` set on the owning pa/revision.
                     serving imports networking, so just use string.
                   type: string
               required:
@@ -146,38 +139,33 @@ spec:
                 - protocolType
               type: object
             status:
-              description:
-                'Status is the current state of the ServerlessService. More
-                info:
-                https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+              description: |-
+                Status is the current state of the ServerlessService.
+                More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
               properties:
                 annotations:
                   additionalProperties:
                     type: string
-                  description:
-                    Annotations is additional Status fields for the Resource to
-                    save some additional State as well as convey more
-                    information to the user. This is roughly akin to Annotations
-                    on any k8s resource, just the reconciler conveying richer
-                    information outwards.
+                  description: |-
+                    Annotations is additional Status fields for the Resource to save some
+                    additional State as well as convey more information to the user. This is
+                    roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                    richer information outwards.
                   type: object
                 conditions:
                   description:
                     Conditions the latest available observations of a resource's
                     current state.
                   items:
-                    description:
-                      'Condition defines a readiness condition for a Knative
-                      resource. See:
-                      https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                    description: |-
+                      Condition defines a readiness condition for a Knative resource.
+                      See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
                     properties:
                       lastTransitionTime:
-                        description:
-                          LastTransitionTime is the last time the condition
-                          transitioned from one status to another. We use
-                          VolatileTime in place of metav1.Time to exclude this
-                          from creating equality.Semantic differences (all other
-                          things held constant).
+                        description: |-
+                          LastTransitionTime is the last time the condition transitioned from one status to another.
+                          We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                          differences (all other things held constant).
                         type: string
                       message:
                         description:
@@ -189,10 +177,9 @@ spec:
                           The reason for the condition's last transition.
                         type: string
                       severity:
-                        description:
-                          Severity with which to treat failures of this type of
-                          condition. When this is not specified, it defaults to
-                          Error.
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
                         type: string
                       status:
                         description:
@@ -207,22 +194,20 @@ spec:
                     type: object
                   type: array
                 observedGeneration:
-                  description:
+                  description: |-
                     ObservedGeneration is the 'Generation' of the Service that
                     was last processed by the controller.
                   format: int64
                   type: integer
                 privateServiceName:
-                  description:
-                    PrivateServiceName holds the name of a core K8s Service
-                    resource that load balances over the user service pods
-                    backing this Revision.
+                  description: |-
+                    PrivateServiceName holds the name of a core K8s Service resource that
+                    load balances over the user service pods backing this Revision.
                   type: string
                 serviceName:
-                  description:
-                    ServiceName holds the name of a core K8s Service resource
-                    that load balances over the pods backing this Revision
-                    (activator or revision).
+                  description: |-
+                    ServiceName holds the name of a core K8s Service resource that
+                    load balances over the pods backing this Revision (activator or revision).
                   type: string
               type: object
           type: object

--- a/platform_umbrella/apps/common_core/priv/manifests/knative-serving/services_serving_knative_dev.yaml
+++ b/platform_umbrella/apps/common_core/priv/manifests/knative-serving/services_serving_knative_dev.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: 1.12.3
+    app.kubernetes.io/version: 1.14.1
     duck.knative.dev/addressable: 'true'
     duck.knative.dev/podspecable: 'true'
     knative.dev/crd-install: 'true'
@@ -34,47 +34,57 @@ spec:
         - jsonPath: .status.latestReadyRevisionName
           name: LatestReady
           type: string
-        - jsonPath: .status.conditions[?(@.type=='Ready')].status
+        - jsonPath: ".status.conditions[?(@.type=='Ready')].status"
           name: Ready
           type: string
-        - jsonPath: .status.conditions[?(@.type=='Ready')].reason
+        - jsonPath: ".status.conditions[?(@.type=='Ready')].reason"
           name: Reason
           type: string
       name: v1
       schema:
         openAPIV3Schema:
           description: |-
-            Service acts as a top-level container that manages a Route and Configuration which implement a network service. Service exists to provide a singular abstraction which can be access controlled, reasoned about, and which encapsulates software lifecycle decisions such as rollout policy and team resource ownership. Service acts only as an orchestrator of the underlying Routes and Configurations (much as a kubernetes Deployment orchestrates ReplicaSets), and its usage is optional but recommended. 
-             The Service's controller will track the statuses of its owned Configuration and Route, reflecting their statuses and conditions as its own. 
-             See also: https://github.com/knative/serving/blob/main/docs/spec/overview.md#service
+            Service acts as a top-level container that manages a Route and Configuration
+            which implement a network service. Service exists to provide a singular
+            abstraction which can be access controlled, reasoned about, and which
+            encapsulates software lifecycle decisions such as rollout policy and
+            team resource ownership. Service acts only as an orchestrator of the
+            underlying Routes and Configurations (much as a kubernetes Deployment
+            orchestrates ReplicaSets), and its usage is optional but recommended.
+
+
+            The Service's controller will track the statuses of its owned Configuration
+            and Route, reflecting their statuses and conditions as its own.
+
+
+            See also: https://github.com/knative/serving/blob/main/docs/spec/overview.md#service
           properties:
             apiVersion:
-              description:
-                'APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the
-                latest internal value, and may reject unrecognized values. More
-                info:
-                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description:
-                'Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the
-                client submits requests to. Cannot be updated. In CamelCase.
-                More info:
-                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
             spec:
-              description:
+              description: |-
                 ServiceSpec represents the configuration for the Service object.
-                A Service's specification is the union of the specifications for
-                a Route and Configuration.  The Service restricts what can be
-                expressed in these fields, e.g. the Route must reference the
-                provided Configuration; however, these limitations also enable
-                friendlier defaulting, e.g. Route never needs a Configuration
-                name, and may be defaulted to the appropriate "run latest" spec.
+                A Service's specification is the union of the specifications for a Route
+                and Configuration.  The Service restricts what can be expressed in these
+                fields, e.g. the Route must reference the provided Configuration;
+                however, these limitations also enable friendlier defaulting,
+                e.g. Route never needs a Configuration name, and may be defaulted to
+                the appropriate "run latest" spec.
               properties:
                 template:
                   description:
@@ -119,66 +129,54 @@ spec:
                             mounted.
                           type: boolean
                         containerConcurrency:
-                          description:
-                            ContainerConcurrency specifies the maximum allowed
-                            in-flight (concurrent) requests per container of the
-                            Revision.  Defaults to `0` which means concurrency
-                            to the application is not limited, and the system
-                            decides the target concurrency for the autoscaler.
+                          description: |-
+                            ContainerConcurrency specifies the maximum allowed in-flight (concurrent)
+                            requests per container of the Revision.  Defaults to `0` which means
+                            concurrency to the application is not limited, and the system decides the
+                            target concurrency for the autoscaler.
                           format: int64
                           type: integer
                         containers:
-                          description:
-                            List of containers belonging to the pod. Containers
-                            cannot currently be added or removed. There must be
-                            at least one container in a Pod. Cannot be updated.
+                          description: |-
+                            List of containers belonging to the pod.
+                            Containers cannot currently be added or removed.
+                            There must be at least one container in a Pod.
+                            Cannot be updated.
                           items:
                             description:
                               A single application container that you want to
                               run within a pod.
                             properties:
                               args:
-                                description:
-                                  'Arguments to the entrypoint. The container
-                                  image''s CMD is used if this is not provided.
-                                  Variable references $(VAR_NAME) are expanded
-                                  using the container''s environment. If a
-                                  variable cannot be resolved, the reference in
-                                  the input string will be unchanged. Double $$
-                                  are reduced to a single $, which allows for
-                                  escaping the $(VAR_NAME) syntax: i.e.
-                                  "$$(VAR_NAME)" will produce the string literal
-                                  "$(VAR_NAME)". Escaped references will never
-                                  be expanded, regardless of whether the
-                                  variable exists or not. Cannot be updated.
-                                  More info:
-                                  https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                description: |-
+                                  Arguments to the entrypoint.
+                                  The container image's CMD is used if this is not provided.
+                                  Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                  cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                  to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                  produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                  of whether the variable exists or not. Cannot be updated.
+                                  More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                 items:
                                   type: string
                                 type: array
                               command:
-                                description:
-                                  'Entrypoint array. Not executed within a
-                                  shell. The container image''s ENTRYPOINT is
-                                  used if this is not provided. Variable
-                                  references $(VAR_NAME) are expanded using the
-                                  container''s environment. If a variable cannot
-                                  be resolved, the reference in the input string
-                                  will be unchanged. Double $$ are reduced to a
-                                  single $, which allows for escaping the
-                                  $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                                  produce the string literal "$(VAR_NAME)".
-                                  Escaped references will never be expanded,
-                                  regardless of whether the variable exists or
-                                  not. Cannot be updated. More info:
-                                  https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                                description: |-
+                                  Entrypoint array. Not executed within a shell.
+                                  The container image's ENTRYPOINT is used if this is not provided.
+                                  Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                  cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                  to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                  produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                  of whether the variable exists or not. Cannot be updated.
+                                  More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                                 items:
                                   type: string
                                 type: array
                               env:
-                                description:
-                                  List of environment variables to set in the
-                                  container. Cannot be updated.
+                                description: |-
+                                  List of environment variables to set in the container.
+                                  Cannot be updated.
                                 items:
                                   description:
                                     EnvVar represents an environment variable
@@ -190,21 +188,16 @@ spec:
                                         be a C_IDENTIFIER.
                                       type: string
                                     value:
-                                      description:
-                                        'Variable references $(VAR_NAME) are
-                                        expanded using the previously defined
-                                        environment variables in the container
-                                        and any service environment variables.
-                                        If a variable cannot be resolved, the
-                                        reference in the input string will be
-                                        unchanged. Double $$ are reduced to a
-                                        single $, which allows for escaping the
-                                        $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                        will produce the string literal
-                                        "$(VAR_NAME)". Escaped references will
-                                        never be expanded, regardless of whether
-                                        the variable exists or not. Defaults to
-                                        "".'
+                                      description: |-
+                                        Variable references $(VAR_NAME) are expanded
+                                        using the previously defined environment variables in the container and
+                                        any service environment variables. If a variable cannot be resolved,
+                                        the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                        Escaped references will never be expanded, regardless of whether the variable
+                                        exists or not.
+                                        Defaults to "".
                                       type: string
                                     valueFrom:
                                       description:
@@ -220,12 +213,10 @@ spec:
                                               description: The key to select.
                                               type: string
                                             name:
-                                              description:
-                                                'Name of the referent. More
-                                                info:
-                                                https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields.
-                                                apiVersion, kind, uid?'
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description:
@@ -262,12 +253,10 @@ spec:
                                                 key.
                                               type: string
                                             name:
-                                              description:
-                                                'Name of the referent. More
-                                                info:
-                                                https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields.
-                                                apiVersion, kind, uid?'
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description:
@@ -284,16 +273,13 @@ spec:
                                   type: object
                                 type: array
                               envFrom:
-                                description:
-                                  List of sources to populate environment
-                                  variables in the container. The keys defined
-                                  within a source must be a C_IDENTIFIER. All
-                                  invalid keys will be reported as an event when
-                                  the container is starting. When a key exists
-                                  in multiple sources, the value associated with
-                                  the last source will take precedence. Values
-                                  defined by an Env with a duplicate key will
-                                  take precedence. Cannot be updated.
+                                description: |-
+                                  List of sources to populate environment variables in the container.
+                                  The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                  will be reported as an event when the container is starting. When a key exists in multiple
+                                  sources, the value associated with the last source will take precedence.
+                                  Values defined by an Env with a duplicate key will take precedence.
+                                  Cannot be updated.
                                 items:
                                   description:
                                     EnvFromSource represents the source of a set
@@ -303,11 +289,10 @@ spec:
                                       description: The ConfigMap to select from
                                       properties:
                                         name:
-                                          description:
-                                            'Name of the referent. More info:
-                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields.
-                                            apiVersion, kind, uid?'
+                                          description: |-
+                                            Name of the referent.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                           type: string
                                         optional:
                                           description:
@@ -326,11 +311,10 @@ spec:
                                       description: The Secret to select from
                                       properties:
                                         name:
-                                          description:
-                                            'Name of the referent. More info:
-                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields.
-                                            apiVersion, kind, uid?'
+                                          description: |-
+                                            Name of the referent.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                           type: string
                                         optional:
                                           description:
@@ -342,57 +326,46 @@ spec:
                                   type: object
                                 type: array
                               image:
-                                description:
-                                  'Container image name. More info:
-                                  https://kubernetes.io/docs/concepts/containers/images
-                                  This field is optional to allow higher level
-                                  config management to default or override
-                                  container images in workload controllers like
-                                  Deployments and StatefulSets.'
+                                description: |-
+                                  Container image name.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images
+                                  This field is optional to allow higher level config management to default or override
+                                  container images in workload controllers like Deployments and StatefulSets.
                                 type: string
                               imagePullPolicy:
-                                description:
-                                  'Image pull policy. One of Always, Never,
-                                  IfNotPresent. Defaults to Always if :latest
-                                  tag is specified, or IfNotPresent otherwise.
-                                  Cannot be updated. More info:
-                                  https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                                description: |-
+                                  Image pull policy.
+                                  One of Always, Never, IfNotPresent.
+                                  Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                                 type: string
                               livenessProbe:
-                                description:
-                                  'Periodic probe of container liveness.
-                                  Container will be restarted if the probe
-                                  fails. Cannot be updated. More info:
-                                  https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                description: |-
+                                  Periodic probe of container liveness.
+                                  Container will be restarted if the probe fails.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                 properties:
                                   exec:
                                     description:
                                       Exec specifies the action to take.
                                     properties:
                                       command:
-                                        description:
-                                          Command is the command line to execute
-                                          inside the container, the working
-                                          directory for the command  is root
-                                          ('/') in the container's filesystem.
-                                          The command is simply exec'd, it is
-                                          not run inside a shell, so traditional
-                                          shell instructions ('|', etc) won't
-                                          work. To use a shell, you need to
-                                          explicitly call out to that shell.
-                                          Exit status of 0 is treated as
-                                          live/healthy and non-zero is
-                                          unhealthy.
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                         items:
                                           type: string
                                         type: array
                                     type: object
                                   failureThreshold:
-                                    description:
-                                      Minimum consecutive failures for the probe
-                                      to be considered failed after having
-                                      succeeded. Defaults to 3. Minimum value is
-                                      1.
+                                    description: |-
+                                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
                                     format: int32
                                     type: integer
                                   grpc:
@@ -409,8 +382,11 @@ spec:
                                         type: integer
                                       service:
                                         description: |-
-                                          Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). 
-                                           If this is not specified, the default behavior is defined by gRPC.
+                                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                          If this is not specified, the default behavior is defined by gRPC.
                                         type: string
                                     required:
                                       - port
@@ -421,9 +397,8 @@ spec:
                                       perform.
                                     properties:
                                       host:
-                                        description:
-                                          Host name to connect to, defaults to
-                                          the pod IP. You probably want to set
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
                                           "Host" in httpHeaders instead.
                                         type: string
                                       httpHeaders:
@@ -436,11 +411,9 @@ spec:
                                             to be used in HTTP probes
                                           properties:
                                             name:
-                                              description:
-                                                The header field name. This will
-                                                be canonicalized upon output, so
-                                                case-variant names will be
-                                                understood as the same header.
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                               type: string
                                             value:
                                               description:
@@ -459,24 +432,21 @@ spec:
                                         anyOf:
                                           - type: integer
                                           - type: string
-                                        description:
-                                          Name or number of the port to access
-                                          on the container. Number must be in
-                                          the range 1 to 65535. Name must be an
-                                          IANA_SVC_NAME.
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
                                         x-kubernetes-int-or-string: true
                                       scheme:
-                                        description:
-                                          Scheme to use for connecting to the
-                                          host. Defaults to HTTP.
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
                                         type: string
                                     type: object
                                   initialDelaySeconds:
-                                    description:
-                                      'Number of seconds after the container has
-                                      started before liveness probes are
-                                      initiated. More info:
-                                      https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: |-
+                                      Number of seconds after the container has started before liveness probes are initiated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     format: int32
                                     type: integer
                                   periodSeconds:
@@ -486,12 +456,9 @@ spec:
                                     format: int32
                                     type: integer
                                   successThreshold:
-                                    description:
-                                      Minimum consecutive successes for the
-                                      probe to be considered successful after
-                                      having failed. Defaults to 1. Must be 1
-                                      for liveness and startup. Minimum value is
-                                      1.
+                                    description: |-
+                                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                     format: int32
                                     type: integer
                                   tcpSocket:
@@ -508,39 +475,34 @@ spec:
                                         anyOf:
                                           - type: integer
                                           - type: string
-                                        description:
-                                          Number or name of the port to access
-                                          on the container. Number must be in
-                                          the range 1 to 65535. Name must be an
-                                          IANA_SVC_NAME.
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
                                         x-kubernetes-int-or-string: true
                                     type: object
                                   timeoutSeconds:
-                                    description:
-                                      'Number of seconds after which the probe
-                                      times out. Defaults to 1 second. Minimum
-                                      value is 1. More info:
-                                      https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: |-
+                                      Number of seconds after which the probe times out.
+                                      Defaults to 1 second. Minimum value is 1.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     format: int32
                                     type: integer
                                 type: object
                               name:
-                                description:
-                                  Name of the container specified as a
-                                  DNS_LABEL. Each container in a pod must have a
-                                  unique name (DNS_LABEL). Cannot be updated.
+                                description: |-
+                                  Name of the container specified as a DNS_LABEL.
+                                  Each container in a pod must have a unique name (DNS_LABEL).
+                                  Cannot be updated.
                                 type: string
                               ports:
-                                description:
-                                  List of ports to expose from the container.
-                                  Not specifying a port here DOES NOT prevent
-                                  that port from being exposed. Any port which
-                                  is listening on the default "0.0.0.0" address
-                                  inside a container will be accessible from the
-                                  network. Modifying this array with strategic
-                                  merge patch may corrupt the data. For more
-                                  information See
-                                  https://github.com/kubernetes/kubernetes/issues/108255.
+                                description: |-
+                                  List of ports to expose from the container. Not specifying a port here
+                                  DOES NOT prevent that port from being exposed. Any port which is
+                                  listening on the default "0.0.0.0" address inside a container will be
+                                  accessible from the network.
+                                  Modifying this array with strategic merge patch may corrupt the data.
+                                  For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                                   Cannot be updated.
                                 items:
                                   description:
@@ -548,25 +510,22 @@ spec:
                                     single container.
                                   properties:
                                     containerPort:
-                                      description:
-                                        Number of port to expose on the pod's IP
-                                        address. This must be a valid port
-                                        number, 0 < x < 65536.
+                                      description: |-
+                                        Number of port to expose on the pod's IP address.
+                                        This must be a valid port number, 0 < x < 65536.
                                       format: int32
                                       type: integer
                                     name:
-                                      description:
-                                        If specified, this must be an
-                                        IANA_SVC_NAME and unique within the pod.
-                                        Each named port in a pod must have a
-                                        unique name. Name for the port that can
-                                        be referred to by services.
+                                      description: |-
+                                        If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                        named port in a pod must have a unique name. Name for the port that can be
+                                        referred to by services.
                                       type: string
                                     protocol:
                                       default: TCP
-                                      description:
-                                        Protocol for port. Must be UDP, TCP, or
-                                        SCTP. Defaults to "TCP".
+                                      description: |-
+                                        Protocol for port. Must be UDP, TCP, or SCTP.
+                                        Defaults to "TCP".
                                       type: string
                                   required:
                                     - containerPort
@@ -577,41 +536,31 @@ spec:
                                   - protocol
                                 x-kubernetes-list-type: map
                               readinessProbe:
-                                description:
-                                  'Periodic probe of container service
-                                  readiness. Container will be removed from
-                                  service endpoints if the probe fails. Cannot
-                                  be updated. More info:
-                                  https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                description: |-
+                                  Periodic probe of container service readiness.
+                                  Container will be removed from service endpoints if the probe fails.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                 properties:
                                   exec:
                                     description:
                                       Exec specifies the action to take.
                                     properties:
                                       command:
-                                        description:
-                                          Command is the command line to execute
-                                          inside the container, the working
-                                          directory for the command  is root
-                                          ('/') in the container's filesystem.
-                                          The command is simply exec'd, it is
-                                          not run inside a shell, so traditional
-                                          shell instructions ('|', etc) won't
-                                          work. To use a shell, you need to
-                                          explicitly call out to that shell.
-                                          Exit status of 0 is treated as
-                                          live/healthy and non-zero is
-                                          unhealthy.
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                         items:
                                           type: string
                                         type: array
                                     type: object
                                   failureThreshold:
-                                    description:
-                                      Minimum consecutive failures for the probe
-                                      to be considered failed after having
-                                      succeeded. Defaults to 3. Minimum value is
-                                      1.
+                                    description: |-
+                                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
                                     format: int32
                                     type: integer
                                   grpc:
@@ -628,8 +577,11 @@ spec:
                                         type: integer
                                       service:
                                         description: |-
-                                          Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md). 
-                                           If this is not specified, the default behavior is defined by gRPC.
+                                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                          If this is not specified, the default behavior is defined by gRPC.
                                         type: string
                                     required:
                                       - port
@@ -640,9 +592,8 @@ spec:
                                       perform.
                                     properties:
                                       host:
-                                        description:
-                                          Host name to connect to, defaults to
-                                          the pod IP. You probably want to set
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
                                           "Host" in httpHeaders instead.
                                         type: string
                                       httpHeaders:
@@ -655,11 +606,9 @@ spec:
                                             to be used in HTTP probes
                                           properties:
                                             name:
-                                              description:
-                                                The header field name. This will
-                                                be canonicalized upon output, so
-                                                case-variant names will be
-                                                understood as the same header.
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                               type: string
                                             value:
                                               description:
@@ -678,24 +627,21 @@ spec:
                                         anyOf:
                                           - type: integer
                                           - type: string
-                                        description:
-                                          Name or number of the port to access
-                                          on the container. Number must be in
-                                          the range 1 to 65535. Name must be an
-                                          IANA_SVC_NAME.
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
                                         x-kubernetes-int-or-string: true
                                       scheme:
-                                        description:
-                                          Scheme to use for connecting to the
-                                          host. Defaults to HTTP.
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
                                         type: string
                                     type: object
                                   initialDelaySeconds:
-                                    description:
-                                      'Number of seconds after the container has
-                                      started before liveness probes are
-                                      initiated. More info:
-                                      https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: |-
+                                      Number of seconds after the container has started before liveness probes are initiated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     format: int32
                                     type: integer
                                   periodSeconds:
@@ -705,12 +651,9 @@ spec:
                                     format: int32
                                     type: integer
                                   successThreshold:
-                                    description:
-                                      Minimum consecutive successes for the
-                                      probe to be considered successful after
-                                      having failed. Defaults to 1. Must be 1
-                                      for liveness and startup. Minimum value is
-                                      1.
+                                    description: |-
+                                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                     format: int32
                                     type: integer
                                   tcpSocket:
@@ -727,45 +670,47 @@ spec:
                                         anyOf:
                                           - type: integer
                                           - type: string
-                                        description:
-                                          Number or name of the port to access
-                                          on the container. Number must be in
-                                          the range 1 to 65535. Name must be an
-                                          IANA_SVC_NAME.
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
                                         x-kubernetes-int-or-string: true
                                     type: object
                                   timeoutSeconds:
-                                    description:
-                                      'Number of seconds after which the probe
-                                      times out. Defaults to 1 second. Minimum
-                                      value is 1. More info:
-                                      https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                    description: |-
+                                      Number of seconds after which the probe times out.
+                                      Defaults to 1 second. Minimum value is 1.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                                     format: int32
                                     type: integer
                                 type: object
                               resources:
-                                description:
-                                  'Compute Resources required by this container.
-                                  Cannot be updated. More info:
-                                  https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                description: |-
+                                  Compute Resources required by this container.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 properties:
                                   claims:
                                     description: |-
-                                      Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. 
-                                       This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. 
-                                       This field is immutable. It can only be set for containers.
+                                      Claims lists the names of resources, defined in spec.resourceClaims,
+                                      that are used by this container.
+
+
+                                      This is an alpha field and requires enabling the
+                                      DynamicResourceAllocation feature gate.
+
+
+                                      This field is immutable. It can only be set for containers.
                                     items:
                                       description:
                                         ResourceClaim references one entry in
                                         PodSpec.ResourceClaims.
                                       properties:
                                         name:
-                                          description:
-                                            Name must match the name of one
-                                            entry in pod.spec.resourceClaims of
-                                            the Pod where this field is used. It
-                                            makes that resource available inside
-                                            a container.
+                                          description: |-
+                                            Name must match the name of one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used. It makes that resource available
+                                            inside a container.
                                           type: string
                                       required:
                                         - name
@@ -781,10 +726,9 @@ spec:
                                         - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
-                                    description:
-                                      'Limits describes the maximum amount of
-                                      compute resources allowed. More info:
-                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    description: |-
+                                      Limits describes the maximum amount of compute resources allowed.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                     type: object
                                   requests:
                                     additionalProperties:
@@ -793,46 +737,34 @@ spec:
                                         - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
-                                    description:
-                                      'Requests describes the minimum amount of
-                                      compute resources required. If Requests is
-                                      omitted for a container, it defaults to
-                                      Limits if that is explicitly specified,
-                                      otherwise to an implementation-defined
-                                      value. Requests cannot exceed Limits. More
-                                      info:
-                                      https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                    description: |-
+                                      Requests describes the minimum amount of compute resources required.
+                                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                     type: object
                                 type: object
                               securityContext:
-                                description:
-                                  'SecurityContext defines the security options
-                                  the container should be run with. If set, the
-                                  fields of SecurityContext override the
-                                  equivalent fields of PodSecurityContext. More
-                                  info:
-                                  https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                                description: |-
+                                  SecurityContext defines the security options the container should be run with.
+                                  If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                  More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                                 properties:
                                   allowPrivilegeEscalation:
-                                    description:
-                                      'AllowPrivilegeEscalation controls whether
-                                      a process can gain more privileges than
-                                      its parent process. This bool directly
-                                      controls if the no_new_privs flag will be
-                                      set on the container process.
-                                      AllowPrivilegeEscalation is true always
-                                      when the container is: 1) run as
-                                      Privileged 2) has CAP_SYS_ADMIN Note that
-                                      this field cannot be set when spec.os.name
-                                      is windows.'
+                                    description: |-
+                                      AllowPrivilegeEscalation controls whether a process can gain more
+                                      privileges than its parent process. This bool directly controls if
+                                      the no_new_privs flag will be set on the container process.
+                                      AllowPrivilegeEscalation is true always when the container is:
+                                      1) run as Privileged
+                                      2) has CAP_SYS_ADMIN
+                                      Note that this field cannot be set when spec.os.name is windows.
                                     type: boolean
                                   capabilities:
-                                    description:
-                                      The capabilities to add/drop when running
-                                      containers. Defaults to the default set of
-                                      capabilities granted by the container
-                                      runtime. Note that this field cannot be
-                                      set when spec.os.name is windows.
+                                    description: |-
+                                      The capabilities to add/drop when running containers.
+                                      Defaults to the default set of capabilities granted by the container runtime.
+                                      Note that this field cannot be set when spec.os.name is windows.
                                     properties:
                                       add:
                                         description:
@@ -855,138 +787,112 @@ spec:
                                         type: array
                                     type: object
                                   readOnlyRootFilesystem:
-                                    description:
-                                      Whether this container has a read-only
-                                      root filesystem. Default is false. Note
-                                      that this field cannot be set when
-                                      spec.os.name is windows.
+                                    description: |-
+                                      Whether this container has a read-only root filesystem.
+                                      Default is false.
+                                      Note that this field cannot be set when spec.os.name is windows.
                                     type: boolean
                                   runAsGroup:
-                                    description:
-                                      The GID to run the entrypoint of the
-                                      container process. Uses runtime default if
-                                      unset. May also be set in
-                                      PodSecurityContext.  If set in both
-                                      SecurityContext and PodSecurityContext,
-                                      the value specified in SecurityContext
-                                      takes precedence. Note that this field
-                                      cannot be set when spec.os.name is
-                                      windows.
+                                    description: |-
+                                      The GID to run the entrypoint of the container process.
+                                      Uses runtime default if unset.
+                                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is windows.
                                     format: int64
                                     type: integer
                                   runAsNonRoot:
-                                    description:
-                                      Indicates that the container must run as a
-                                      non-root user. If true, the Kubelet will
-                                      validate the image at runtime to ensure
-                                      that it does not run as UID 0 (root) and
-                                      fail to start the container if it does. If
-                                      unset or false, no such validation will be
-                                      performed. May also be set in
-                                      PodSecurityContext.  If set in both
-                                      SecurityContext and PodSecurityContext,
-                                      the value specified in SecurityContext
-                                      takes precedence.
+                                    description: |-
+                                      Indicates that the container must run as a non-root user.
+                                      If true, the Kubelet will validate the image at runtime to ensure that it
+                                      does not run as UID 0 (root) and fail to start the container if it does.
+                                      If unset or false, no such validation will be performed.
+                                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
                                     type: boolean
                                   runAsUser:
-                                    description:
-                                      The UID to run the entrypoint of the
-                                      container process. Defaults to user
-                                      specified in image metadata if
-                                      unspecified. May also be set in
-                                      PodSecurityContext.  If set in both
-                                      SecurityContext and PodSecurityContext,
-                                      the value specified in SecurityContext
-                                      takes precedence. Note that this field
-                                      cannot be set when spec.os.name is
-                                      windows.
+                                    description: |-
+                                      The UID to run the entrypoint of the container process.
+                                      Defaults to user specified in image metadata if unspecified.
+                                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is windows.
                                     format: int64
                                     type: integer
                                   seccompProfile:
-                                    description:
-                                      The seccomp options to use by this
-                                      container. If seccomp options are provided
-                                      at both the pod & container level, the
-                                      container options override the pod
-                                      options. Note that this field cannot be
-                                      set when spec.os.name is windows.
+                                    description: |-
+                                      The seccomp options to use by this container. If seccomp options are
+                                      provided at both the pod & container level, the container options
+                                      override the pod options.
+                                      Note that this field cannot be set when spec.os.name is windows.
                                     properties:
                                       localhostProfile:
-                                        description:
-                                          localhostProfile indicates a profile
-                                          defined in a file on the node should
-                                          be used. The profile must be
-                                          preconfigured on the node to work.
-                                          Must be a descending path, relative to
-                                          the kubelet's configured seccomp
-                                          profile location. Must only be set if
-                                          type is "Localhost".
+                                        description: |-
+                                          localhostProfile indicates a profile defined in a file on the node should be used.
+                                          The profile must be preconfigured on the node to work.
+                                          Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                          Must be set if type is "Localhost". Must NOT be set for any other type.
                                         type: string
                                       type:
                                         description: |-
-                                          type indicates which kind of seccomp profile will be applied. Valid options are: 
-                                           Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+                                          type indicates which kind of seccomp profile will be applied.
+                                          Valid options are:
+
+
+                                          Localhost - a profile defined in a file on the node should be used.
+                                          RuntimeDefault - the container runtime default profile should be used.
+                                          Unconfined - no profile should be applied.
                                         type: string
                                     required:
                                       - type
                                     type: object
                                 type: object
                               terminationMessagePath:
-                                description:
-                                  "Optional: Path at which the file to which the
-                                  container's termination message will be
-                                  written is mounted into the container's
-                                  filesystem. Message written is intended to be
-                                  brief final status, such as an assertion
-                                  failure message. Will be truncated by the node
-                                  if greater than 4096 bytes. The total message
-                                  length across all containers will be limited
-                                  to 12kb. Defaults to /dev/termination-log.
-                                  Cannot be updated."
+                                description: |-
+                                  Optional: Path at which the file to which the container's termination message
+                                  will be written is mounted into the container's filesystem.
+                                  Message written is intended to be brief final status, such as an assertion failure message.
+                                  Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                  all containers will be limited to 12kb.
+                                  Defaults to /dev/termination-log.
+                                  Cannot be updated.
                                 type: string
                               terminationMessagePolicy:
-                                description:
-                                  Indicate how the termination message should be
-                                  populated. File will use the contents of
-                                  terminationMessagePath to populate the
-                                  container status message on both success and
-                                  failure. FallbackToLogsOnError will use the
-                                  last chunk of container log output if the
-                                  termination message file is empty and the
-                                  container exited with an error. The log output
-                                  is limited to 2048 bytes or 80 lines,
-                                  whichever is smaller. Defaults to File. Cannot
-                                  be updated.
+                                description: |-
+                                  Indicate how the termination message should be populated. File will use the contents of
+                                  terminationMessagePath to populate the container status message on both success and failure.
+                                  FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                  message file is empty and the container exited with an error.
+                                  The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                  Defaults to File.
+                                  Cannot be updated.
                                 type: string
                               volumeMounts:
-                                description:
-                                  Pod volumes to mount into the container's
-                                  filesystem. Cannot be updated.
+                                description: |-
+                                  Pod volumes to mount into the container's filesystem.
+                                  Cannot be updated.
                                 items:
                                   description:
                                     VolumeMount describes a mounting of a Volume
                                     within a container.
                                   properties:
                                     mountPath:
-                                      description:
-                                        Path within the container at which the
-                                        volume should be mounted.  Must not
-                                        contain ':'.
+                                      description: |-
+                                        Path within the container at which the volume should be mounted.  Must
+                                        not contain ':'.
                                       type: string
                                     name:
                                       description:
                                         This must match the Name of a Volume.
                                       type: string
                                     readOnly:
-                                      description:
-                                        Mounted read-only if true, read-write
-                                        otherwise (false or unspecified).
+                                      description: |-
+                                        Mounted read-only if true, read-write otherwise (false or unspecified).
                                         Defaults to false.
                                       type: boolean
                                     subPath:
-                                      description:
-                                        Path within the volume from which the
-                                        container's volume should be mounted.
+                                      description: |-
+                                        Path within the volume from which the container's volume should be mounted.
                                         Defaults to "" (volume's root).
                                       type: string
                                   required:
@@ -995,11 +901,11 @@ spec:
                                   type: object
                                 type: array
                               workingDir:
-                                description:
-                                  Container's working directory. If not
-                                  specified, the container runtime's default
-                                  will be used, which might be configured in the
-                                  container image. Cannot be updated.
+                                description: |-
+                                  Container's working directory.
+                                  If not specified, the container runtime's default will be used, which
+                                  might be configured in the container image.
+                                  Cannot be updated.
                                 type: string
                             type: object
                           type: array
@@ -1033,57 +939,46 @@ spec:
                             x-kubernetes-preserve-unknown-fields: true
                           type: array
                         idleTimeoutSeconds:
-                          description:
-                            IdleTimeoutSeconds is the maximum duration in
-                            seconds a request will be allowed to stay open while
-                            not receiving any bytes from the user's application.
-                            If unspecified, a system default will be provided.
+                          description: |-
+                            IdleTimeoutSeconds is the maximum duration in seconds a request will be allowed
+                            to stay open while not receiving any bytes from the user's application. If
+                            unspecified, a system default will be provided.
                           format: int64
                           type: integer
                         imagePullSecrets:
-                          description:
-                            'ImagePullSecrets is an optional list of references
-                            to secrets in the same namespace to use for pulling
-                            any of the images used by this PodSpec. If
-                            specified, these secrets will be passed to
-                            individual puller implementations for them to use.
-                            More info:
-                            https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
+                          description: |-
+                            ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+                            If specified, these secrets will be passed to individual puller implementations for them to use.
+                            More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
                           items:
-                            description:
-                              LocalObjectReference contains enough information
-                              to let you locate the referenced object inside the
-                              same namespace.
+                            description: |-
+                              LocalObjectReference contains enough information to let you locate the
+                              referenced object inside the same namespace.
                             properties:
                               name:
-                                description:
-                                  'Name of the referent. More info:
-                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion,
-                                  kind, uid?'
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
                           type: array
                         initContainers:
-                          description:
-                            'List of initialization containers belonging to the
-                            pod. Init containers are executed in order prior to
-                            containers being started. If any init container
-                            fails, the pod is considered to have failed and is
-                            handled according to its restartPolicy. The name for
-                            an init container or normal container must be unique
-                            among all containers. Init containers may not have
-                            Lifecycle actions, Readiness probes, Liveness
-                            probes, or Startup probes. The resourceRequirements
-                            of an init container are taken into account during
-                            scheduling by finding the highest request/limit for
-                            each resource type, and then using the max of of
-                            that value or the sum of the normal containers.
-                            Limits are applied to init containers in a similar
-                            fashion. Init containers cannot currently be added
-                            or removed. Cannot be updated. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                          description: |-
+                            List of initialization containers belonging to the pod.
+                            Init containers are executed in order prior to containers being started. If any
+                            init container fails, the pod is considered to have failed and is handled according
+                            to its restartPolicy. The name for an init container or normal container must be
+                            unique among all containers.
+                            Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+                            The resourceRequirements of an init container are taken into account during scheduling
+                            by finding the highest request/limit for each resource type, and then using the max of
+                            of that value or the sum of the normal containers. Limits are applied to init containers
+                            in a similar fashion.
+                            Init containers cannot currently be added or removed.
+                            Cannot be updated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
                           items:
                             description:
                               This is accessible behind a feature flag -
@@ -1105,10 +1000,9 @@ spec:
                           type: string
                           x-kubernetes-preserve-unknown-fields: true
                         responseStartTimeoutSeconds:
-                          description:
-                            ResponseStartTimeoutSeconds is the maximum duration
-                            in seconds that the request routing layer will wait
-                            for a request delivered to a container to begin
+                          description: |-
+                            ResponseStartTimeoutSeconds is the maximum duration in seconds that the request
+                            routing layer will wait for a request delivered to a container to begin
                             sending any network traffic.
                           format: int64
                           type: integer
@@ -1131,10 +1025,9 @@ spec:
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
                         serviceAccountName:
-                          description:
-                            'ServiceAccountName is the name of the
-                            ServiceAccount to use to run this pod. More info:
-                            https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                          description: |-
+                            ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+                            More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
                           type: string
                         shareProcessNamespace:
                           description:
@@ -1143,11 +1036,10 @@ spec:
                           type: boolean
                           x-kubernetes-preserve-unknown-fields: true
                         timeoutSeconds:
-                          description:
-                            TimeoutSeconds is the maximum duration in seconds
-                            that the request instance is allowed to respond to a
-                            request. If unspecified, a system default will be
-                            provided.
+                          description: |-
+                            TimeoutSeconds is the maximum duration in seconds that the request instance
+                            is allowed to respond to a request. If unspecified, a system default will
+                            be provided.
                           format: int64
                           type: integer
                         tolerations:
@@ -1173,10 +1065,9 @@ spec:
                             x-kubernetes-preserve-unknown-fields: true
                           type: array
                         volumes:
-                          description:
-                            'List of volumes that can be mounted by containers
-                            belonging to the pod. More info:
-                            https://kubernetes.io/docs/concepts/storage/volumes'
+                          description: |-
+                            List of volumes that can be mounted by containers belonging to the pod.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes
                           items:
                             description:
                               Volume represents a named volume in a pod that may
@@ -1188,36 +1079,25 @@ spec:
                                   populate this volume
                                 properties:
                                   defaultMode:
-                                    description:
-                                      'defaultMode is optional: mode bits used
-                                      to set permissions on created files by
-                                      default. Must be an octal value between
-                                      0000 and 0777 or a decimal value between 0
-                                      and 511. YAML accepts both octal and
-                                      decimal values, JSON requires decimal
-                                      values for mode bits. Defaults to 0644.
-                                      Directories within the path are not
-                                      affected by this setting. This might be in
-                                      conflict with other options that affect
-                                      the file mode, like fsGroup, and the
-                                      result can be other mode bits set.'
+                                    description: |-
+                                      defaultMode is optional: mode bits used to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      Defaults to 0644.
+                                      Directories within the path are not affected by this setting.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
                                     format: int32
                                     type: integer
                                   items:
-                                    description:
-                                      items if unspecified, each key-value pair
-                                      in the Data field of the referenced
-                                      ConfigMap will be projected into the
-                                      volume as a file whose name is the key and
-                                      content is the value. If specified, the
-                                      listed keys will be projected into the
-                                      specified paths, and unlisted keys will
-                                      not be present. If a key is specified
-                                      which is not present in the ConfigMap, the
-                                      volume setup will error unless it is
-                                      marked optional. Paths must be relative
-                                      and may not contain the '..' path or start
-                                      with '..'.
+                                    description: |-
+                                      items if unspecified, each key-value pair in the Data field of the referenced
+                                      ConfigMap will be projected into the volume as a file whose name is the
+                                      key and content is the value. If specified, the listed keys will be
+                                      projected into the specified paths, and unlisted keys will not be
+                                      present. If a key is specified which is not present in the ConfigMap,
+                                      the volume setup will error unless it is marked optional. Paths must be
+                                      relative and may not contain the '..' path or start with '..'.
                                     items:
                                       description:
                                         Maps a string key to a path within a
@@ -1228,29 +1108,21 @@ spec:
                                             key is the key to project.
                                           type: string
                                         mode:
-                                          description:
-                                            'mode is Optional: mode bits used to
-                                            set permissions on this file. Must
-                                            be an octal value between 0000 and
-                                            0777 or a decimal value between 0
-                                            and 511. YAML accepts both octal and
-                                            decimal values, JSON requires
-                                            decimal values for mode bits. If not
-                                            specified, the volume defaultMode
-                                            will be used. This might be in
-                                            conflict with other options that
-                                            affect the file mode, like fsGroup,
-                                            and the result can be other mode
-                                            bits set.'
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description:
-                                            path is the relative path of the
-                                            file to map the key to. May not be
-                                            an absolute path. May not contain
-                                            the path element '..'. May not start
-                                            with the string '..'.
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
                                           type: string
                                       required:
                                         - key
@@ -1258,11 +1130,10 @@ spec:
                                       type: object
                                     type: array
                                   name:
-                                    description:
-                                      'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion,
-                                      kind, uid?'
+                                    description: |-
+                                      Name of the referent.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                   optional:
                                     description:
@@ -1278,10 +1149,10 @@ spec:
                                 type: object
                                 x-kubernetes-preserve-unknown-fields: true
                               name:
-                                description:
-                                  'name of the volume. Must be a DNS_LABEL and
-                                  unique within the pod. More info:
-                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                description: |-
+                                  name of the volume.
+                                  Must be a DNS_LABEL and unique within the pod.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                 type: string
                               persistentVolumeClaim:
                                 description:
@@ -1295,18 +1166,13 @@ spec:
                                   secrets, configmaps, and downward API
                                 properties:
                                   defaultMode:
-                                    description:
-                                      defaultMode are the mode bits used to set
-                                      permissions on created files by default.
-                                      Must be an octal value between 0000 and
-                                      0777 or a decimal value between 0 and 511.
-                                      YAML accepts both octal and decimal
-                                      values, JSON requires decimal values for
-                                      mode bits. Directories within the path are
-                                      not affected by this setting. This might
-                                      be in conflict with other options that
-                                      affect the file mode, like fsGroup, and
-                                      the result can be other mode bits set.
+                                    description: |-
+                                      defaultMode are the mode bits used to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      Directories within the path are not affected by this setting.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
                                     format: int32
                                     type: integer
                                   sources:
@@ -1323,23 +1189,14 @@ spec:
                                             configMap data to project
                                           properties:
                                             items:
-                                              description:
-                                                items if unspecified, each
-                                                key-value pair in the Data field
-                                                of the referenced ConfigMap will
-                                                be projected into the volume as
-                                                a file whose name is the key and
-                                                content is the value. If
-                                                specified, the listed keys will
-                                                be projected into the specified
-                                                paths, and unlisted keys will
-                                                not be present. If a key is
-                                                specified which is not present
-                                                in the ConfigMap, the volume
-                                                setup will error unless it is
-                                                marked optional. Paths must be
-                                                relative and may not contain the
-                                                '..' path or start with '..'.
+                                              description: |-
+                                                items if unspecified, each key-value pair in the Data field of the referenced
+                                                ConfigMap will be projected into the volume as a file whose name is the
+                                                key and content is the value. If specified, the listed keys will be
+                                                projected into the specified paths, and unlisted keys will not be
+                                                present. If a key is specified which is not present in the ConfigMap,
+                                                the volume setup will error unless it is marked optional. Paths must be
+                                                relative and may not contain the '..' path or start with '..'.
                                               items:
                                                 description:
                                                   Maps a string key to a path
@@ -1350,36 +1207,21 @@ spec:
                                                       key is the key to project.
                                                     type: string
                                                   mode:
-                                                    description:
-                                                      'mode is Optional: mode
-                                                      bits used to set
-                                                      permissions on this file.
-                                                      Must be an octal value
-                                                      between 0000 and 0777 or a
-                                                      decimal value between 0
-                                                      and 511. YAML accepts both
-                                                      octal and decimal values,
-                                                      JSON requires decimal
-                                                      values for mode bits. If
-                                                      not specified, the volume
-                                                      defaultMode will be used.
-                                                      This might be in conflict
-                                                      with other options that
-                                                      affect the file mode, like
-                                                      fsGroup, and the result
-                                                      can be other mode bits
-                                                      set.'
+                                                    description: |-
+                                                      mode is Optional: mode bits used to set permissions on this file.
+                                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                      If not specified, the volume defaultMode will be used.
+                                                      This might be in conflict with other options that affect the file
+                                                      mode, like fsGroup, and the result can be other mode bits set.
                                                     format: int32
                                                     type: integer
                                                   path:
-                                                    description:
-                                                      path is the relative path
-                                                      of the file to map the key
-                                                      to. May not be an absolute
-                                                      path. May not contain the
-                                                      path element '..'. May not
-                                                      start with the string
-                                                      '..'.
+                                                    description: |-
+                                                      path is the relative path of the file to map the key to.
+                                                      May not be an absolute path.
+                                                      May not contain the path element '..'.
+                                                      May not start with the string '..'.
                                                     type: string
                                                 required:
                                                   - key
@@ -1387,12 +1229,10 @@ spec:
                                                 type: object
                                               type: array
                                             name:
-                                              description:
-                                                'Name of the referent. More
-                                                info:
-                                                https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields.
-                                                apiVersion, kind, uid?'
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description:
@@ -1444,25 +1284,13 @@ spec:
                                                     type: object
                                                     x-kubernetes-map-type: atomic
                                                   mode:
-                                                    description:
-                                                      'Optional: mode bits used
-                                                      to set permissions on this
-                                                      file, must be an octal
-                                                      value between 0000 and
-                                                      0777 or a decimal value
-                                                      between 0 and 511. YAML
-                                                      accepts both octal and
-                                                      decimal values, JSON
-                                                      requires decimal values
-                                                      for mode bits. If not
-                                                      specified, the volume
-                                                      defaultMode will be used.
-                                                      This might be in conflict
-                                                      with other options that
-                                                      affect the file mode, like
-                                                      fsGroup, and the result
-                                                      can be other mode bits
-                                                      set.'
+                                                    description: |-
+                                                      Optional: mode bits used to set permissions on this file, must be an octal value
+                                                      between 0000 and 0777 or a decimal value between 0 and 511.
+                                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                      If not specified, the volume defaultMode will be used.
+                                                      This might be in conflict with other options that affect the file
+                                                      mode, like fsGroup, and the result can be other mode bits set.
                                                     format: int32
                                                     type: integer
                                                   path:
@@ -1477,15 +1305,9 @@ spec:
                                                       must not start with '..'"
                                                     type: string
                                                   resourceFieldRef:
-                                                    description:
-                                                      'Selects a resource of the
-                                                      container: only resources
-                                                      limits and requests
-                                                      (limits.cpu,
-                                                      limits.memory,
-                                                      requests.cpu and
-                                                      requests.memory) are
-                                                      currently supported.'
+                                                    description: |-
+                                                      Selects a resource of the container: only resources limits and requests
+                                                      (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                     properties:
                                                       containerName:
                                                         description:
@@ -1524,23 +1346,14 @@ spec:
                                             data to project
                                           properties:
                                             items:
-                                              description:
-                                                items if unspecified, each
-                                                key-value pair in the Data field
-                                                of the referenced Secret will be
-                                                projected into the volume as a
-                                                file whose name is the key and
-                                                content is the value. If
-                                                specified, the listed keys will
-                                                be projected into the specified
-                                                paths, and unlisted keys will
-                                                not be present. If a key is
-                                                specified which is not present
-                                                in the Secret, the volume setup
-                                                will error unless it is marked
-                                                optional. Paths must be relative
-                                                and may not contain the '..'
-                                                path or start with '..'.
+                                              description: |-
+                                                items if unspecified, each key-value pair in the Data field of the referenced
+                                                Secret will be projected into the volume as a file whose name is the
+                                                key and content is the value. If specified, the listed keys will be
+                                                projected into the specified paths, and unlisted keys will not be
+                                                present. If a key is specified which is not present in the Secret,
+                                                the volume setup will error unless it is marked optional. Paths must be
+                                                relative and may not contain the '..' path or start with '..'.
                                               items:
                                                 description:
                                                   Maps a string key to a path
@@ -1551,36 +1364,21 @@ spec:
                                                       key is the key to project.
                                                     type: string
                                                   mode:
-                                                    description:
-                                                      'mode is Optional: mode
-                                                      bits used to set
-                                                      permissions on this file.
-                                                      Must be an octal value
-                                                      between 0000 and 0777 or a
-                                                      decimal value between 0
-                                                      and 511. YAML accepts both
-                                                      octal and decimal values,
-                                                      JSON requires decimal
-                                                      values for mode bits. If
-                                                      not specified, the volume
-                                                      defaultMode will be used.
-                                                      This might be in conflict
-                                                      with other options that
-                                                      affect the file mode, like
-                                                      fsGroup, and the result
-                                                      can be other mode bits
-                                                      set.'
+                                                    description: |-
+                                                      mode is Optional: mode bits used to set permissions on this file.
+                                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                      If not specified, the volume defaultMode will be used.
+                                                      This might be in conflict with other options that affect the file
+                                                      mode, like fsGroup, and the result can be other mode bits set.
                                                     format: int32
                                                     type: integer
                                                   path:
-                                                    description:
-                                                      path is the relative path
-                                                      of the file to map the key
-                                                      to. May not be an absolute
-                                                      path. May not contain the
-                                                      path element '..'. May not
-                                                      start with the string
-                                                      '..'.
+                                                    description: |-
+                                                      path is the relative path of the file to map the key to.
+                                                      May not be an absolute path.
+                                                      May not contain the path element '..'.
+                                                      May not start with the string '..'.
                                                     type: string
                                                 required:
                                                   - key
@@ -1588,12 +1386,10 @@ spec:
                                                 type: object
                                               type: array
                                             name:
-                                              description:
-                                                'Name of the referent. More
-                                                info:
-                                                https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields.
-                                                apiVersion, kind, uid?'
+                                              description: |-
+                                                Name of the referent.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description:
@@ -1610,39 +1406,26 @@ spec:
                                             to project
                                           properties:
                                             audience:
-                                              description:
-                                                audience is the intended
-                                                audience of the token. A
-                                                recipient of a token must
-                                                identify itself with an
-                                                identifier specified in the
-                                                audience of the token, and
-                                                otherwise should reject the
-                                                token. The audience defaults to
-                                                the identifier of the apiserver.
+                                              description: |-
+                                                audience is the intended audience of the token. A recipient of a token
+                                                must identify itself with an identifier specified in the audience of the
+                                                token, and otherwise should reject the token. The audience defaults to the
+                                                identifier of the apiserver.
                                               type: string
                                             expirationSeconds:
-                                              description:
-                                                expirationSeconds is the
-                                                requested duration of validity
-                                                of the service account token. As
-                                                the token approaches expiration,
-                                                the kubelet volume plugin will
-                                                proactively rotate the service
-                                                account token. The kubelet will
-                                                start trying to rotate the token
-                                                if the token is older than 80
-                                                percent of its time to live or
-                                                if the token is older than 24
-                                                hours.Defaults to 1 hour and
-                                                must be at least 10 minutes.
+                                              description: |-
+                                                expirationSeconds is the requested duration of validity of the service
+                                                account token. As the token approaches expiration, the kubelet volume
+                                                plugin will proactively rotate the service account token. The kubelet will
+                                                start trying to rotate the token if the token is older than 80 percent of
+                                                its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                                and must be at least 10 minutes.
                                               format: int64
                                               type: integer
                                             path:
-                                              description:
-                                                path is the path relative to the
-                                                mount point of the file to
-                                                project the token into.
+                                              description: |-
+                                                path is the path relative to the mount point of the file to project the
+                                                token into.
                                               type: string
                                           required:
                                             - path
@@ -1651,42 +1434,30 @@ spec:
                                     type: array
                                 type: object
                               secret:
-                                description:
-                                  'secret represents a secret that should
-                                  populate this volume. More info:
-                                  https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                description: |-
+                                  secret represents a secret that should populate this volume.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                 properties:
                                   defaultMode:
-                                    description:
-                                      'defaultMode is Optional: mode bits used
-                                      to set permissions on created files by
-                                      default. Must be an octal value between
-                                      0000 and 0777 or a decimal value between 0
-                                      and 511. YAML accepts both octal and
-                                      decimal values, JSON requires decimal
-                                      values for mode bits. Defaults to 0644.
-                                      Directories within the path are not
-                                      affected by this setting. This might be in
-                                      conflict with other options that affect
-                                      the file mode, like fsGroup, and the
-                                      result can be other mode bits set.'
+                                    description: |-
+                                      defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values
+                                      for mode bits. Defaults to 0644.
+                                      Directories within the path are not affected by this setting.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
                                     format: int32
                                     type: integer
                                   items:
-                                    description:
-                                      items If unspecified, each key-value pair
-                                      in the Data field of the referenced Secret
-                                      will be projected into the volume as a
-                                      file whose name is the key and content is
-                                      the value. If specified, the listed keys
-                                      will be projected into the specified
-                                      paths, and unlisted keys will not be
-                                      present. If a key is specified which is
-                                      not present in the Secret, the volume
-                                      setup will error unless it is marked
-                                      optional. Paths must be relative and may
-                                      not contain the '..' path or start with
-                                      '..'.
+                                    description: |-
+                                      items If unspecified, each key-value pair in the Data field of the referenced
+                                      Secret will be projected into the volume as a file whose name is the
+                                      key and content is the value. If specified, the listed keys will be
+                                      projected into the specified paths, and unlisted keys will not be
+                                      present. If a key is specified which is not present in the Secret,
+                                      the volume setup will error unless it is marked optional. Paths must be
+                                      relative and may not contain the '..' path or start with '..'.
                                     items:
                                       description:
                                         Maps a string key to a path within a
@@ -1697,29 +1468,21 @@ spec:
                                             key is the key to project.
                                           type: string
                                         mode:
-                                          description:
-                                            'mode is Optional: mode bits used to
-                                            set permissions on this file. Must
-                                            be an octal value between 0000 and
-                                            0777 or a decimal value between 0
-                                            and 511. YAML accepts both octal and
-                                            decimal values, JSON requires
-                                            decimal values for mode bits. If not
-                                            specified, the volume defaultMode
-                                            will be used. This might be in
-                                            conflict with other options that
-                                            affect the file mode, like fsGroup,
-                                            and the result can be other mode
-                                            bits set.'
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description:
-                                            path is the relative path of the
-                                            file to map the key to. May not be
-                                            an absolute path. May not contain
-                                            the path element '..'. May not start
-                                            with the string '..'.
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
                                           type: string
                                       required:
                                         - key
@@ -1732,10 +1495,9 @@ spec:
                                       or its keys must be defined
                                     type: boolean
                                   secretName:
-                                    description:
-                                      "secretName is the name of the secret in
-                                      the pod's namespace to use. More info:
-                                      https://kubernetes.io/docs/concepts/storage/volumes#secret"
+                                    description: |-
+                                      secretName is the name of the secret in the pod's namespace to use.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                     type: string
                                 type: object
                             required:
@@ -1747,64 +1509,57 @@ spec:
                       type: object
                   type: object
                 traffic:
-                  description:
-                    Traffic specifies how to distribute traffic over a
-                    collection of revisions and configurations.
+                  description: |-
+                    Traffic specifies how to distribute traffic over a collection of
+                    revisions and configurations.
                   items:
                     description:
                       TrafficTarget holds a single entry of the routing table
                       for a Route.
                     properties:
                       configurationName:
-                        description:
-                          ConfigurationName of a configuration to whose latest
-                          revision we will send this portion of traffic. When
-                          the "status.latestReadyRevisionName" of the referenced
-                          configuration changes, we will automatically migrate
-                          traffic from the prior "latest ready" revision to the
-                          new one.  This field is never set in Route's status,
-                          only its spec.  This is mutually exclusive with
+                        description: |-
+                          ConfigurationName of a configuration to whose latest revision we will send
+                          this portion of traffic. When the "status.latestReadyRevisionName" of the
+                          referenced configuration changes, we will automatically migrate traffic
+                          from the prior "latest ready" revision to the new one.  This field is never
+                          set in Route's status, only its spec.  This is mutually exclusive with
                           RevisionName.
                         type: string
                       latestRevision:
-                        description:
-                          LatestRevision may be optionally provided to indicate
-                          that the latest ready Revision of the Configuration
-                          should be used for this traffic target.  When provided
-                          LatestRevision must be true if RevisionName is empty;
-                          it must be false when RevisionName is non-empty.
+                        description: |-
+                          LatestRevision may be optionally provided to indicate that the latest
+                          ready Revision of the Configuration should be used for this traffic
+                          target.  When provided LatestRevision must be true if RevisionName is
+                          empty; it must be false when RevisionName is non-empty.
                         type: boolean
                       percent:
-                        description:
-                          'Percent indicates that percentage based routing
-                          should be used and the value indicates the percent of
-                          traffic that is be routed to this Revision or
-                          Configuration. `0` (zero) mean no traffic, `100` means
-                          all traffic. When percentage based routing is being
-                          used the follow rules apply: - the sum of all percent
-                          values must equal 100 - when not specified, the
-                          implied value for `percent` is zero for that
-                          particular Revision or Configuration'
+                        description: |-
+                          Percent indicates that percentage based routing should be used and
+                          the value indicates the percent of traffic that is be routed to this
+                          Revision or Configuration. `0` (zero) mean no traffic, `100` means all
+                          traffic.
+                          When percentage based routing is being used the follow rules apply:
+                          - the sum of all percent values must equal 100
+                          - when not specified, the implied value for `percent` is zero for
+                            that particular Revision or Configuration
                         format: int64
                         type: integer
                       revisionName:
-                        description:
-                          RevisionName of a specific revision to which to send
-                          this portion of traffic.  This is mutually exclusive
-                          with ConfigurationName.
+                        description: |-
+                          RevisionName of a specific revision to which to send this portion of
+                          traffic.  This is mutually exclusive with ConfigurationName.
                         type: string
                       tag:
-                        description:
-                          Tag is optionally used to expose a dedicated url for
-                          referencing this target exclusively.
+                        description: |-
+                          Tag is optionally used to expose a dedicated url for referencing
+                          this target exclusively.
                         type: string
                       url:
-                        description:
-                          URL displays the URL for accessing named traffic
-                          targets. URL is displayed in status, and is disallowed
-                          on spec. URL must contain a scheme (e.g. http://) and
-                          a hostname, but may not contain anything else (e.g.
-                          basic auth, url path, etc.)
+                        description: |-
+                          URL displays the URL for accessing named traffic targets. URL is displayed in
+                          status, and is disallowed on spec. URL must contain a scheme (e.g. http://) and
+                          a hostname, but may not contain anything else (e.g. basic auth, url path, etc.)
                         type: string
                     type: object
                   type: array
@@ -1820,10 +1575,9 @@ spec:
                     target of an event.
                   properties:
                     CACerts:
-                      description:
-                        CACerts is the Certification Authority (CA) certificates
-                        in PEM format according to
-                        https://www.rfc-editor.org/rfc/rfc7468.
+                      description: |-
+                        CACerts is the Certification Authority (CA) certificates in PEM format
+                        according to https://www.rfc-editor.org/rfc/rfc7468.
                       type: string
                     audience:
                       description:
@@ -1838,30 +1592,26 @@ spec:
                 annotations:
                   additionalProperties:
                     type: string
-                  description:
-                    Annotations is additional Status fields for the Resource to
-                    save some additional State as well as convey more
-                    information to the user. This is roughly akin to Annotations
-                    on any k8s resource, just the reconciler conveying richer
-                    information outwards.
+                  description: |-
+                    Annotations is additional Status fields for the Resource to save some
+                    additional State as well as convey more information to the user. This is
+                    roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                    richer information outwards.
                   type: object
                 conditions:
                   description:
                     Conditions the latest available observations of a resource's
                     current state.
                   items:
-                    description:
-                      'Condition defines a readiness condition for a Knative
-                      resource. See:
-                      https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                    description: |-
+                      Condition defines a readiness condition for a Knative resource.
+                      See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
                     properties:
                       lastTransitionTime:
-                        description:
-                          LastTransitionTime is the last time the condition
-                          transitioned from one status to another. We use
-                          VolatileTime in place of metav1.Time to exclude this
-                          from creating equality.Semantic differences (all other
-                          things held constant).
+                        description: |-
+                          LastTransitionTime is the last time the condition transitioned from one status to another.
+                          We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                          differences (all other things held constant).
                         type: string
                       message:
                         description:
@@ -1873,10 +1623,9 @@ spec:
                           The reason for the condition's last transition.
                         type: string
                       severity:
-                        description:
-                          Severity with which to treat failures of this type of
-                          condition. When this is not specified, it defaults to
-                          Error.
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
                         type: string
                       status:
                         description:
@@ -1891,28 +1640,26 @@ spec:
                     type: object
                   type: array
                 latestCreatedRevisionName:
-                  description:
-                    LatestCreatedRevisionName is the last revision that was
-                    created from this Configuration. It might not be ready yet,
-                    for that use LatestReadyRevisionName.
+                  description: |-
+                    LatestCreatedRevisionName is the last revision that was created from this
+                    Configuration. It might not be ready yet, for that use LatestReadyRevisionName.
                   type: string
                 latestReadyRevisionName:
-                  description:
-                    LatestReadyRevisionName holds the name of the latest
-                    Revision stamped out from this Configuration that has had
-                    its "Ready" condition become "True".
+                  description: |-
+                    LatestReadyRevisionName holds the name of the latest Revision stamped out
+                    from this Configuration that has had its "Ready" condition become "True".
                   type: string
                 observedGeneration:
-                  description:
+                  description: |-
                     ObservedGeneration is the 'Generation' of the Service that
                     was last processed by the controller.
                   format: int64
                   type: integer
                 traffic:
-                  description:
-                    Traffic holds the configured traffic distribution. These
-                    entries will always contain RevisionName references. When
-                    ConfigurationName appears in the spec, this will hold the
+                  description: |-
+                    Traffic holds the configured traffic distribution.
+                    These entries will always contain RevisionName references.
+                    When ConfigurationName appears in the spec, this will hold the
                     LatestReadyRevisionName that we last observed.
                   items:
                     description:
@@ -1920,63 +1667,55 @@ spec:
                       for a Route.
                     properties:
                       configurationName:
-                        description:
-                          ConfigurationName of a configuration to whose latest
-                          revision we will send this portion of traffic. When
-                          the "status.latestReadyRevisionName" of the referenced
-                          configuration changes, we will automatically migrate
-                          traffic from the prior "latest ready" revision to the
-                          new one.  This field is never set in Route's status,
-                          only its spec.  This is mutually exclusive with
+                        description: |-
+                          ConfigurationName of a configuration to whose latest revision we will send
+                          this portion of traffic. When the "status.latestReadyRevisionName" of the
+                          referenced configuration changes, we will automatically migrate traffic
+                          from the prior "latest ready" revision to the new one.  This field is never
+                          set in Route's status, only its spec.  This is mutually exclusive with
                           RevisionName.
                         type: string
                       latestRevision:
-                        description:
-                          LatestRevision may be optionally provided to indicate
-                          that the latest ready Revision of the Configuration
-                          should be used for this traffic target.  When provided
-                          LatestRevision must be true if RevisionName is empty;
-                          it must be false when RevisionName is non-empty.
+                        description: |-
+                          LatestRevision may be optionally provided to indicate that the latest
+                          ready Revision of the Configuration should be used for this traffic
+                          target.  When provided LatestRevision must be true if RevisionName is
+                          empty; it must be false when RevisionName is non-empty.
                         type: boolean
                       percent:
-                        description:
-                          'Percent indicates that percentage based routing
-                          should be used and the value indicates the percent of
-                          traffic that is be routed to this Revision or
-                          Configuration. `0` (zero) mean no traffic, `100` means
-                          all traffic. When percentage based routing is being
-                          used the follow rules apply: - the sum of all percent
-                          values must equal 100 - when not specified, the
-                          implied value for `percent` is zero for that
-                          particular Revision or Configuration'
+                        description: |-
+                          Percent indicates that percentage based routing should be used and
+                          the value indicates the percent of traffic that is be routed to this
+                          Revision or Configuration. `0` (zero) mean no traffic, `100` means all
+                          traffic.
+                          When percentage based routing is being used the follow rules apply:
+                          - the sum of all percent values must equal 100
+                          - when not specified, the implied value for `percent` is zero for
+                            that particular Revision or Configuration
                         format: int64
                         type: integer
                       revisionName:
-                        description:
-                          RevisionName of a specific revision to which to send
-                          this portion of traffic.  This is mutually exclusive
-                          with ConfigurationName.
+                        description: |-
+                          RevisionName of a specific revision to which to send this portion of
+                          traffic.  This is mutually exclusive with ConfigurationName.
                         type: string
                       tag:
-                        description:
-                          Tag is optionally used to expose a dedicated url for
-                          referencing this target exclusively.
+                        description: |-
+                          Tag is optionally used to expose a dedicated url for referencing
+                          this target exclusively.
                         type: string
                       url:
-                        description:
-                          URL displays the URL for accessing named traffic
-                          targets. URL is displayed in status, and is disallowed
-                          on spec. URL must contain a scheme (e.g. http://) and
-                          a hostname, but may not contain anything else (e.g.
-                          basic auth, url path, etc.)
+                        description: |-
+                          URL displays the URL for accessing named traffic targets. URL is displayed in
+                          status, and is disallowed on spec. URL must contain a scheme (e.g. http://) and
+                          a hostname, but may not contain anything else (e.g. basic auth, url path, etc.)
                         type: string
                     type: object
                   type: array
                 url:
-                  description:
-                    URL holds the url that will distribute traffic over the
-                    provided traffic targets. It generally has the form
-                    http[s]://{route-name}.{route-namespace}.{cluster-level-suffix}
+                  description: |-
+                    URL holds the url that will distribute traffic over the provided traffic targets.
+                    It generally has the form http[s]://{route-name}.{route-namespace}.{cluster-level-suffix}
                   type: string
               type: object
           type: object


### PR DESCRIPTION
Summary:
While trying to figure out why knative hates our pastebin images I
wanted to update. That wasn't possible. This is the result

- Move to battery config for image names
- Move defaults to defaults
- Update to 1.14.1

Test Plan:
- Existing tests
