### PR TITLE
feat: run a genserver to check install status

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/et/install_status.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/et/install_status.ex
@@ -1,0 +1,38 @@
+defmodule CommonCore.ET.InstallStatus do
+  @moduledoc """
+  This module is used to return the status of an installation.
+  """
+  use CommonCore, :embedded_schema
+
+  batt_embedded_schema do
+    field :status, Ecto.Enum,
+      values: ~w(ok unknown needs_account needs_payment bad)a,
+      default: :unknown
+
+    field :message, :string
+  end
+
+  def status_ok?(%__MODULE__{status: :bad}), do: false
+  def status_ok?(%__MODULE__{status: :needs_payment}), do: false
+  def status_ok?(%__MODULE__{status: :needs_account}), do: false
+  def status_ok?(_), do: true
+
+  @doc ~S"""
+  Returns the path to redirect to based on the status of
+  the installation. This is to be used in the control server.
+
+  ### Examples
+      iex> InstallStatus.redirect_path(%InstallStatus{status: :needs_account})
+      "/error/needs_account"
+
+      iex> InstallStatus.redirect_path(%InstallStatus{status: :ok})
+      nil
+  """
+  @spec redirect_path(t()) :: nil | binary()
+  def redirect_path(_)
+
+  def redirect_path(%__MODULE__{status: :needs_account}), do: "/error/needs_account"
+  def redirect_path(%__MODULE__{status: :needs_payment}), do: "/error/needs_payment"
+  def redirect_path(%__MODULE__{status: :bad}), do: "/error/bad"
+  def redirect_path(_), do: nil
+end

--- a/platform_umbrella/apps/common_core/test/common_core/et/install_status_test.exs
+++ b/platform_umbrella/apps/common_core/test/common_core/et/install_status_test.exs
@@ -1,0 +1,48 @@
+defmodule CommonCore.ET.InstallStatusTest do
+  use ExUnit.Case
+
+  alias CommonCore.ET.InstallStatus
+
+  doctest CommonCore.ET.InstallStatus
+
+  describe "status_ok?/1" do
+    test "returns false when status is :bad" do
+      status = InstallStatus.new!(status: :bad)
+      assert InstallStatus.status_ok?(status) == false
+    end
+
+    test "returns false when status is :needs_payment" do
+      status = InstallStatus.new!(status: :needs_payment)
+      assert InstallStatus.status_ok?(status) == false
+    end
+
+    test "returns false when status is :needs_account" do
+      status = InstallStatus.new!(status: :needs_account)
+      assert InstallStatus.status_ok?(status) == false
+    end
+
+    test "returns true when status is :ok" do
+      # This is the best status
+      status = InstallStatus.new!(status: :ok)
+      assert InstallStatus.status_ok?(status) == true
+    end
+
+    test "returns true when status is :unknown" do
+      # This is just while we try and figure out what the status is
+      status = InstallStatus.new!(status: :unknown)
+      assert InstallStatus.status_ok?(status) == true
+    end
+  end
+
+  describe "redirect_path/1" do
+    test "returns '/error/needs_account' when status is :needs_account" do
+      status = InstallStatus.new!(status: :needs_account)
+      assert InstallStatus.redirect_path(status) == "/error/needs_account"
+    end
+
+    test "returns ni`CommonCore.Resources.MapUtilsl when status is :ok" do
+      status = InstallStatus.new!(status: :ok)
+      assert InstallStatus.redirect_path(status) == nil
+    end
+  end
+end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/router.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/router.ex
@@ -10,6 +10,7 @@ defmodule ControlServerWeb.Router do
     plug :put_root_layout, {ControlServerWeb.Layouts, :root}
     plug :protect_from_forgery
     plug :put_secure_browser_headers, ControlServerWeb.CSP.new()
+    plug KubeServices.ET.StatusPlug
   end
 
   pipeline :api do

--- a/platform_umbrella/apps/kube_services/lib/kube_services/application.ex
+++ b/platform_umbrella/apps/kube_services/lib/kube_services/application.ex
@@ -16,7 +16,7 @@ defmodule KubeServices.Application do
     res
   end
 
-  defp start_services?, do: Application.get_env(:kube_services, :start_services)
+  def start_services?, do: Application.get_env(:kube_services, :start_services)
 
   def children(true = _run) do
     [

--- a/platform_umbrella/apps/kube_services/lib/kube_services/batteries/battery_core.ex
+++ b/platform_umbrella/apps/kube_services/lib/kube_services/batteries/battery_core.ex
@@ -11,7 +11,8 @@ defmodule KubeServices.Batteries.BatteryCore do
       KubeServices.ResourceDeleter,
       {KubeServices.ET.HomeBaseClient, [home_url: CommonCore.ET.URLs.home_base_url(battery.config)]},
       {KubeServices.ET.Usage, [home_client_pid: KubeServices.ET.HomeBaseClient]},
-      {KubeServices.ET.Hosts, [home_client_pid: KubeServices.ET.HomeBaseClient]}
+      {KubeServices.ET.Hosts, [home_client_pid: KubeServices.ET.HomeBaseClient]},
+      {KubeServices.ET.InstallStatusWorker, [home_client_pid: KubeServices.ET.HomeBaseClient]}
     ]
 
     Supervisor.init(children, strategy: :one_for_one)

--- a/platform_umbrella/apps/kube_services/lib/kube_services/et/status_plug.ex
+++ b/platform_umbrella/apps/kube_services/lib/kube_services/et/status_plug.ex
@@ -1,0 +1,35 @@
+defmodule KubeServices.ET.StatusPlug do
+  @moduledoc false
+  import Plug.Conn
+
+  alias CommonCore.ET.InstallStatus
+  alias KubeServices.ET.InstallStatusWorker
+
+  def init(opts \\ []) do
+    opts
+  end
+
+  def call(conn, _opts) do
+    if KubeServices.Application.start_services?() do
+      status = InstallStatusWorker.get_status()
+      maybe_redirect(conn, status)
+    else
+      # If we are in test mode and there are no
+      # kube services running, we should
+      # assume everything is fine
+      conn
+    end
+  end
+
+  defp maybe_redirect(conn, status) do
+    if InstallStatus.status_ok?(status) do
+      conn
+    else
+      conn
+      |> resp(:found, "")
+      |> put_resp_header("location", InstallStatus.redirect_path(status))
+      |> send_resp()
+      |> halt()
+    end
+  end
+end

--- a/platform_umbrella/apps/kube_services/lib/kube_services/et/status_worker.ex
+++ b/platform_umbrella/apps/kube_services/lib/kube_services/et/status_worker.ex
@@ -1,0 +1,80 @@
+defmodule KubeServices.ET.InstallStatusWorker do
+  @moduledoc false
+
+  use GenServer
+  use TypedStruct
+
+  alias CommonCore.ET.InstallStatus
+  alias KubeServices.ET.HomeBaseClient
+
+  require Logger
+
+  typedstruct module: State do
+    field :sleep_time, integer()
+    field :home_client, pid() | atom(), default: HomeBaseClient
+    field :last_status, CommonCore.ET.InstallStatus.t(), default: nil
+  end
+
+  @state_opts ~w(sleep_time home_client_pid)a
+
+  @max_sleep_time 11 * 60 * 1000
+  @min_sleep_time 10 * 60 * 1000
+
+  @impl GenServer
+  @spec init(keyword()) :: {:ok, State.t()}
+  def init(args \\ []) do
+    min_sleep_time = Keyword.get(args, :min_sleep_time, @min_sleep_time)
+    max_sleep_time = Keyword.get(args, :max_sleep_time, @max_sleep_time)
+
+    sleep_time = :rand.uniform(max_sleep_time - min_sleep_time) + min_sleep_time
+    home_client = Keyword.get(args, :home_client, HomeBaseClient)
+
+    state = struct!(State, sleep_time: sleep_time, home_client: home_client)
+
+    _ = schedule_inital_report(state)
+    {:ok, state}
+  end
+
+  @spec start_link(Keyword.t()) :: :ignore | {:error, any()} | {:ok, pid()}
+  def start_link(opts \\ []) do
+    opts = Keyword.put_new(opts, :name, __MODULE__)
+    {state_opts, opts} = Keyword.split(opts, @state_opts)
+
+    GenServer.start_link(__MODULE__, state_opts, opts)
+  end
+
+  @spec get_status(atom() | pid() | {atom(), any()}) :: CommonCore.ET.InstallStatus.t()
+  def get_status(client \\ __MODULE__) do
+    GenServer.call(client, :get_status)
+  end
+
+  defp schedule_report(%State{sleep_time: sleep_time} = _state) do
+    Process.send_after(self(), :report, sleep_time)
+  end
+
+  defp schedule_inital_report(%State{sleep_time: _} = _state) do
+    Process.send_after(self(), :report, :rand.uniform(90) + 10)
+  end
+
+  @impl GenServer
+  def handle_info(:report, state) do
+    Logger.info("Checking on the status of the installation")
+    status_result = HomeBaseClient.get_status(state.home_client)
+    _ = schedule_report(state)
+
+    case status_result do
+      {:ok, status} ->
+        Logger.info("Status of the installation is #{inspect(status)}")
+        {:noreply, %{state | last_status: status}}
+
+      {:error, error} ->
+        Logger.error("Error checking the status of the installation: #{inspect(error)}")
+        {:noreply, state}
+    end
+  end
+
+  @impl GenServer
+  def handle_call(:get_status, _from, %{last_status: status} = state) do
+    {:reply, status || InstallStatus.new!(status: :unknown), state}
+  end
+end

--- a/platform_umbrella/apps/kube_services/lib/kube_services/et/usage.ex
+++ b/platform_umbrella/apps/kube_services/lib/kube_services/et/usage.ex
@@ -33,9 +33,9 @@ defmodule KubeServices.ET.Usage do
   @spec start_link(Keyword.t()) :: :ignore | {:error, any()} | {:ok, pid()}
   def start_link(opts \\ []) do
     opts = Keyword.put_new(opts, :name, __MODULE__)
-    {genserver_opts, opts} = Keyword.split(opts, @state_opts)
+    {init_opts, opts} = Keyword.split(opts, @state_opts)
 
-    GenServer.start_link(__MODULE__, opts, genserver_opts)
+    GenServer.start_link(__MODULE__, init_opts, opts)
   end
 
   defp schedule_report(%State{sleep_time: sleep_time} = _state) do


### PR DESCRIPTION
Summary:
- Run a gen server to check the status of an install (It's paid up, has reported usage lately, etc)
- Add a plug that will redirect if there's some issue
- Add a `InstallStatus` struct

Test Plan:
- Tests included
- All requests go through the plug so integration tests work.
