### PR TITLE
fix(aws): statically assign EIPs for ingress

### DIFF
--- a/bi/pkg/installs/kube_provider.go
+++ b/bi/pkg/installs/kube_provider.go
@@ -124,7 +124,31 @@ func (env *InstallEnv) configureLBControllerBattery(outputs *eksOutputs) error {
 
 	b.Config["service_role_arn"] = outputs.LBController["roleARN"].Value
 
+	eips, err := toStringSlice(outputs.LBController["eipAllocations"].Value.([]interface{}))
+	if err != nil {
+		return err
+	}
+	b.Config["eip_allocations"] = eips
+
+	subnets, err := toStringSlice(outputs.VPC["publicSubnetIDs"].Value.([]interface{}))
+	if err != nil {
+		return err
+	}
+	b.Config["subnets"] = subnets
+
 	return nil
+}
+
+func toStringSlice(maybeStrings []interface{}) ([]string, error) {
+	ss := []string{}
+	for _, in := range maybeStrings {
+		s, ok := in.(string)
+		if !ok {
+			return nil, fmt.Errorf("failed parsing output into string")
+		}
+		ss = append(ss, s)
+	}
+	return ss, nil
 }
 
 func (env *InstallEnv) configureKarpenterBattery(outputs *eksOutputs) error {

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/aws_loadbalancer_controller_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/aws_loadbalancer_controller_config.ex
@@ -8,5 +8,7 @@ defmodule CommonCore.Batteries.AwsLoadBalancerControllerConfig do
   batt_polymorphic_schema type: :aws_load_balancer_controller do
     defaultable_field :image, :string, default: Defaults.Images.aws_load_balancer_controller_image()
     field :service_role_arn, :string
+    field :subnets, {:array, :string}
+    field :eip_allocations, {:array, :string}
   end
 end

--- a/platform_umbrella/apps/common_core/lib/common_core/state_summary/access_spec.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/state_summary/access_spec.ex
@@ -34,6 +34,7 @@ defmodule CommonCore.StateSummary.AccessSpec do
     host != nil and
       String.length(host) > 0 and
       !String.contains?(host, "..ip.batteriesincl.com") and
+      !String.contains?(host, "127.0.0.1") and
       valid_uri?(host)
   end
 


### PR DESCRIPTION
This works to keep the load balancer from flapping. 

https://control.core.18.246.221.24.ip.batteriesincl.com/