### PR TITLE
fix: turn off tag resolution for ECR on knative

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/resources/knative/serving.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/resources/knative/serving.ex
@@ -245,7 +245,14 @@ defmodule CommonCore.Resources.KnativeServing do
   end
 
   resource(:config_map_deployment, battery, _state) do
-    data = %{"queue-sidecar-image" => battery.config.queue_image}
+    data = %{
+      "queue-sidecar-image" => battery.config.queue_image,
+      # AWS public ECR is not accessible on the /v2 docker enpoint
+      # without permissions.
+      #
+      # So for now we are skipping tag resolving for public.ecr.aws
+      "registries-skipping-tag-resolving" => "public.ecr.aws"
+    }
 
     :config_map
     |> B.build_resource()


### PR DESCRIPTION
Summary:
Docker tags should be immutable (except for latest type) however in
practice that's not the case. So Knative will pre-determine the sha hash
of each docker container and use that sha as the revision.

However AWS's registry requires tokens for metadata operations even
reading. So turn that off for aws.

Test Plan:
/test locally.
