### PR TITLE
fix: don't allow an empty ip for a hostname

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/resources/battery/control_server.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/resources/battery/control_server.ex
@@ -202,7 +202,9 @@ defmodule CommonCore.Resources.ControlServer do
   # assume for now that, if it's parseable, that's good enough
   defp valid_uri?(host) do
     case URI.new(host) do
-      {:ok, _} -> true
+      # Don't accept any hostnames with ".." in them
+      # That's likely becayse there was no ip
+      {:ok, uri} -> !String.contains?(uri.host, "..")
       _ -> false
     end
   end

--- a/platform_umbrella/apps/common_core/lib/common_core/state_summary/hosts.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/state_summary/hosts.ex
@@ -81,7 +81,13 @@ defmodule CommonCore.StateSummary.Hosts do
     summary |> ingress_ips() |> List.first()
   end
 
-  defp host(ip, name, group \\ "core") do
+  defp host(ip, name, group \\ "core")
+
+  defp host(nil, _name, _group), do: ""
+
+  defp host("", _name, _group), do: ""
+
+  defp host(ip, name, group) do
     "#{name}.#{group}.#{ip}.ip.batteriesincl.com"
   end
 


### PR DESCRIPTION
Summary:
Fix accepting an empty hostname

Test Plan:
Test on aws after things build
