### PR TITLE
refactor: quiet k8s logs

### DIFF
--- a/platform_umbrella/config/config.exs
+++ b/platform_umbrella/config/config.exs
@@ -87,7 +87,10 @@ config :common_ui, CommonUIWeb.Endpoint,
 config :logger,
   level: :debug,
   handle_otp_reports: true,
-  handle_sasl_reports: false
+  handle_sasl_reports: false,
+  compile_time_purge_matching: [
+    [library: :k8s]
+  ]
 
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason


### PR DESCRIPTION
Summary:
I am reasonably confident that k8s is getting a bookmark. I don't need
to be told about it every 10ms for the rest of my life.

Test Plan:
mix compile
bix dev
