### PR TITLE
Fix the way switch inputs work with boolean values

### DIFF
--- a/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/input_test/test_checkbox_input_component_disabled.heyya_snap
+++ b/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/input_test/test_checkbox_input_component_disabled.heyya_snap
@@ -1,0 +1,12 @@
+<label phx-feedback-for="foo" class="flex flex-wrap items-center gap-x-2 cursor-pointer ">
+  <input type="hidden" name="foo" value="false" disabled>
+  <input type="checkbox" name="foo" value="true" checked class="size-5 text-primary rounded cursor-pointer bg-white dark:bg-gray-darkest-tint checked:border-primary checked:hover:border-primary border-gray-lighter dark:border-gray-darker-tint hover:border-primary" disabled>
+
+  <span class="text-sm text-gray-darkest dark:text-gray-lighter">
+    Foobar
+    
+  </span>
+
+  
+  
+</label>

--- a/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/input_test/test_switch_input_component_disabled_with_boolean.heyya_snap
+++ b/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/input_test/test_switch_input_component_disabled_with_boolean.heyya_snap
@@ -1,0 +1,14 @@
+<label phx-feedback-for="foo" class="inline-flex flex-wrap items-center justify-between gap-2 cursor-pointer select-none ">
+  <span class="text-sm text-gray-darkest dark:text-gray-lighter">Foobar</span>
+
+  <div>
+    <input type="hidden" name="foo" value="false" disabled>
+
+    <input type="checkbox" name="foo" value="true" checked class="peer sr-only" disabled>
+
+    <div class="relative w-[44px] h-[24px] rounded-full bg-gray-lightest border border-gray-lighter hover:border-primary dark:bg-gray-darkest-tint dark:border-gray-darker dark:hover:border-gray-dark after:content-[&#39;&#39;] after:absolute after:top-[3px] after:start-[3px] after:w-[16px] after:h-[16px] after:rounded-full after:bg-gray after:transition-all peer-checked:after:translate-x-[20px] peer-checked:after:bg-primary peer-disabled:cursor-not-allowed peer-disabled:hover:border-gray-lighter peer-disabled:after:bg-gray-lighter peer-checked:peer-disabled:after:bg-primary/50 dark:peer-checked:peer-disabled:after:bg-primary/50 dark:peer-disabled:hover:border-gray-darker"></div>
+  </div>
+
+  
+  
+</label>

--- a/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/input_test/test_switch_input_component_with_boolean.heyya_snap
+++ b/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/input_test/test_switch_input_component_with_boolean.heyya_snap
@@ -1,0 +1,14 @@
+<label phx-feedback-for="foo" class="inline-flex flex-wrap items-center justify-between gap-2 cursor-pointer select-none ">
+  <span class="text-sm text-gray-darkest dark:text-gray-lighter">Foobar</span>
+
+  <div>
+    <input type="hidden" name="foo" value="false">
+
+    <input type="checkbox" name="foo" value="true" checked class="peer sr-only">
+
+    <div class="relative w-[44px] h-[24px] rounded-full bg-gray-lightest border border-gray-lighter hover:border-primary dark:bg-gray-darkest-tint dark:border-gray-darker dark:hover:border-gray-dark after:content-[&#39;&#39;] after:absolute after:top-[3px] after:start-[3px] after:w-[16px] after:h-[16px] after:rounded-full after:bg-gray after:transition-all peer-checked:after:translate-x-[20px] peer-checked:after:bg-primary peer-disabled:cursor-not-allowed peer-disabled:hover:border-gray-lighter peer-disabled:after:bg-gray-lighter peer-checked:peer-disabled:after:bg-primary/50 dark:peer-checked:peer-disabled:after:bg-primary/50 dark:peer-disabled:hover:border-gray-darker"></div>
+  </div>
+
+  
+  
+</label>

--- a/platform_umbrella/apps/common_ui/test/common_ui/components/input_test.exs
+++ b/platform_umbrella/apps/common_ui/test/common_ui/components/input_test.exs
@@ -137,6 +137,14 @@ defmodule CommonUI.Components.InputTest do
       <.input type="checkbox" name="foo" label="Foobar" checked errors={["Oh no"]} />
       """
     end
+
+    component_snapshot_test "disabled" do
+      assigns = %{}
+
+      ~H"""
+      <.input type="checkbox" name="foo" label="Foobar" checked disabled />
+      """
+    end
   end
 
   describe "radio input component" do
@@ -177,6 +185,22 @@ defmodule CommonUI.Components.InputTest do
 
       ~H"""
       <.input type="switch" name="foo" value="bar" label="Foobar" checked errors={["Oh no"]} />
+      """
+    end
+
+    component_snapshot_test "with boolean" do
+      assigns = %{}
+
+      ~H"""
+      <.input type="switch" name="foo" value="true" label="Foobar" checked />
+      """
+    end
+
+    component_snapshot_test "disabled with boolean" do
+      assigns = %{}
+
+      ~H"""
+      <.input type="switch" name="foo" value="true" label="Foobar" checked disabled />
       """
     end
   end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web.ex
@@ -92,6 +92,7 @@ defmodule ControlServerWeb do
 
       import CommonUI.Gettext
       import Phoenix.HTML
+      import Phoenix.HTML.Form
 
       # Shortcut for generating JS commands
       alias Phoenix.LiveView.JS

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/ai_form.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/ai_form.ex
@@ -95,8 +95,8 @@ defmodule ControlServerWeb.Projects.AIForm do
     params =
       Map.take(params, [
         "jupyter",
-        if(params["need_postgres"] == "on" && params["db_type"] == "new", do: "postgres"),
-        if(params["need_postgres"] == "on" && params["db_type"] == "existing", do: "postgres_ids")
+        if(normalize_value("checkbox", params["need_postgres"]) && params["db_type"] == "new", do: "postgres"),
+        if(normalize_value("checkbox", params["need_postgres"]) && params["db_type"] == "existing", do: "postgres_ids")
       ])
 
     # Don't create the resources yet, send data to parent liveview
@@ -145,7 +145,7 @@ defmodule ControlServerWeb.Projects.AIForm do
 
         <.input field={@form[:need_postgres]} type="switch" label="I need a database" />
 
-        <div class={@form[:need_postgres].value != "on" && "hidden"}>
+        <div class={!normalize_value("checkbox", @form[:need_postgres].value) && "hidden"}>
           <.tab_bar variant="secondary" class="mb-6">
             <:tab
               phx-click="db_type"

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/batteries_form.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/batteries_form.ex
@@ -22,7 +22,7 @@ defmodule ControlServerWeb.Projects.BatteriesForm do
     # Turns on batteries that are required for this project
     form =
       required
-      |> Map.new(&{Atom.to_string(&1.type), "on"})
+      |> Map.new(&{Atom.to_string(&1.type), true})
       |> to_form()
 
     {:ok,
@@ -53,7 +53,7 @@ defmodule ControlServerWeb.Projects.BatteriesForm do
   """
   def handle_event("toggle", %{"_target" => [target]} = params, socket) do
     selected =
-      if params[target] == "on" do
+      if normalize_value("checkbox", params[target]) do
         socket.assigns.selected ++ [target]
       else
         Enum.reject(socket.assigns.selected, &(&1 == target))
@@ -62,7 +62,7 @@ defmodule ControlServerWeb.Projects.BatteriesForm do
     params =
       Map.merge(
         %{"search" => socket.assigns.form.params["search"]},
-        Map.new(selected, &{&1, "on"})
+        Map.new(selected, &{&1, true})
       )
 
     {:noreply,
@@ -82,7 +82,7 @@ defmodule ControlServerWeb.Projects.BatteriesForm do
 
   def handle_event("save", _params, socket) do
     # Don't actually care about the form data, we just want the selected batteries
-    params = Map.new(socket.assigns.selected, &{&1, "on"})
+    params = Map.new(socket.assigns.selected, &{&1, true})
 
     # Don't create the resources yet, send data to parent liveview
     send(self(), {:next, {__MODULE__, params}})

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/database_form.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/database_form.ex
@@ -28,7 +28,7 @@ defmodule ControlServerWeb.Projects.DatabaseForm do
 
     form =
       to_form(%{
-        "need_postgres" => "on",
+        "need_postgres" => "true",
         "postgres" => postgres_changeset,
         "redis" => redis_changeset
       })
@@ -89,8 +89,8 @@ defmodule ControlServerWeb.Projects.DatabaseForm do
   def handle_event("save", params, socket) do
     params =
       Map.take(params, [
-        if(params["need_postgres"] == "on", do: "postgres"),
-        if(params["need_redis"] == "on", do: "redis")
+        if(normalize_value("checkbox", params["need_postgres"]), do: "postgres"),
+        if(normalize_value("checkbox", params["need_redis"]), do: "redis")
       ])
 
     # Don't create the resources yet, send data to parent liveview
@@ -116,7 +116,7 @@ defmodule ControlServerWeb.Projects.DatabaseForm do
         <.input field={@form[:need_postgres]} type="switch" label="I need a postgres instance" />
 
         <PostgresFormSubcomponents.size_form
-          class={@form[:need_postgres].value != "on" && "hidden"}
+          class={!normalize_value("checkbox", @form[:need_postgres].value) && "hidden"}
           form={to_form(@form[:postgres].value, as: :postgres)}
           phx_target={@myself}
           ticks={PGCluster.compact_storage_range_ticks()}
@@ -125,7 +125,7 @@ defmodule ControlServerWeb.Projects.DatabaseForm do
         <.input field={@form[:need_redis]} type="switch" label="I need a redis instance" />
 
         <RedisFormSubcomponents.size_form
-          class={@form[:need_redis].value != "on" && "hidden"}
+          class={!normalize_value("checkbox", @form[:need_redis].value) && "hidden"}
           form={to_form(@form[:redis].value, as: :redis)}
         />
 

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/web_form.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/web_form.ex
@@ -98,7 +98,7 @@ defmodule ControlServerWeb.Projects.WebForm do
         "project_type",
         if(params["db_type"] == "new", do: "postgres"),
         if(params["db_type"] == "existing", do: "postgres_ids"),
-        if(params["need_redis"] == "on", do: "redis")
+        if(normalize_value("checkbox", params["need_redis"]), do: "redis")
       ])
 
     # Don't create the resources yet, send data to parent liveview
@@ -168,7 +168,7 @@ defmodule ControlServerWeb.Projects.WebForm do
         <.input field={@form[:need_redis]} type="switch" label="I need a redis instance" />
 
         <RedisFormSubcomponents.size_form
-          class={@form[:need_redis].value != "on" && "hidden"}
+          class={!normalize_value("checkbox", @form[:need_redis].value) && "hidden"}
           form={to_form(@form[:redis].value, as: :redis)}
         />
 

--- a/platform_umbrella/apps/home_base_web/lib/home_base_web.ex
+++ b/platform_umbrella/apps/home_base_web/lib/home_base_web.ex
@@ -100,6 +100,7 @@ defmodule HomeBaseWeb do
 
       import CommonUI.Gettext
       import Phoenix.HTML
+      import Phoenix.HTML.Form
 
       # Shortcut for generating JS commands
       alias Phoenix.LiveView.JS

--- a/platform_umbrella/apps/home_base_web/lib/home_base_web/live/installation/index_live.ex
+++ b/platform_umbrella/apps/home_base_web/lib/home_base_web/live/installation/index_live.ex
@@ -127,7 +127,7 @@ defmodule HomeBaseWeb.InstallationLive do
         <.input field={@form[:sso_enabled]} type="switch" label="Use Single Sign On" />
 
         <.input
-          :if={@form[:sso_enabled].value}
+          :if={normalize_value("checkbox", @form[:sso_enabled].value)}
           field={@form[:initial_oauth_email]}
           placeholder="Initial OAuth Email"
         />

--- a/platform_umbrella/apps/home_base_web/lib/home_base_web/live/installation/show_live.ex
+++ b/platform_umbrella/apps/home_base_web/lib/home_base_web/live/installation/show_live.ex
@@ -116,8 +116,8 @@ defmodule HomeBaseWeb.InstallationShowLive do
         <.input field={@form[:sso_enabled]} type="switch" label="Use Single Sign On" />
 
         <.input
+          :if={normalize_value("checkbox", @form[:sso_enabled].value)}
           field={@form[:initial_oauth_email]}
-          class={@form[:sso_enabled].value != "on" && "hidden"}
           placeholder="Initial OAuth Email"
         />
 


### PR DESCRIPTION
This PR fixes the way switch inputs handle boolean inputs. Rather than passing an empty value to the input tag if nothing is defined (which makes the browser default to "on" and "off"), it uses the same hidden input trick as the checkbox with "true" and "false". Requires the usage of [Phoenix.HTML.Form.normalize_value/2](https://hexdocs.pm/phoenix_html/Phoenix.HTML.Form.html#normalize_value/2) when using the raw form value anywhere else.

[See this discussion in Slack.](https://batteries-included.slack.com/archives/C077UVAP13M/p1718380577027399)