### PR TITLE
feat: run keycloak in prod mode

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/resources/sso/keycloak.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/resources/sso/keycloak.ex
@@ -154,7 +154,7 @@ defmodule CommonCore.Resources.Keycloak do
               ],
               "envFrom" => [%{"configMapRef" => %{"name" => "keycloak-env-vars"}}],
               "image" => battery.config.image,
-              "args" => ["start-dev", "--features=preview", "--metrics-enabled=true"],
+              "args" => ["start", "--features=preview", "--metrics-enabled=true"],
               "imagePullPolicy" => "IfNotPresent",
               "livenessProbe" => %{
                 "failureThreshold" => 3,


### PR DESCRIPTION
I futzed around with a bunch of settings but this seems to be sufficient to get keycloak running with "prod profile".
Is there anything else we're trying to do for #77?

Tests:
- [x] "native" sso (e.g. grafana)
- [x] auth proxy (e.g. smtp4dev) 
- [x] dev
- [x] local
- [x] aws