### PR TITLE
fix: keep everything in utf-8

### DIFF
--- a/nix/platform-containers.nix
+++ b/nix/platform-containers.nix
@@ -21,6 +21,14 @@
             "${pkgs.tini}/bin/tini"
             "--"
           ];
+
+      # UTF-8 is the only encoding we support.
+      # Tell that to elixir.
+      Env = [
+        "LC_ALL=en_US.UTF-8"
+        "LANG=en_US.UTF-8"
+        "LC_CTYPE=en_US.UTF-8"
+      ];
     in
     {
       packages = {
@@ -29,7 +37,7 @@
           tag = taggedVersion;
           contents = [ self'.packages.kube-bootstrap ] ++ additionalContents;
           config = {
-            inherit Entrypoint;
+            inherit Entrypoint Env;
             Cmd = [ "bootstrap" ];
           };
         };
@@ -39,7 +47,7 @@
           tag = taggedVersion;
           contents = [ self'.packages.home-base ] ++ additionalContents;
           config = {
-            inherit Entrypoint;
+            inherit Entrypoint Env;
             Cmd = [
               "home_base"
               "start"
@@ -52,7 +60,7 @@
           tag = taggedVersion;
           contents = [ self'.packages.control-server ] ++ additionalContents;
           config = {
-            inherit Entrypoint;
+            inherit Entrypoint Env;
             Cmd = [
               "control_server"
               "start"

--- a/platform_umbrella/apps/common_core/lib/common_core/resources/battery/control_server.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/resources/battery/control_server.ex
@@ -149,6 +149,18 @@ defmodule CommonCore.Resources.ControlServer do
     |> Map.put_new("resources", %{"requests" => %{"cpu" => "1000m", "memory" => "2000Mi"}})
     |> Map.put_new("env", [
       %{
+        "name" => "LC_CTYPE",
+        "value" => "en_US.UTF-8"
+      },
+      %{
+        "name" => "LANG",
+        "value" => "en_US.UTF-8"
+      },
+      %{
+        "name" => "LC_ALL",
+        "value" => "en_US.UTF-8"
+      },
+      %{
         "name" => "PORT",
         "value" => "#{@server_port}"
       },


### PR DESCRIPTION
Summary:
Previously there were errors about lang.
This adds env to the docker images
This adds it to the containers for control-server

Fixes: #108 

Test Plan:
Local after this lands
