### PR TITLE
feat: add progress bars for eks

### DIFF
--- a/bi/go.mod
+++ b/bi/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.9.0
 	github.com/testcontainers/testcontainers-go v0.29.1
+	github.com/vbauerster/mpb/v8 v8.7.3
 	gopkg.in/ini.v1 v1.67.0
 	k8s.io/api v0.30.1
 	k8s.io/apiextensions-apiserver v0.30.1
@@ -39,6 +40,8 @@ require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/Microsoft/hcsshim v0.11.4 // indirect
 	github.com/ProtonMail/go-crypto v1.0.0 // indirect
+	github.com/VividCortex/ewma v1.2.0 // indirect
+	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/alessio/shellescape v1.4.2 // indirect

--- a/bi/go.sum
+++ b/bi/go.sum
@@ -15,6 +15,10 @@ github.com/Microsoft/hcsshim v0.11.4 h1:68vKo2VN8DE9AdN4tnkWnmdhqdbpUFM8OF3Airm7
 github.com/Microsoft/hcsshim v0.11.4/go.mod h1:smjE4dvqPX9Zldna+t5FG3rnoHhaB7QYxPRqGcpAD9w=
 github.com/ProtonMail/go-crypto v1.0.0 h1:LRuvITjQWX+WIfr930YHG2HNfjR1uOfyf5vE0kC2U78=
 github.com/ProtonMail/go-crypto v1.0.0/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
+github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
+github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
+github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
+github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
 github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da h1:KjTM2ks9d14ZYCvmHS9iAKVt9AyzRSqNU1qabPih5BY=
@@ -426,6 +430,8 @@ github.com/uber/jaeger-client-go v2.30.0+incompatible h1:D6wyKGCecFaSRUpo8lCVbaO
 github.com/uber/jaeger-client-go v2.30.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.4.1+incompatible h1:td4jdvLcExb4cBISKIpHuGoVXh+dVKhn2Um6rjCsSsg=
 github.com/uber/jaeger-lib v2.4.1+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
+github.com/vbauerster/mpb/v8 v8.7.3 h1:n/mKPBav4FFWp5fH4U0lPpXfiOmCEgl5Yx/NM3tKJA0=
+github.com/vbauerster/mpb/v8 v8.7.3/go.mod h1:9nFlNpDGVoTmQ4QvNjSLtwLmAFjwmq0XaAF26toHGNM=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=

--- a/bi/gomod2nix.toml
+++ b/bi/gomod2nix.toml
@@ -19,6 +19,12 @@ schema = 3
   [mod."github.com/ProtonMail/go-crypto"]
     version = "v1.0.0"
     hash = "sha256-Gflazvyv+457FpUTtPafJ+SdolYSalpsU0tragTxNi8="
+  [mod."github.com/VividCortex/ewma"]
+    version = "v1.2.0"
+    hash = "sha256-mHprIVRUOgs1qyYpiMO3bh6fCzDrqasDsaTaRE0oHXI="
+  [mod."github.com/acarl005/stripansi"]
+    version = "v0.0.0-20180116102854-5a71ef0e047d"
+    hash = "sha256-Q2ejMYDBsPf7ihVntBygIhy2WYN1LixDOrXHBnWMXQs="
   [mod."github.com/adrg/xdg"]
     version = "v0.4.0"
     hash = "sha256-zGjkdUQmrVqD6rMO9oDY+TeJCpuqnHyvkPCaXDlac/U="
@@ -505,6 +511,9 @@ schema = 3
   [mod."github.com/uber/jaeger-lib"]
     version = "v2.4.1+incompatible"
     hash = "sha256-RcnLDfoiYkzUnmQAC2D2/VNGOaOXmiEcfAFcyXph6R8="
+  [mod."github.com/vbauerster/mpb/v8"]
+    version = "v8.7.3"
+    hash = "sha256-aS/k0kaJZzRCqXPGRQouxxhWzYdqJa0Z3V4usShxr24="
   [mod."github.com/xanzy/ssh-agent"]
     version = "v0.3.3"
     hash = "sha256-l3pGB6IdzcPA/HLk93sSN6NM2pKPy+bVOoacR5RC2+c="

--- a/bi/pkg/cluster/util/progress.go
+++ b/bi/pkg/cluster/util/progress.go
@@ -1,0 +1,59 @@
+package util
+
+import (
+	"github.com/pulumi/pulumi/sdk/v3/go/auto/events"
+	"github.com/vbauerster/mpb/v8"
+	"github.com/vbauerster/mpb/v8/decor"
+)
+
+// Progress is a helper for creating progress bars for Pulumi operations.
+type Progress struct {
+	progress *mpb.Progress
+}
+
+// NewProgress creates a new Progress instance.
+func NewProgress() *Progress {
+	return &Progress{
+		progress: mpb.New(),
+	}
+}
+
+// Shutdown stops all registered progress bars.
+func (p *Progress) Shutdown() {
+	p.progress.Shutdown()
+}
+
+// AddBar creates a new progress bar with the given name and initial total.
+// The returns events channel can be passed to pulumi via optup.EventStreams()
+// and optdestroy.EventStreams().
+func (p *Progress) AddBar(name string, destroy bool) chan<- events.EngineEvent {
+	bar := p.progress.AddBar(0,
+		mpb.PrependDecorators(
+			decor.Name(name, decor.WC{C: decor.DindentRight | decor.DextraSpace}),
+		),
+		mpb.AppendDecorators(
+			decor.Percentage(),
+		),
+	)
+
+	// Pulumi will close the events channel when no more events are available.
+	events := make(chan events.EngineEvent)
+	go func() {
+		var total int64
+		for event := range events {
+			if event.ResourcePreEvent != nil {
+				total++
+				bar.SetTotal(total, false)
+			} else if !destroy && event.ResOutputsEvent != nil {
+				bar.Increment()
+			} else if destroy && event.CancelEvent != nil { // Somehow cancel also means (the operation completed).
+				bar.Increment()
+			}
+		}
+
+		// Ensure the bar is at 100% when done.
+		bar.SetTotal(bar.Current(), true)
+	}()
+
+	return events
+}

--- a/bi/pkg/cluster/util/pulumi_logging.go
+++ b/bi/pkg/cluster/util/pulumi_logging.go
@@ -1,0 +1,41 @@
+package util
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+)
+
+type logWriter struct {
+	io.Writer
+}
+
+// DebugLogWriter creates a new io.Writer that logs each nnon-empty line written
+// to it at debug level.
+func DebugLogWriter(ctx context.Context, logger *slog.Logger) io.Writer {
+	pr, pw := io.Pipe()
+	go func() {
+		<-ctx.Done()
+
+		if err := pw.Close(); err != nil {
+			logger.Error("Failed to close debug log writer", slog.Any("error", err))
+		}
+	}()
+
+	go func() {
+		scanner := bufio.NewScanner(pr)
+		for scanner.Scan() {
+			msg := strings.TrimSpace(scanner.Text())
+			if msg != "" {
+				logger.Debug(msg)
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			logger.Error("Failed to read from debug log writer", slog.Any("error", err))
+		}
+	}()
+
+	return &logWriter{Writer: pw}
+}


### PR DESCRIPTION
Log pulumi raw output to the debug logs and add an events based progress bar for the pulumi components, unfortunately finer granularity progress reporting for pulumi is not really possible, maybe components could be split up a bit finer.

In a future PR, I will address progress reporting for KinD etc.

![Screenshot from 2024-06-11 19-19-30](https://github.com/batteries-included/batteries-included/assets/3140685/2842a1ec-bcad-4b0e-8002-8116c2f040f6)
