### PR TITLE
feat: disply a clickable link after starting an install

### DIFF
--- a/bi/pkg/access/specs.go
+++ b/bi/pkg/access/specs.go
@@ -1,0 +1,42 @@
+package access
+
+import (
+	"encoding/json"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+type AccessSpec struct {
+	Hostname string         `json:"hostname"`
+	SSL      StringableBool `json:"ssl"`
+}
+
+func (a *AccessSpec) PrintToConsole() error {
+
+	// Display a clickable URL
+	// If SSL is enabled, use https, otherwise use http
+	protocol := "http"
+	if a.SSL {
+		protocol = "https"
+	}
+	_, err := fmt.Printf("Batteries Included control server started: %s://%s\n", protocol, a.Hostname)
+	if err != nil {
+		return fmt.Errorf("failed to print control server URL: %w", err)
+	}
+	return nil
+}
+func NewFromConfigMap(config *v1.ConfigMap) (*AccessSpec, error) {
+	// Round trip the data through JSON to ensure we're getting the correct types
+	// and to avoid any potential issues with the unstructured data
+	jsonBytes, err := json.Marshal(config.Data)
+	if err != nil {
+		return nil, err
+	}
+
+	accessSpec := &AccessSpec{}
+	if err := json.Unmarshal(jsonBytes, accessSpec); err != nil {
+		return nil, err
+	}
+	return accessSpec, nil
+}

--- a/bi/pkg/access/stringable_bool.go
+++ b/bi/pkg/access/stringable_bool.go
@@ -1,0 +1,30 @@
+package access
+
+import (
+	"fmt"
+	"strings"
+)
+
+// StringableBool is a boolean that can be unmarshalled from a string
+// value of "true" or "false" or "1" or "0"
+//
+// This is useful for getting boolean values from kubernetes configmaps
+// The keys and values of which must be strings
+type StringableBool bool
+
+func (bit *StringableBool) UnmarshalJSON(data []byte) error {
+	withoutQuotes := strings.Trim(string(data), "\"")
+	switch str := strings.ToLower(withoutQuotes); str {
+	case "1":
+		*bit = true
+	case "true":
+		*bit = true
+	case "0":
+		*bit = false
+	case "false":
+		*bit = false
+	default:
+		return fmt.Errorf("invalid boolean value: %s", str)
+	}
+	return nil
+}

--- a/bi/pkg/kube/access.go
+++ b/bi/pkg/kube/access.go
@@ -1,0 +1,26 @@
+package kube
+
+import (
+	"bi/pkg/access"
+	"context"
+	"log/slog"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const controlServerInfoConfigMapName = "access-info"
+
+func (batteryKube *batteryKubeClient) GetAccessInfo(ctx context.Context, namespace string) (*access.AccessSpec, error) {
+	slog.Debug("Getting control access info", slog.String("namespace", namespace), slog.String("configMap", controlServerInfoConfigMapName))
+	config, err := batteryKube.client.CoreV1().ConfigMaps(namespace).Get(ctx, controlServerInfoConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	accessSpec, err := access.NewFromConfigMap(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return accessSpec, nil
+}

--- a/bi/pkg/kube/kube.go
+++ b/bi/pkg/kube/kube.go
@@ -1,6 +1,7 @@
 package kube
 
 import (
+	"bi/pkg/access"
 	"context"
 	"fmt"
 	"io"
@@ -40,6 +41,7 @@ type KubeClient interface {
 	RemoveAll(ctx context.Context) error
 	WaitForConnection(time.Duration) error
 	WatchFor(context.Context, *WatchOptions) error
+	GetAccessInfo(ctx context.Context, namespace string) (*access.AccessSpec, error)
 }
 
 type batteryKubeClient struct {

--- a/bi/pkg/specs/battery_spec.go
+++ b/bi/pkg/specs/battery_spec.go
@@ -25,3 +25,10 @@ func (s *InstallSpec) GetBatteryConfigField(typ, field string) (any, error) {
 	}
 	return cfg, nil
 }
+func (s *InstallSpec) GetCoreNamespace() (string, error) {
+	ns, err := s.GetBatteryConfigField("battery_core", "core_namespace")
+	if err != nil {
+		return "", err
+	}
+	return ns.(string), nil
+}

--- a/bi/pkg/specs/print.go
+++ b/bi/pkg/specs/print.go
@@ -1,0 +1,38 @@
+package specs
+
+import (
+	"bi/pkg/kube"
+	"context"
+	"fmt"
+)
+
+func (spec *InstallSpec) PrintAccessInfo(ctx context.Context, kubeClient kube.KubeClient) error {
+	// Print the control server URL
+	// This should only be called after `WaitForBootstrap`
+	inCluster, err := spec.GetBatteryConfigField("battery_core", "server_in_cluster")
+	if err != nil {
+		return fmt.Errorf("failed to determine if control server is running in cluster: %w", err)
+	}
+
+	// If we're running in dev mode then assume the control server will be run via `bix dev`
+	if !inCluster.(bool) {
+		return nil
+	}
+
+	ns, err := spec.GetCoreNamespace()
+	if err != nil {
+		return fmt.Errorf("failed to get core namespace: %w", err)
+	}
+
+	// Get the access info from kubernetes.
+	// It should be stored in a ConfigMap named "access-info"
+	// and should be there only after the control server
+	// has been bootstrapped.
+	accessSpec, err := kubeClient.GetAccessInfo(ctx, ns)
+
+	if err != nil {
+		return fmt.Errorf("failed to get access info: %w", err)
+	}
+
+	return accessSpec.PrintToConsole()
+}

--- a/bi/pkg/specs/wait.go
+++ b/bi/pkg/specs/wait.go
@@ -25,14 +25,9 @@ func (spec *InstallSpec) WaitForBootstrap(ctx context.Context, kubeClient kube.K
 		return nil
 	}
 
-	maybeNamespace, err := spec.GetBatteryConfigField("battery_core", "core_namespace")
+	ns, err := spec.GetCoreNamespace()
 	if err != nil {
 		return fmt.Errorf("failed to get core namespace: %w", err)
-	}
-
-	ns, ok := maybeNamespace.(string)
-	if !ok {
-		return fmt.Errorf("failed to get core namespace string. is type: %T", maybeNamespace)
 	}
 
 	for name, opts := range map[string]*kube.WatchOptions{
@@ -138,7 +133,7 @@ func batteryInfoConfigMapWatchOpts(ns string) *kube.WatchOptions {
 				{
 					Key:      "battery/app",
 					Operator: metav1.LabelSelectorOpIn,
-					Values:   []string{"battery-control-server"},
+					Values:   []string{"battery-access-info"},
 				},
 			},
 		})},

--- a/bi/pkg/start/start.go
+++ b/bi/pkg/start/start.go
@@ -41,5 +41,10 @@ func StartInstall(ctx context.Context, env *installs.InstallEnv) error {
 		return fmt.Errorf("failed to wait for bootstrap: %w", err)
 	}
 
+	slog.Info("Displaying access information")
+	if err := env.Spec.PrintAccessInfo(ctx, kubeClient); err != nil {
+		return fmt.Errorf("failed get and display access info: %w", err)
+	}
+
 	return nil
 }

--- a/platform_umbrella/apps/common_core/lib/common_core/installs/batteries.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/installs/batteries.ex
@@ -84,7 +84,6 @@ defmodule CommonCore.Installs.Batteries do
         |> Enum.map(fn cb -> cb.type end)
 
       _ ->
-        # TODO: This should include a control server.
         ~w(metallb)a ++ @standard_battery_types
     end
   end
@@ -105,7 +104,16 @@ defmodule CommonCore.Installs.Batteries do
     end
   end
 
-  defp provided_batteries(_install) do
-    @standard_battery_types
+  defp provided_batteries(install) do
+    case install.usage do
+      :kitchen_sink ->
+        # AWS doesn't work with some batteries
+        Catalog.all()
+        |> Enum.reject(fn cb -> cb.type in [:metallb] end)
+        |> Enum.map(fn cb -> cb.type end)
+
+      _ ->
+        ~w(metallb)a ++ @standard_battery_types
+    end
   end
 end

--- a/platform_umbrella/apps/common_core/lib/common_core/resources/battery/access.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/resources/battery/access.ex
@@ -1,0 +1,23 @@
+defmodule CommonCore.Resources.BatteryAccess do
+  @moduledoc false
+
+  use CommonCore.Resources.ResourceGenerator, app_name: "battery-access-info"
+
+  import CommonCore.StateSummary.Namespaces
+
+  alias CommonCore.Resources.Builder, as: B
+
+  resource(:info_configmap, _battery, state) do
+    case CommonCore.StateSummary.AccessSpec.new(state) do
+      {:ok, spec} ->
+        :config_map
+        |> B.build_resource()
+        |> B.name("access-info")
+        |> B.namespace(core_namespace(state))
+        |> B.data(CommonCore.StateSummary.AccessSpec.to_data(spec))
+
+      {:error, _} ->
+        nil
+    end
+  end
+end

--- a/platform_umbrella/apps/common_core/lib/common_core/resources/battery/control_server.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/resources/battery/control_server.ex
@@ -194,31 +194,4 @@ defmodule CommonCore.Resources.ControlServer do
       }
     ])
   end
-
-  resource(:info_configmap, _battery, state) do
-    host = control_host(state)
-    data = %{"hostname" => host}
-
-    :config_map
-    |> B.build_resource()
-    |> B.name("control-server-info")
-    |> B.namespace(core_namespace(state))
-    |> B.data(data)
-    |> F.require(valid_host?(host))
-  end
-
-  defp valid_host?(host) do
-    host != nil and
-      String.length(host) > 0 and
-      !String.contains?(host, "..ip.batteriesincl.com") and
-      valid_uri?(host)
-  end
-
-  # assume for now that, if it's parseable, that's good enough
-  defp valid_uri?(host) do
-    case URI.new(host) do
-      {:ok, _uri} -> true
-      _ -> false
-    end
-  end
 end

--- a/platform_umbrella/apps/common_core/lib/common_core/resources/istio/istio_ingress.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/resources/istio/istio_ingress.ex
@@ -3,7 +3,7 @@ defmodule CommonCore.Resources.IstioIngress do
   use CommonCore.Resources.ResourceGenerator, app_name: "istio-ingressgateway"
 
   import CommonCore.Resources.ProxyUtils, only: [sanitize: 1]
-  import CommonCore.StateSummary.Batteries, only: [hosts_by_battery_type: 1, batteries_installed?: 2]
+  import CommonCore.StateSummary.Batteries, only: [hosts_by_battery_type: 1]
   import CommonCore.StateSummary.Namespaces
 
   alias CommonCore.Resources.Builder, as: B
@@ -332,7 +332,7 @@ defmodule CommonCore.Resources.IstioIngress do
   resource(:gateway, _battery, state) do
     namespace = istio_namespace(state)
 
-    ssl_enabled? = batteries_installed?(state, :cert_manager)
+    ssl_enabled? = CommonCore.StateSummary.SSL.ssl_enabled?(state)
 
     servers =
       state

--- a/platform_umbrella/apps/common_core/lib/common_core/resources/resource_generator/builder.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/resources/resource_generator/builder.ex
@@ -121,7 +121,21 @@ defmodule CommonCore.Resources.Builder do
   end
 
   def spec(resource, spec), do: Map.put(resource, "spec", spec)
-  def data(resource, data), do: Map.put(resource, "data", data)
+
+  @doc """
+  Add the data field to a resource. Data is a map of key value pairs.
+  """
+  @spec data(map(), any()) :: map()
+  def data(resource, data) when is_struct(data), do: data(resource, Map.from_struct(data))
+
+  def data(resource, data) do
+    Map.put(resource, "data", Map.new(data, fn {k, v} -> {to_data_key(k), v} end))
+  end
+
+  defp to_data_key(key) when is_binary(key), do: key
+  defp to_data_key(key) when is_atom(key), do: Atom.to_string(key)
+  defp to_data_key(key), do: to_string(key)
+
   def template(resource, %{} = template), do: Map.put(resource, "template", template)
   def ports(resource, ports), do: Map.put(resource, "ports", ports)
   def rules(resource, rules), do: Map.put(resource, "rules", rules)

--- a/platform_umbrella/apps/common_core/lib/common_core/resources/root.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/resources/root.ex
@@ -4,6 +4,7 @@ defmodule CommonCore.Resources.RootResourceGenerator do
   """
   alias CommonCore.Resources.AwsLoadBalancerController
   alias CommonCore.Resources.BackendServices
+  alias CommonCore.Resources.BatteryAccess
   alias CommonCore.Resources.BatteryCA
   alias CommonCore.Resources.BatteryCore
   alias CommonCore.Resources.CertManager.Certificates
@@ -58,7 +59,7 @@ defmodule CommonCore.Resources.RootResourceGenerator do
     aws_load_balancer_controller: [AwsLoadBalancerController],
     backend_services: [BackendServices],
     battery_ca: [BatteryCA],
-    battery_core: [BatteryCore, ControlServerResources],
+    battery_core: [BatteryCore, ControlServerResources, BatteryAccess],
     cert_manager: [CertManager, Certificates],
     cloudnative_pg: [CloudnativePG, CloudnativePGClusters, CloudnativePGDashboards],
     forgejo: [Forgejo],

--- a/platform_umbrella/apps/common_core/lib/common_core/state_summary/access_spec.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/state_summary/access_spec.ex
@@ -1,0 +1,47 @@
+defmodule CommonCore.StateSummary.AccessSpec do
+  @moduledoc false
+  use TypedStruct
+
+  alias CommonCore.StateSummary
+
+  @derive Jason.Encoder
+  typedstruct do
+    field :hostname, :string
+    field :ssl, :boolean
+
+    # TODO: Add initial username and password fields
+  end
+
+  def new(%StateSummary{} = state_summary) do
+    hostname = StateSummary.Hosts.control_host(state_summary)
+
+    if valid_host?(hostname) do
+      ssl = StateSummary.SSL.ssl_enabled?(state_summary)
+      {:ok, struct!(__MODULE__, hostname: hostname, ssl: ssl)}
+    else
+      {:error, "Invalid hostname"}
+    end
+  end
+
+  def to_data(%__MODULE__{} = spec) do
+    %{
+      "hostname" => spec.hostname,
+      "ssl" => to_string(spec.ssl)
+    }
+  end
+
+  defp valid_host?(host) do
+    host != nil and
+      String.length(host) > 0 and
+      !String.contains?(host, "..ip.batteriesincl.com") and
+      valid_uri?(host)
+  end
+
+  # assume for now that, if it's parseable, that's good enough
+  defp valid_uri?(host) do
+    case URI.new(host) do
+      {:ok, _uri} -> true
+      _ -> false
+    end
+  end
+end

--- a/platform_umbrella/apps/common_core/lib/common_core/state_summary/ssl.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/state_summary/ssl.ex
@@ -1,0 +1,19 @@
+defmodule CommonCore.StateSummary.SSL do
+  @moduledoc false
+  alias CommonCore.StateSummary
+
+  @doc """
+  Returns true if SSL is to access Control Server and other istio ingress fronted services.
+  """
+  def ssl_enabled?(state) do
+    cert_manager_installed?(state) and !kind_cluster?(state)
+  end
+
+  defp kind_cluster?(state) do
+    :kind == StateSummary.Core.config_field(state, :cluster_type)
+  end
+
+  defp cert_manager_installed?(state) do
+    CommonCore.StateSummary.Batteries.batteries_installed?(state, :cert_manager)
+  end
+end

--- a/platform_umbrella/apps/common_core/lib/common_core/state_summary/urls.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/state_summary/urls.ex
@@ -2,15 +2,15 @@ defmodule CommonCore.StateSummary.URLs do
   @moduledoc false
 
   alias CommonCore.StateSummary
-  alias CommonCore.StateSummary.Batteries
   alias CommonCore.StateSummary.Hosts
+  alias CommonCore.StateSummary.SSL
 
   @spec uri_for_battery(StateSummary.t(), atom()) :: URI.t()
   def uri_for_battery(state, battery) do
     "http://#{Hosts.for_battery(state, battery)}"
     |> URI.new!()
     |> then(fn uri ->
-      if Batteries.batteries_installed?(state, :cert_manager), do: %URI{uri | scheme: "https", port: 443}, else: uri
+      if SSL.ssl_enabled?(state), do: %URI{uri | scheme: "https", port: 443}, else: uri
     end)
   end
 

--- a/platform_umbrella/apps/common_core/test/common_core/resources/istio/kiali_config_generator_test.exs
+++ b/platform_umbrella/apps/common_core/test/common_core/resources/istio/kiali_config_generator_test.exs
@@ -18,7 +18,7 @@ defmodule CommonCore.Resources.Istio.KialiConfigGeneratorTest do
     end
 
     test "sets server config to https when :cert_manager is installed" do
-      state = build(:install_spec, usage: :kitchen_sink, kube_provider: :kind).target_summary
+      state = build(:install_spec, usage: :kitchen_sink, kube_provider: :aws).target_summary
       batteries = Batteries.by_type(state)
 
       config = KialiConfigGenerator.materialize(batteries.kiali, state)
@@ -28,7 +28,7 @@ defmodule CommonCore.Resources.Istio.KialiConfigGeneratorTest do
     end
 
     test "sets server config to http when :cert_manager is not installed" do
-      state = build(:install_spec, usage: :integration_test, kube_provider: :kind).target_summary
+      state = build(:install_spec, usage: :integration_test, kube_provider: :provided).target_summary
 
       batt =
         :kiali

--- a/platform_umbrella/apps/common_core/test/common_core/state_summary/urls_test.exs
+++ b/platform_umbrella/apps/common_core/test/common_core/state_summary/urls_test.exs
@@ -12,15 +12,21 @@ defmodule CommonCore.StateSummary.URLsTest do
     end
 
     test "returns an HTTPS URI when :cert_manager is installed" do
-      summary = build(:install_spec, usage: :kitchen_sink, kube_provider: :kind).target_summary
+      summary = build(:install_spec, usage: :kitchen_sink, kube_provider: :provided).target_summary
       expected = URI.new!("https://keycloak.core.127.0.0.1.ip.batteriesincl.com")
       assert expected == uri_for_battery(summary, :keycloak)
     end
 
     test "returns an HTTP URI when :cert_manager is not installed" do
-      summary = build(:install_spec, usage: :internal_int_test, kube_provider: :kind).target_summary
+      summary = build(:install_spec, usage: :internal_int_test, kube_provider: :provided).target_summary
       expected = URI.new!("http://forgejo.core.127.0.0.1.ip.batteriesincl.com")
       assert expected == uri_for_battery(summary, :forgejo)
+    end
+
+    test "returns an HTTP URI on Kind" do
+      summary = build(:install_spec, usage: :kitchen_sink, kube_provider: :kind).target_summary
+      expected = URI.new!("http://keycloak.core.127.0.0.1.ip.batteriesincl.com")
+      assert expected == uri_for_battery(summary, :keycloak)
     end
   end
 
@@ -34,10 +40,19 @@ defmodule CommonCore.StateSummary.URLsTest do
 
   describe "cloud_native_pg_dashboard" do
     test "returns the cloud native pg dashboard URI" do
-      summary = build(:install_spec, usage: :kitchen_sink, kube_provider: :kind).target_summary
+      summary = build(:install_spec, usage: :kitchen_sink, kube_provider: :aws).target_summary
 
       expected =
         URI.new!("https://grafana.core.127.0.0.1.ip.batteriesincl.com/d/cloudnative-pg/cloudnativepg")
+
+      assert expected == cloud_native_pg_dashboard(summary)
+    end
+
+    test "returns the cloud native pg dashboard URI as http for kind" do
+      summary = build(:install_spec, usage: :kitchen_sink, kube_provider: :kind).target_summary
+
+      expected =
+        URI.new!("http://grafana.core.127.0.0.1.ip.batteriesincl.com/d/cloudnative-pg/cloudnativepg")
 
       assert expected == cloud_native_pg_dashboard(summary)
     end

--- a/platform_umbrella/apps/kube_services/test/kube_services/system_state/summary_urls_test.exs
+++ b/platform_umbrella/apps/kube_services/test/kube_services/system_state/summary_urls_test.exs
@@ -12,7 +12,7 @@ defmodule KubeServices.SystemState.SummaryURLsTest do
 
   describe "url_for_battery/2" do
     test "returns an HTTPS URL when :cert_manager is installed", %{pid: pid} do
-      sepc = build(:install_spec, usage: :kitchen_sink, kube_provider: :kind)
+      sepc = build(:install_spec, usage: :kitchen_sink, kube_provider: :aws)
       send(pid, sepc.target_summary)
 
       assert "https://keycloak.core.127.0.0.1.ip.batteriesincl.com" == SummaryURLs.url_for_battery(pid, :keycloak)
@@ -21,7 +21,7 @@ defmodule KubeServices.SystemState.SummaryURLsTest do
     end
 
     test "returns an HTTP URL when :cert_manager is not installed", %{pid: pid} do
-      spec = build(:install_spec, usage: :internal_int_test, kube_provider: :kind)
+      spec = build(:install_spec, usage: :internal_int_test, kube_provider: :provided)
       send(pid, spec.target_summary)
 
       assert "http://keycloak.core.127.0.0.1.ip.batteriesincl.com" == SummaryURLs.url_for_battery(pid, :keycloak)


### PR DESCRIPTION
Summary:
We want users to be able to very easily log into the started control
server. So print that info.

This contains a number of changes to make this possible.

- Make a method for if ssl is enabled. We can start using that
  everywhere. It will fix #115
- Add types and fields to the configmap being written.
- Move that to new modules
- Add golang code to read the configmap after waiting for it to exist.

Test Plan:
- Next commit will turn on building the images and then I'll try
