### PR TITLE
feat: remove unreferenced documents

### DIFF
--- a/platform_umbrella/apps/control_server/lib/control_server/content_addressable/reap.ex
+++ b/platform_umbrella/apps/control_server/lib/control_server/content_addressable/reap.ex
@@ -1,0 +1,42 @@
+defmodule ControlServer.ContentAddressable.Reap do
+  @moduledoc false
+
+  import Ecto.Query
+
+  alias ControlServer.ContentAddressable.Document
+  alias ControlServer.Deleted.DeletedResource
+  alias ControlServer.Repo
+  alias ControlServer.SnapshotApply.KeycloakAction
+  alias ControlServer.SnapshotApply.ResourcePath
+
+  def reap_unused_documents do
+    rp_id_subquery =
+      from rp in ResourcePath,
+        select: rp.document_id
+
+    key_action_id_subquery =
+      from ka in KeycloakAction,
+        select: ka.document_id
+
+    deleted_id_subquery =
+      from dr in DeletedResource,
+        select: dr.document_id
+
+    # Don't delete really recent documents
+    # JuUUUUUUUuuust in case there's some race somewhere
+    #
+    # Be a good neighbor and use transactions.
+    safe_delete_time = DateTime.add(DateTime.utc_now(), -90, :second)
+
+    query =
+      from d in Document,
+        where:
+          d.id not in subquery(rp_id_subquery) and
+            d.id not in subquery(key_action_id_subquery) and
+            d.id not in subquery(deleted_id_subquery) and
+            d.inserted_at < ^safe_delete_time
+
+    {count, _} = Repo.delete_all(query)
+    count
+  end
+end

--- a/platform_umbrella/apps/control_server/priv/repo/migrations/20230613204302_create_umbrella_snapshots.exs
+++ b/platform_umbrella/apps/control_server/priv/repo/migrations/20230613204302_create_umbrella_snapshots.exs
@@ -52,7 +52,7 @@ defmodule ControlServer.Repo.Migrations.CreateUmbrellaSnapshots do
       add :apply_result, :string
 
       add :kube_snapshot_id, references(:kube_snapshots, on_delete: :delete_all, type: :uuid)
-      add :document_id, references(:documents)
+      add :document_id, references(:documents, on_delete: :nothing)
 
       timestamps(type: :utc_datetime_usec)
     end
@@ -81,7 +81,8 @@ defmodule ControlServer.Repo.Migrations.CreateUmbrellaSnapshots do
 
       add :document_id, references(:documents, on_delete: :nothing)
 
-      add :keycloak_snapshot_id, references(:keycloak_snapshots, on_delete: :nothing)
+      add :keycloak_snapshot_id,
+          references(:keycloak_snapshots, on_delete: :delete_all, type: :uuid)
 
       timestamps(type: :utc_datetime_usec)
     end

--- a/platform_umbrella/apps/control_server/test/control_server/content_addressable/reaper_test.exs
+++ b/platform_umbrella/apps/control_server/test/control_server/content_addressable/reaper_test.exs
@@ -1,0 +1,39 @@
+defmodule ControlServer.ContentAddressable.ReaperTest do
+  use ControlServer.DataCase
+
+  import ControlServer.Factory
+
+  alias ControlServer.ContentAddressable.Document
+  alias ControlServer.ContentAddressable.Reap
+  alias ControlServer.Repo
+
+  describe "Reap.reap_unused_documents/1" do
+    test "leaves new documents alone" do
+      document = insert(:content_addressable_document)
+      assert Reap.reap_unused_documents() == 0
+      # This document shoudl be fine since the document is new
+      assert Repo.get!(Document, document.id) != nil
+    end
+
+    test "Removes old documents" do
+      document = insert(:content_addressable_document, inserted_at: DateTime.add(DateTime.utc_now(), -91, :second))
+      assert Reap.reap_unused_documents() == 1
+      assert Repo.get(Document, document.id) == nil
+    end
+
+    test "doesnt remove referenced rows" do
+      document = insert(:content_addressable_document, inserted_at: DateTime.add(DateTime.utc_now(), -91, :second))
+
+      umbrella = insert(:umbrella_snapshot)
+      kube = insert(:kube_snapshot, umbrella_snapshot_id: umbrella.id, status: :ok)
+
+      # Create the Resource path so the document is referenced
+      _ = insert(:resource_path, kube_snapshot_id: kube.id, document_id: document.id, hash: document.hash)
+      assert Reap.reap_unused_documents() == 0
+      # Now delete the umbrella snapshot
+      assert {:ok, _} = Repo.delete(umbrella)
+      # The document gets deleted
+      assert Reap.reap_unused_documents() == 1
+    end
+  end
+end

--- a/platform_umbrella/apps/control_server/test/support/factory.ex
+++ b/platform_umbrella/apps/control_server/test/support/factory.ex
@@ -15,6 +15,27 @@ defmodule ControlServer.Factory do
   alias CommonCore.Timeline
   alias CommonCore.Timeline.TimelineEvent
 
+  def umbrella_snapshot_factory do
+    %ControlServer.SnapshotApply.UmbrellaSnapshot{}
+  end
+
+  def kube_snapshot_factory do
+    %ControlServer.SnapshotApply.KubeSnapshot{
+      status: sequence(:status, [:creation, :generation, :applying, :ok, :error])
+    }
+  end
+
+  def resource_path_factory do
+    %ControlServer.SnapshotApply.ResourcePath{
+      path: sequence("/path/path-"),
+      # Junk hash this might break things
+      hash: Hashing.compute_hash(%{}),
+      name: sequence("resource-path-"),
+      type: sequence(:type, CommonCore.ApiVersionKind.all_known()),
+      is_success: sequence(:is_success, [true, false])
+    }
+  end
+
   def project_factory do
     %CommonCore.Projects.Project{
       name: sequence("project-"),

--- a/platform_umbrella/apps/kube_services/lib/kube_services/kube_state/resource_watcher.ex
+++ b/platform_umbrella/apps/kube_services/lib/kube_services/kube_state/resource_watcher.ex
@@ -137,7 +137,6 @@ defmodule KubeServices.KubeState.ResourceWatcher do
         {:delay, nil}
 
       _ ->
-        Logger.debug("Restarting watch on #{inspect(resource_type)}.")
         # add 6 seconds per retry. the max is configured in `start_watch` where retries is incremented.
         {:delay, trigger_start_watch((retries + 1) * @defaults.retry_secs * 1_000)}
     end


### PR DESCRIPTION
Summary:
- Add ControlServer.ContentAddressable.Reap that will remove un-needed
  documents that are older than 90 seconds
- Changed table creation to make the deletes cascade correctly
- Changed the current snapshot reaper to delete the old documents too.

Test Plan:
- Added factory methods for more content addressable structs
- Added 3 tests
