### PR TITLE
feat: hook up status worker and status api

### DIFF
--- a/bootstrap/damian.install.json
+++ b/bootstrap/damian.install.json
@@ -1,20 +1,20 @@
 {
-  "id": "batt_01902a1b14a57f419fbf8065a8951cab",
+  "id": "batt_01903204fc9b7b72926ae64af26ff22c",
   "usage": "internal_dev",
-  "inserted_at": null,
-  "updated_at": null,
   "default_size": "small",
   "control_jwk": {
     "crv": "Ed25519",
-    "d": "rGqaSm8bTRHswqVI3mXJdrusBti5rdOB-fNkLbWyLOU",
+    "d": "6Npp_nMpkvFZn8AneNf3Do0_zcKvY-UewI4qZPM8Itw",
     "kty": "OKP",
-    "x": "emJcsXrUXxpCFLjIeDiT_-4ApiSL9Px3J-LPfAgpG8k"
+    "x": "p9HKQoO0vXLso5siDKtAm_TuKfpLa9lyfAVdUQqGHTQ"
   },
+  "inserted_at": null,
+  "updated_at": null,
   "slug": "damian",
   "kube_provider": "aws",
   "kube_provider_config": {},
   "sso_enabled": false,
   "initial_oauth_email": null,
   "user_id": null,
-  "team_id": "batt_01902a1b147376018d018eca4ece4958"
+  "team_id": "batt_01903204fc4b7e8293da31c980058ac4"
 }

--- a/bootstrap/damian.spec.json
+++ b/bootstrap/damian.spec.json
@@ -8,26 +8,26 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_01902a1b14c374d1a6b1b675a32dbb07",
+        "id": "batt_01903204fcbf7614adec6cae8b2dd4c0",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
           "image": "public.ecr.aws/batteries-included/control-server:latest",
           "cluster_type": "aws",
-          "cluster_name": "damian",
           "core_namespace": "battery-core",
           "base_namespace": "battery-base",
           "data_namespace": "battery-data",
           "ai_namespace": "battery-ai",
           "bootstrap_image": "public.ecr.aws/batteries-included/kube-bootstrap:latest",
           "default_size": "small",
+          "cluster_name": "damian",
           "server_in_cluster": false,
-          "install_id": "batt_01902a1b14a57f419fbf8065a8951cab",
+          "install_id": "batt_01903204fc9b7b72926ae64af26ff22c",
           "control_jwk": {
             "crv": "Ed25519",
-            "d": "rGqaSm8bTRHswqVI3mXJdrusBti5rdOB-fNkLbWyLOU",
+            "d": "6Npp_nMpkvFZn8AneNf3Do0_zcKvY-UewI4qZPM8Itw",
             "kty": "OKP",
-            "x": "emJcsXrUXxpCFLjIeDiT_-4ApiSL9Px3J-LPfAgpG8k"
+            "x": "p9HKQoO0vXLso5siDKtAm_TuKfpLa9lyfAVdUQqGHTQ"
           },
           "image_override": null,
           "bootstrap_image_override": null
@@ -37,7 +37,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01902a1b14c37e2a980d95261deeb721",
+        "id": "batt_01903204fcbf7002a890102d65be2893",
         "type": "karpenter",
         "config": {
           "type": "karpenter",
@@ -52,7 +52,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01902a1b14c37bc28b062253cf9dd00c",
+        "id": "batt_01903204fcbf7f9c8c361de2887d849c",
         "type": "cert_manager",
         "config": {
           "type": "cert_manager",
@@ -62,18 +62,18 @@
           "controller_image": "quay.io/jetstack/cert-manager-controller:v1.14.6",
           "ctl_image": "quay.io/jetstack/cert-manager-ctl:v1.14.6",
           "webhook_image": "quay.io/jetstack/cert-manager-webhook:v1.14.6",
+          "controller_image_override": null,
+          "webhook_image_override": null,
           "acmesolver_image_override": null,
           "cainjector_image_override": null,
-          "controller_image_override": null,
-          "ctl_image_override": null,
-          "webhook_image_override": null
+          "ctl_image_override": null
         },
         "group": "net_sec",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_01902a1b14c375ba9625dcee59407ee7",
+        "id": "batt_01903204fcbf71449a59d7bb233ee9a5",
         "type": "battery_ca",
         "config": {
           "type": "battery_ca"
@@ -83,7 +83,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01902a1b14c3747b84f66ddaac6fd3f0",
+        "id": "batt_01903204fcbf79578cb132938256c77a",
         "type": "aws_load_balancer_controller",
         "config": {
           "type": "aws_load_balancer_controller",
@@ -98,7 +98,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01902a1b14c37ba29448840075a8c5b1",
+        "id": "batt_01903204fcbf7936a6c7fa5a49576315",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
@@ -110,7 +110,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01902a1b14c37a42b9a783a5b20e13d9",
+        "id": "batt_01903204fcbf7a3e9d897794e060cb76",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -124,7 +124,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01902a1b14c37fef96ef85a89a5b0ef1",
+        "id": "batt_01903204fcbf74a98fb6d5390602054e",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -136,7 +136,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01902a1b14c378c6a01517cbee2529ca",
+        "id": "batt_01903204fcbf7c08b1d5f54fd7faa8d6",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -158,9 +158,15 @@
           "name": "control",
           "owner": "battery-control-user"
         },
+        "storage_class": null,
+        "cpu_requested": 500,
+        "cpu_limits": 2000,
+        "memory_requested": 1073741824,
+        "memory_limits": 4294967296,
+        "num_instances": 1,
+        "virtual_size": "small",
         "inserted_at": null,
         "updated_at": null,
-        "project_id": null,
         "users": [
           {
             "position": null,
@@ -172,19 +178,13 @@
           {
             "position": null,
             "username": "battery-control-user",
-            "password": "FEJ2HGWLBM3ZJTKTICS65L3W",
+            "password": "WHFKHXXCBRGLYYUUVW4XKXQ3",
             "roles": ["createdb", "login"],
             "credential_namespaces": ["battery-core"]
           }
         ],
-        "cpu_requested": 500,
-        "cpu_limits": 2000,
-        "memory_requested": 1073741824,
-        "memory_limits": 4294967296,
-        "storage_class": null,
-        "num_instances": 1,
-        "virtual_size": "small",
         "storage_size": 17179869184,
+        "project_id": null,
         "virtual_storage_size_range_value": 287219363990
       }
     ],
@@ -200,7 +200,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "QTREOJBKSFWH2QIX2XWA2OH4BAXCAWVJMAG7YYEFGC7EJKWZSTEQ===="
+          "battery/hash": "QZMMJDRXKFTJMJ2CRZLHZZVFDPTZHEYUGGQAAYCXZPF6RHQAGLRA===="
         },
         "labels": {
           "app": "battery-core",
@@ -210,7 +210,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01902a1b14c374d1a6b1b675a32dbb07",
+          "battery/owner": "batt_01903204fcbf7614adec6cae8b2dd4c0",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -223,7 +223,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "PJNIMSCHY2JWUDHHIS6XY7TB4Z2WX6RVJACXINLORGE7YDY5BPTA====",
+          "battery/hash": "HMXJ4TJTLCDG365WJXK2WGEYUMG4PK3AC26RL3GTT5V3TQWC2LJA====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -234,7 +234,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01902a1b14c374d1a6b1b675a32dbb07",
+          "battery/owner": "batt_01903204fcbf7614adec6cae8b2dd4c0",
           "version": "latest"
         },
         "name": "gp2"
@@ -249,7 +249,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "V65PKNPPRYCLTFILIHQYTPSU4ZYS24OAUF4NB4MA7KGQS6Y5AZWA====",
+          "battery/hash": "A64ULFTTM6HJQW2MCKEJNKYKNTGXNH6ABU2QWBO4BCIFNEOWQFIQ====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -260,7 +260,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01902a1b14c374d1a6b1b675a32dbb07",
+          "battery/owner": "batt_01903204fcbf7614adec6cae8b2dd4c0",
           "version": "latest"
         },
         "name": "gp2-90032408"
@@ -280,7 +280,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "2LT2ONX2PIMV3YE2U6RKHZ3V546RT3NHNWDTA2F4SKTLEPOWIAJQ====",
+          "battery/hash": "V47ZKKHUEWXUQ3VBRE4BEHQ5AUJZSKFL2FSDCAVEPLRMQAGZS2OQ====",
           "storageclass.kubernetes.io/is-default-class": "true"
         },
         "labels": {
@@ -291,7 +291,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01902a1b14c374d1a6b1b675a32dbb07",
+          "battery/owner": "batt_01903204fcbf7614adec6cae8b2dd4c0",
           "version": "latest"
         },
         "name": "gp3-105457460"

--- a/bootstrap/dev.install.json
+++ b/bootstrap/dev.install.json
@@ -1,20 +1,20 @@
 {
-  "id": "batt_01902a1b147571debff6a45ae62a0285",
+  "id": "batt_01903204fc6a772e987dfcd8c644debf",
   "usage": "internal_dev",
-  "inserted_at": null,
-  "updated_at": null,
   "default_size": "tiny",
   "control_jwk": {
     "crv": "Ed25519",
-    "d": "9OOG10XDxHZ95M766QBsUdx9V6w1S2XrUx-uZ_hu-WU",
+    "d": "Qsd0a0dQ3crQB-cIwcI6tdXeDtegSA3l48sM-qozPiE",
     "kty": "OKP",
-    "x": "B5qhzJ6oYirbvBx2xV6zaufJVPqNkH0tz9PeQSn6fdY"
+    "x": "kRHknxeTfdGwBkFzWzlxpi1WtUQNNGqMK35JTiNO9VU"
   },
+  "inserted_at": null,
+  "updated_at": null,
   "slug": "dev",
   "kube_provider": "kind",
   "kube_provider_config": {},
   "sso_enabled": false,
   "initial_oauth_email": null,
   "user_id": null,
-  "team_id": "batt_01902a1b147376018d018eca4ece4958"
+  "team_id": "batt_01903204fc4b7e8293da31c980058ac4"
 }

--- a/bootstrap/dev.spec.json
+++ b/bootstrap/dev.spec.json
@@ -8,7 +8,7 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_01902a1b14a77870951ee13d84fdf465",
+        "id": "batt_01903204fc9e72628b2daa304c3b4404",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -22,7 +22,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01902a1b14a870bd8fc3076e418645aa",
+        "id": "batt_01903204fca07dfaaeccd8c1f3d42ae4",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -34,26 +34,26 @@
         "updated_at": null
       },
       {
-        "id": "batt_01902a1b14a97a9097bb2a12add9afd8",
+        "id": "batt_01903204fca07954bb19a7811af62661",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
           "image": "public.ecr.aws/batteries-included/control-server:latest",
           "cluster_type": "kind",
-          "cluster_name": "dev",
           "core_namespace": "battery-core",
           "base_namespace": "battery-base",
           "data_namespace": "battery-data",
           "ai_namespace": "battery-ai",
           "bootstrap_image": "public.ecr.aws/batteries-included/kube-bootstrap:latest",
           "default_size": "tiny",
+          "cluster_name": "dev",
           "server_in_cluster": false,
-          "install_id": "batt_01902a1b147571debff6a45ae62a0285",
+          "install_id": "batt_01903204fc6a772e987dfcd8c644debf",
           "control_jwk": {
             "crv": "Ed25519",
-            "d": "9OOG10XDxHZ95M766QBsUdx9V6w1S2XrUx-uZ_hu-WU",
+            "d": "Qsd0a0dQ3crQB-cIwcI6tdXeDtegSA3l48sM-qozPiE",
             "kty": "OKP",
-            "x": "B5qhzJ6oYirbvBx2xV6zaufJVPqNkH0tz9PeQSn6fdY"
+            "x": "kRHknxeTfdGwBkFzWzlxpi1WtUQNNGqMK35JTiNO9VU"
           },
           "image_override": null,
           "bootstrap_image_override": null
@@ -63,15 +63,15 @@
         "updated_at": null
       },
       {
-        "id": "batt_01902a1b14ab7daa892e8e1e782ed64d",
+        "id": "batt_01903204fca472fa91c6c911d2d11f12",
         "type": "metallb",
         "config": {
           "type": "metallb",
           "controller_image": "quay.io/metallb/controller:v0.13.12",
           "speaker_image": "quay.io/metallb/speaker:v0.13.12",
           "frrouting_image": "quay.io/frrouting/frr:8.5.4",
-          "controller_image_override": null,
           "speaker_image_override": null,
+          "controller_image_override": null,
           "frrouting_image_override": null
         },
         "group": "net_sec",
@@ -79,7 +79,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01902a1b14ac7986ab28654655aae32d",
+        "id": "batt_01903204fca47b34bbb5a535dcdf0ee8",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
@@ -91,7 +91,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01902a1b14ad743db4e53009798836c4",
+        "id": "batt_01903204fca5768894fb300bc305371b",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -113,9 +113,15 @@
           "name": "control",
           "owner": "battery-control-user"
         },
+        "storage_class": null,
+        "cpu_requested": 500,
+        "cpu_limits": 500,
+        "memory_requested": 536870912,
+        "memory_limits": 536870912,
+        "num_instances": 1,
+        "virtual_size": "tiny",
         "inserted_at": null,
         "updated_at": null,
-        "project_id": null,
         "users": [
           {
             "position": null,
@@ -127,19 +133,13 @@
           {
             "position": null,
             "username": "battery-control-user",
-            "password": "H22RCNCA2PURTDBQGPK3MF66",
+            "password": "DZWB7UQFUD2ZVKYE2D3OZYWJ",
             "roles": ["createdb", "login"],
             "credential_namespaces": ["battery-core"]
           }
         ],
-        "cpu_requested": 500,
-        "cpu_limits": 500,
-        "memory_requested": 536870912,
-        "memory_limits": 536870912,
-        "storage_class": null,
-        "num_instances": 1,
-        "virtual_size": "tiny",
         "storage_size": 536870912,
+        "project_id": null,
         "virtual_storage_size_range_value": 5035931120
       }
     ],
@@ -155,7 +155,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "PUDK56WSXHOJP6BQQGBM6LWE4LFLOYO6MSN2NOXRQJV7EEL22YWA===="
+          "battery/hash": "PEYD5XG4W245UY4UK5I7Y5LDQG7M3RYZ7V6SRLFJ4H2XYEMFDJNA===="
         },
         "labels": {
           "app": "battery-core",
@@ -165,7 +165,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01902a1b14a97a9097bb2a12add9afd8",
+          "battery/owner": "batt_01903204fca07954bb19a7811af62661",
           "istio-injection": "enabled",
           "version": "latest"
         },

--- a/bootstrap/elliott.install.json
+++ b/bootstrap/elliott.install.json
@@ -1,20 +1,20 @@
 {
-  "id": "batt_01902a1b14a572c5b867dc36165cae80",
+  "id": "batt_01903204fc9b776daf43847ef8321154",
   "usage": "development",
-  "inserted_at": null,
-  "updated_at": null,
   "default_size": "small",
   "control_jwk": {
     "crv": "Ed25519",
-    "d": "_vjP5IK49G2oqjgMykjBxgOUAAS1IuGfKSouIAlGuf4",
+    "d": "A93aW-dv71JhnJlghs9__2XrsEqPMMRu2DRpypO3xvA",
     "kty": "OKP",
-    "x": "14TsJ2kIu8fdt1AFztw39H_T9K5FvFHOM5r6-nm43-8"
+    "x": "dhf_zuNfrPYqaoHMy6XfrKvAyEwEYSmt-Uh31FB_Qqk"
   },
+  "inserted_at": null,
+  "updated_at": null,
   "slug": "elliott",
   "kube_provider": "aws",
   "kube_provider_config": {},
   "sso_enabled": false,
   "initial_oauth_email": null,
   "user_id": null,
-  "team_id": "batt_01902a1b147376018d018eca4ece4958"
+  "team_id": "batt_01903204fc4b7e8293da31c980058ac4"
 }

--- a/bootstrap/elliott.spec.json
+++ b/bootstrap/elliott.spec.json
@@ -8,26 +8,26 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_01902a1b14bf720696fa5dcbe5151c93",
+        "id": "batt_01903204fcba70a0a01e786b6414f2c7",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
           "image": "public.ecr.aws/batteries-included/control-server:latest",
           "cluster_type": "aws",
-          "cluster_name": "elliott",
           "core_namespace": "battery-core",
           "base_namespace": "battery-base",
           "data_namespace": "battery-data",
           "ai_namespace": "battery-ai",
           "bootstrap_image": "public.ecr.aws/batteries-included/kube-bootstrap:latest",
           "default_size": "small",
+          "cluster_name": "elliott",
           "server_in_cluster": true,
-          "install_id": "batt_01902a1b14a572c5b867dc36165cae80",
+          "install_id": "batt_01903204fc9b776daf43847ef8321154",
           "control_jwk": {
             "crv": "Ed25519",
-            "d": "_vjP5IK49G2oqjgMykjBxgOUAAS1IuGfKSouIAlGuf4",
+            "d": "A93aW-dv71JhnJlghs9__2XrsEqPMMRu2DRpypO3xvA",
             "kty": "OKP",
-            "x": "14TsJ2kIu8fdt1AFztw39H_T9K5FvFHOM5r6-nm43-8"
+            "x": "dhf_zuNfrPYqaoHMy6XfrKvAyEwEYSmt-Uh31FB_Qqk"
           },
           "image_override": null,
           "bootstrap_image_override": null
@@ -37,7 +37,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01902a1b14bf7df18476a17e579ff80b",
+        "id": "batt_01903204fcba7834bdd7135cfb7467a5",
         "type": "karpenter",
         "config": {
           "type": "karpenter",
@@ -52,7 +52,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01902a1b14c0776b9bb3cf91a622e908",
+        "id": "batt_01903204fcbb7758a37b6cb21d190969",
         "type": "cert_manager",
         "config": {
           "type": "cert_manager",
@@ -62,18 +62,18 @@
           "controller_image": "quay.io/jetstack/cert-manager-controller:v1.14.6",
           "ctl_image": "quay.io/jetstack/cert-manager-ctl:v1.14.6",
           "webhook_image": "quay.io/jetstack/cert-manager-webhook:v1.14.6",
+          "controller_image_override": null,
+          "webhook_image_override": null,
           "acmesolver_image_override": null,
           "cainjector_image_override": null,
-          "controller_image_override": null,
-          "ctl_image_override": null,
-          "webhook_image_override": null
+          "ctl_image_override": null
         },
         "group": "net_sec",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_01902a1b14c174faa2e5a8bb9d29d4ce",
+        "id": "batt_01903204fcbc738da14973bf7a08899c",
         "type": "battery_ca",
         "config": {
           "type": "battery_ca"
@@ -83,7 +83,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01902a1b14c271d3ab867a4e0c32120f",
+        "id": "batt_01903204fcbd7391832e95d947c23738",
         "type": "aws_load_balancer_controller",
         "config": {
           "type": "aws_load_balancer_controller",
@@ -98,7 +98,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01902a1b14c27eb0b8d3da0f24c44ecb",
+        "id": "batt_01903204fcbe798a948bea8c20e1a1c7",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
@@ -110,7 +110,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01902a1b14c27002b32b89046d3acafa",
+        "id": "batt_01903204fcbe7f80be91a5f0608ddecd",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -124,7 +124,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01902a1b14c27b9493ade395e2b88a39",
+        "id": "batt_01903204fcbe7cc2ad256aba80c5fc5e",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -136,7 +136,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01902a1b14c27903b0c8d4f357d77962",
+        "id": "batt_01903204fcbe79698d71364e1045f904",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -158,26 +158,26 @@
           "name": "control",
           "owner": "battery-control-user"
         },
-        "inserted_at": null,
-        "updated_at": null,
-        "project_id": null,
-        "users": [
-          {
-            "position": null,
-            "username": "battery-control-user",
-            "password": "K4VLFXSUM6Z5NX3HYSOGZBDW",
-            "roles": ["createdb", "login"],
-            "credential_namespaces": ["battery-core"]
-          }
-        ],
+        "storage_class": null,
         "cpu_requested": 500,
         "cpu_limits": 2000,
         "memory_requested": 1073741824,
         "memory_limits": 4294967296,
-        "storage_class": null,
         "num_instances": 1,
         "virtual_size": "small",
+        "inserted_at": null,
+        "updated_at": null,
+        "users": [
+          {
+            "position": null,
+            "username": "battery-control-user",
+            "password": "GHEZ74MOD5ROZV3JVKJ4YNAS",
+            "roles": ["createdb", "login"],
+            "credential_namespaces": ["battery-core"]
+          }
+        ],
         "storage_size": 17179869184,
+        "project_id": null,
         "virtual_storage_size_range_value": 287219363990
       }
     ],
@@ -193,7 +193,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "43O47D2KX2YYF64AUQ4HHAM2B7VSXEZXU5JX6JEEWGQK42PR6E3Q===="
+          "battery/hash": "TE7CP3DTO7D6XIQNWHIGWO4ZH33BD4SOZBN4T43VXHDXKH3OTJOQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -203,7 +203,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01902a1b14bf720696fa5dcbe5151c93",
+          "battery/owner": "batt_01903204fcba70a0a01e786b6414f2c7",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -226,7 +226,7 @@
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "C3XDOQVBGUE366ACUHCO3GYBEZIKOKONFFILJFHAZU2GTO4ZABWQ===="
+          "battery/hash": "ZY7BSXUTWL3RPGQNXLPXUIVL55B253GM5TMG6P6LVQ2EJJPHO6BQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -236,7 +236,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01902a1b14bf720696fa5dcbe5151c93",
+          "battery/owner": "batt_01903204fcba70a0a01e786b6414f2c7",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -260,7 +260,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_01902a1b14bf720696fa5dcbe5151c93",
+              "battery/owner": "batt_01903204fcba70a0a01e786b6414f2c7",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -273,7 +273,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "J2LRATUZ6QNA27323CCWANRUMDINP2SQK5N6JLD46W2HQB7SMIJUTOVB2DV62WQC"
+                    "value": "YVOQBXJGWDTSNTQDRF7AQFWRXD7RUNW7B5VZ3DBBVGKJT2Z664RY4YLXYFOSG5VD"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -321,7 +321,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "HL5XT6CXLL6CZPE3DQR43YCQV6IBZII3FTPRR3VXK4PHGGP4TNWA===="
+          "battery/hash": "56YF7Q2FMSC7NNYL4BDMGGAGI6QS5N6CEMYSV4OPKFY2D77ONGWA===="
         },
         "labels": {
           "app": "battery-core",
@@ -331,7 +331,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01902a1b14bf720696fa5dcbe5151c93",
+          "battery/owner": "batt_01903204fcba70a0a01e786b6414f2c7",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -343,7 +343,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "TJEK4ZJYIJU6NHR2EAIFXNG5C5QQOV3ETTU6DO5LD3LASNXUKAVA===="
+          "battery/hash": "H5XF3HIALX73G7ARQGY755Y4XEQYBDO77TW4JY5SAM2GSMU5P7QQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -353,7 +353,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01902a1b14bf720696fa5dcbe5151c93",
+          "battery/owner": "batt_01903204fcba70a0a01e786b6414f2c7",
           "version": "latest"
         },
         "name": "bootstrap",
@@ -366,7 +366,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "OCSM6ES2OG6ZXXRFVT3QDLDD637EMQMXIR6Y2JTPYI2HGDOTVNYA====",
+          "battery/hash": "KAYU5GNLHF3XHL47UZVYKOZEBVCV32XYPP7DIMASESUVZOPZVEMA====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -377,7 +377,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01902a1b14bf720696fa5dcbe5151c93",
+          "battery/owner": "batt_01903204fcba70a0a01e786b6414f2c7",
           "version": "latest"
         },
         "name": "gp2"
@@ -392,7 +392,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "JFQVBNJIUWYX4AYZKLJCKHZGQTGPQGFFK4MJL3RSMDQ3O657BC3Q====",
+          "battery/hash": "OPI4RHIRRZKXT6AHW2NX5MVIJ5WYD5TRP2G2ZAH7ERM73RGIGMMA====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -403,7 +403,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01902a1b14bf720696fa5dcbe5151c93",
+          "battery/owner": "batt_01903204fcba70a0a01e786b6414f2c7",
           "version": "latest"
         },
         "name": "gp2-90032408"
@@ -423,7 +423,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "O3G5PIFP3VHUY3VL5Z4TL3LXMU5H6IC4FNOF6MC7WTFLGFR4GUCQ====",
+          "battery/hash": "QPHLVQHHSK7CAY4SGP7CHCI73VUIK2EW4VYFXS7GVK54VVZFTZWQ====",
           "storageclass.kubernetes.io/is-default-class": "true"
         },
         "labels": {
@@ -434,7 +434,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01902a1b14bf720696fa5dcbe5151c93",
+          "battery/owner": "batt_01903204fcba70a0a01e786b6414f2c7",
           "version": "latest"
         },
         "name": "gp3-105457460"

--- a/bootstrap/integration-test.install.json
+++ b/bootstrap/integration-test.install.json
@@ -1,20 +1,20 @@
 {
-  "id": "batt_01902a1b14a57306ae9f596d7ee91221",
+  "id": "batt_01903204fc9b7b2c859d62860eaa96b7",
   "usage": "internal_int_test",
-  "inserted_at": null,
-  "updated_at": null,
   "default_size": "tiny",
   "control_jwk": {
     "crv": "Ed25519",
-    "d": "lWU0-QQ6m24dCra6AdZW-lIYl3hMw3Go_AScodWQLyo",
+    "d": "WSMEFS5tsnOZSr_SBJXGA2jhttdiTqUeIj3wVopMq4E",
     "kty": "OKP",
-    "x": "Kdbix5pFg5LMu0-fhHswMpcXNXLZh-WOaTEpjsesxOo"
+    "x": "wamaPSqAPy0X0ERAv11k_d0uh-QwrZcwtudRLAJHcL4"
   },
+  "inserted_at": null,
+  "updated_at": null,
   "slug": "integration-test",
   "kube_provider": "kind",
   "kube_provider_config": {},
   "sso_enabled": false,
   "initial_oauth_email": null,
   "user_id": null,
-  "team_id": "batt_01902a1b147376018d018eca4ece4958"
+  "team_id": "batt_01903204fc4b7e8293da31c980058ac4"
 }

--- a/bootstrap/integration-test.spec.json
+++ b/bootstrap/integration-test.spec.json
@@ -8,26 +8,26 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_01902a1b14c373c3950694a6cc624612",
+        "id": "batt_01903204fcbf76509f9203b8a39ec6b3",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
           "image": "public.ecr.aws/batteries-included/control-server:latest",
           "cluster_type": "kind",
-          "cluster_name": "integration-test",
           "core_namespace": "battery-core",
           "base_namespace": "battery-base",
           "data_namespace": "battery-data",
           "ai_namespace": "battery-ai",
           "bootstrap_image": "public.ecr.aws/batteries-included/kube-bootstrap:latest",
           "default_size": "tiny",
+          "cluster_name": "integration-test",
           "server_in_cluster": false,
-          "install_id": "batt_01902a1b14a57306ae9f596d7ee91221",
+          "install_id": "batt_01903204fc9b7b2c859d62860eaa96b7",
           "control_jwk": {
             "crv": "Ed25519",
-            "d": "lWU0-QQ6m24dCra6AdZW-lIYl3hMw3Go_AScodWQLyo",
+            "d": "WSMEFS5tsnOZSr_SBJXGA2jhttdiTqUeIj3wVopMq4E",
             "kty": "OKP",
-            "x": "Kdbix5pFg5LMu0-fhHswMpcXNXLZh-WOaTEpjsesxOo"
+            "x": "wamaPSqAPy0X0ERAv11k_d0uh-QwrZcwtudRLAJHcL4"
           },
           "image_override": null,
           "bootstrap_image_override": null
@@ -47,9 +47,15 @@
           "name": "control",
           "owner": "battery-control-user"
         },
+        "storage_class": null,
+        "cpu_requested": 500,
+        "cpu_limits": 500,
+        "memory_requested": 536870912,
+        "memory_limits": 536870912,
+        "num_instances": 1,
+        "virtual_size": "tiny",
         "inserted_at": null,
         "updated_at": null,
-        "project_id": null,
         "users": [
           {
             "position": null,
@@ -61,19 +67,13 @@
           {
             "position": null,
             "username": "battery-control-user",
-            "password": "RUTNSY3YLB24VSLKWJECALLJ",
+            "password": "5UZAODOCQ2L5FKDU63XAAU46",
             "roles": ["createdb", "login"],
             "credential_namespaces": ["battery-core"]
           }
         ],
-        "cpu_requested": 500,
-        "cpu_limits": 500,
-        "memory_requested": 536870912,
-        "memory_limits": 536870912,
-        "storage_class": null,
-        "num_instances": 1,
-        "virtual_size": "tiny",
         "storage_size": 536870912,
+        "project_id": null,
         "virtual_storage_size_range_value": 5035931120
       }
     ],
@@ -89,7 +89,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "LCRV25WMQPVQMVT4AXQXDSOSV24GJO4BLMBTGQTFDGLNPB27ITIA===="
+          "battery/hash": "NNKI27Q2FX5USIJMWOONLMWRTRUGGDLXZUP723AXRO7KO6AHU6XA===="
         },
         "labels": {
           "app": "battery-core",
@@ -99,7 +99,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01902a1b14c373c3950694a6cc624612",
+          "battery/owner": "batt_01903204fcbf76509f9203b8a39ec6b3",
           "istio-injection": "enabled",
           "version": "latest"
         },

--- a/bootstrap/jason.install.json
+++ b/bootstrap/jason.install.json
@@ -1,20 +1,20 @@
 {
-  "id": "batt_01902a1b14a57b7da2fd54fbd4f83c81",
+  "id": "batt_01903204fc9b71e986f50409d821842e",
   "usage": "development",
-  "inserted_at": null,
-  "updated_at": null,
   "default_size": "small",
   "control_jwk": {
     "crv": "Ed25519",
-    "d": "ebAnOLt1NzR_K5JCPJKPDgcn-GZkH30e_K50Kh3EyBU",
+    "d": "EIEZfWN95psJF-P3EDMsedn0qSh4HWmsps0i2y4eEjw",
     "kty": "OKP",
-    "x": "0xqyTdcwtX2J7IP23xDuOFyrmxCnFUj62Q_HxcPpJhc"
+    "x": "fjmJoMY4XRqCM9MdzrqGykOrMTtg76ehKX49MkTBSu8"
   },
+  "inserted_at": null,
+  "updated_at": null,
   "slug": "jason",
   "kube_provider": "aws",
   "kube_provider_config": {},
   "sso_enabled": false,
   "initial_oauth_email": null,
   "user_id": null,
-  "team_id": "batt_01902a1b147376018d018eca4ece4958"
+  "team_id": "batt_01903204fc4b7e8293da31c980058ac4"
 }

--- a/bootstrap/jason.spec.json
+++ b/bootstrap/jason.spec.json
@@ -8,26 +8,26 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_01902a1b14c37da5bb6d9fec49c091d7",
+        "id": "batt_01903204fcbe72cdb5183bda03d40f86",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
           "image": "public.ecr.aws/batteries-included/control-server:latest",
           "cluster_type": "aws",
-          "cluster_name": "jason",
           "core_namespace": "battery-core",
           "base_namespace": "battery-base",
           "data_namespace": "battery-data",
           "ai_namespace": "battery-ai",
           "bootstrap_image": "public.ecr.aws/batteries-included/kube-bootstrap:latest",
           "default_size": "small",
+          "cluster_name": "jason",
           "server_in_cluster": true,
-          "install_id": "batt_01902a1b14a57b7da2fd54fbd4f83c81",
+          "install_id": "batt_01903204fc9b71e986f50409d821842e",
           "control_jwk": {
             "crv": "Ed25519",
-            "d": "ebAnOLt1NzR_K5JCPJKPDgcn-GZkH30e_K50Kh3EyBU",
+            "d": "EIEZfWN95psJF-P3EDMsedn0qSh4HWmsps0i2y4eEjw",
             "kty": "OKP",
-            "x": "0xqyTdcwtX2J7IP23xDuOFyrmxCnFUj62Q_HxcPpJhc"
+            "x": "fjmJoMY4XRqCM9MdzrqGykOrMTtg76ehKX49MkTBSu8"
           },
           "image_override": null,
           "bootstrap_image_override": null
@@ -37,7 +37,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01902a1b14c37742b19b145b8f56d720",
+        "id": "batt_01903204fcbe796588bffd2d5156765b",
         "type": "karpenter",
         "config": {
           "type": "karpenter",
@@ -52,7 +52,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01902a1b14c372e78cef3caaee41f467",
+        "id": "batt_01903204fcbe72a9839b9583e27d54d7",
         "type": "cert_manager",
         "config": {
           "type": "cert_manager",
@@ -62,18 +62,18 @@
           "controller_image": "quay.io/jetstack/cert-manager-controller:v1.14.6",
           "ctl_image": "quay.io/jetstack/cert-manager-ctl:v1.14.6",
           "webhook_image": "quay.io/jetstack/cert-manager-webhook:v1.14.6",
+          "controller_image_override": null,
+          "webhook_image_override": null,
           "acmesolver_image_override": null,
           "cainjector_image_override": null,
-          "controller_image_override": null,
-          "ctl_image_override": null,
-          "webhook_image_override": null
+          "ctl_image_override": null
         },
         "group": "net_sec",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_01902a1b14c37778aa890008f90bc21a",
+        "id": "batt_01903204fcbe7bf5adc6d50fdb1c538a",
         "type": "battery_ca",
         "config": {
           "type": "battery_ca"
@@ -83,7 +83,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01902a1b14c3770b86f8d910b833949b",
+        "id": "batt_01903204fcbe75ab82b680e65a1d8ffe",
         "type": "aws_load_balancer_controller",
         "config": {
           "type": "aws_load_balancer_controller",
@@ -98,7 +98,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01902a1b14c373b5be67d24967ba41f1",
+        "id": "batt_01903204fcbe7a3f80ff90306ac0d00c",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
@@ -110,7 +110,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01902a1b14c37847badb2fe55116fa17",
+        "id": "batt_01903204fcbe7ff7b270c24e8e6c9030",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -124,7 +124,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01902a1b14c37e5e85ffae0eeee09187",
+        "id": "batt_01903204fcbe7be2b27cf8c6260dfb97",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -136,7 +136,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01902a1b14c3706585e9b3bcc4dc3a0c",
+        "id": "batt_01903204fcbe715a9fc7b543bbc56200",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -158,26 +158,26 @@
           "name": "control",
           "owner": "battery-control-user"
         },
-        "inserted_at": null,
-        "updated_at": null,
-        "project_id": null,
-        "users": [
-          {
-            "position": null,
-            "username": "battery-control-user",
-            "password": "KW6VALRG6RC7JTP2B5BP7SQN",
-            "roles": ["createdb", "login"],
-            "credential_namespaces": ["battery-core"]
-          }
-        ],
+        "storage_class": null,
         "cpu_requested": 500,
         "cpu_limits": 2000,
         "memory_requested": 1073741824,
         "memory_limits": 4294967296,
-        "storage_class": null,
         "num_instances": 1,
         "virtual_size": "small",
+        "inserted_at": null,
+        "updated_at": null,
+        "users": [
+          {
+            "position": null,
+            "username": "battery-control-user",
+            "password": "KKI2AS7ZZ32X54HBGJ2RXE2U",
+            "roles": ["createdb", "login"],
+            "credential_namespaces": ["battery-core"]
+          }
+        ],
         "storage_size": 17179869184,
+        "project_id": null,
         "virtual_storage_size_range_value": 287219363990
       }
     ],
@@ -193,7 +193,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "TSUQVAW2X36QJ5YYOXVCJW4VPXWVK2LJFLODU3XZH7DN4USW6L4Q===="
+          "battery/hash": "R72KO46G6NGJ7QPGIZWUG7W2PUXRIDCZIEOPTDRN5QW7B6MVTEWQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -203,7 +203,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01902a1b14c37da5bb6d9fec49c091d7",
+          "battery/owner": "batt_01903204fcbe72cdb5183bda03d40f86",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -226,7 +226,7 @@
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "3K7TFQDCXXFHOG5BQGSMF4C32AZTXRXOM52FDFFKAKZKC4ZD74PA===="
+          "battery/hash": "G2HCMQJIZYMM4DB4TK4OI4YYMLJLNBVTEUIQN2YRKLGWNZUPY56A===="
         },
         "labels": {
           "app": "battery-core",
@@ -236,7 +236,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01902a1b14c37da5bb6d9fec49c091d7",
+          "battery/owner": "batt_01903204fcbe72cdb5183bda03d40f86",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -260,7 +260,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_01902a1b14c37da5bb6d9fec49c091d7",
+              "battery/owner": "batt_01903204fcbe72cdb5183bda03d40f86",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -273,7 +273,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "ECN4OLCC2MPEB6HY4ONCC22K7MJ3ULAH4IW7DR4ZZGCGE7ZVZKVQDUEXVBJ747KX"
+                    "value": "TILRGHEZYWM2SKQ2CRXM4CHW3PX6XTJYTTXAGQ7ZFCCVWV2JJO4ADDZKT62PSUES"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -321,7 +321,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "A6EE5ULZ3YJ2CNNSCWN5Z7ITF5P4526ICGHRB6LVCWZ7WZYMAURA===="
+          "battery/hash": "Q7GC7C4BG573YEMRZ7OTCEHTQOQXYIPT64WW3ZAMMNVVFUSUGT5Q===="
         },
         "labels": {
           "app": "battery-core",
@@ -331,7 +331,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01902a1b14c37da5bb6d9fec49c091d7",
+          "battery/owner": "batt_01903204fcbe72cdb5183bda03d40f86",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -343,7 +343,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "ZQXD5CYB3HDRJYH4NKGB5YETS6HQ7MJBUFWVVMOLJR2OXYSMDIPA===="
+          "battery/hash": "OVFS6XNSC3BQRDUV4GMZS57J36GS6HVKDQQ5NC7NA6635METJHCA===="
         },
         "labels": {
           "app": "battery-core",
@@ -353,7 +353,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01902a1b14c37da5bb6d9fec49c091d7",
+          "battery/owner": "batt_01903204fcbe72cdb5183bda03d40f86",
           "version": "latest"
         },
         "name": "bootstrap",
@@ -366,7 +366,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "SWQ5ULKAQXQX4PRUOP4EHV4FCDTD4VDMOCFRAQJO2LYE7PEAMOWQ====",
+          "battery/hash": "PPP6RQLJK5TQWARVNAP3RN7HYFSJCXCJFWMDHNRSGEGJBMJOKB6A====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -377,7 +377,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01902a1b14c37da5bb6d9fec49c091d7",
+          "battery/owner": "batt_01903204fcbe72cdb5183bda03d40f86",
           "version": "latest"
         },
         "name": "gp2"
@@ -392,7 +392,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "PAV3ONR524B2VF5IE44VZL4T5SK3S6C6QAMIPUWRIS4EMVY2U7XQ====",
+          "battery/hash": "HMPBC2N7C23BRJXM3TFL5GBK2X2NUSIJUTGBT5DY5DMG6EMVILVQ====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -403,7 +403,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01902a1b14c37da5bb6d9fec49c091d7",
+          "battery/owner": "batt_01903204fcbe72cdb5183bda03d40f86",
           "version": "latest"
         },
         "name": "gp2-90032408"
@@ -423,7 +423,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "YK5EC7YK5LS5VNNBQQMHYXMAXWSIGRDWIOCMNTC57OPISDRY6DJQ====",
+          "battery/hash": "SEZRIWFU6KIUETG2YKYO4FG544CBYGMPHWSNHQSPXWYSZP2MVV3Q====",
           "storageclass.kubernetes.io/is-default-class": "true"
         },
         "labels": {
@@ -434,7 +434,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01902a1b14c37da5bb6d9fec49c091d7",
+          "battery/owner": "batt_01903204fcbe72cdb5183bda03d40f86",
           "version": "latest"
         },
         "name": "gp3-105457460"

--- a/bootstrap/local.install.json
+++ b/bootstrap/local.install.json
@@ -1,20 +1,20 @@
 {
-  "id": "batt_01902a1b14a5782fb5f951314e40ce65",
+  "id": "batt_01903204fc9b7d44b3e09a7c04c5bf03",
   "usage": "development",
-  "inserted_at": null,
-  "updated_at": null,
   "default_size": "tiny",
   "control_jwk": {
     "crv": "Ed25519",
-    "d": "lmjGBvLjvcoBqr_4zm0yOXjv97XGjloGHx-C4p9S6II",
+    "d": "aIH3XZ91CeiB_5ex7Fm3r7QqFABk30aUY6VNeP-MbQI",
     "kty": "OKP",
-    "x": "VSv5WFOiO1UqJFZhLuFxWxgILz-NhLvtFWq4ceI-sPg"
+    "x": "4pa1kRHQ41No5N-s4gh6Zr4rSY4zjO8ssmxiLiOZjb0"
   },
+  "inserted_at": null,
+  "updated_at": null,
   "slug": "local",
   "kube_provider": "kind",
   "kube_provider_config": {},
   "sso_enabled": false,
   "initial_oauth_email": null,
   "user_id": null,
-  "team_id": "batt_01902a1b147376018d018eca4ece4958"
+  "team_id": "batt_01903204fc4b7e8293da31c980058ac4"
 }

--- a/bootstrap/local.spec.json
+++ b/bootstrap/local.spec.json
@@ -8,7 +8,7 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_01902a1b14be71cbab82494567291021",
+        "id": "batt_01903204fcb9718687f0ab81caacc79e",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -22,7 +22,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01902a1b14be7d2ca36dd0479faeca9c",
+        "id": "batt_01903204fcb97346ad9a7d2ef6a79b27",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -34,26 +34,26 @@
         "updated_at": null
       },
       {
-        "id": "batt_01902a1b14be74d7bf0276bf38789ae1",
+        "id": "batt_01903204fcb973c1a283c6d5b02f8603",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
           "image": "public.ecr.aws/batteries-included/control-server:latest",
           "cluster_type": "kind",
-          "cluster_name": "local",
           "core_namespace": "battery-core",
           "base_namespace": "battery-base",
           "data_namespace": "battery-data",
           "ai_namespace": "battery-ai",
           "bootstrap_image": "public.ecr.aws/batteries-included/kube-bootstrap:latest",
           "default_size": "tiny",
+          "cluster_name": "local",
           "server_in_cluster": true,
-          "install_id": "batt_01902a1b14a5782fb5f951314e40ce65",
+          "install_id": "batt_01903204fc9b7d44b3e09a7c04c5bf03",
           "control_jwk": {
             "crv": "Ed25519",
-            "d": "lmjGBvLjvcoBqr_4zm0yOXjv97XGjloGHx-C4p9S6II",
+            "d": "aIH3XZ91CeiB_5ex7Fm3r7QqFABk30aUY6VNeP-MbQI",
             "kty": "OKP",
-            "x": "VSv5WFOiO1UqJFZhLuFxWxgILz-NhLvtFWq4ceI-sPg"
+            "x": "4pa1kRHQ41No5N-s4gh6Zr4rSY4zjO8ssmxiLiOZjb0"
           },
           "image_override": null,
           "bootstrap_image_override": null
@@ -63,15 +63,15 @@
         "updated_at": null
       },
       {
-        "id": "batt_01902a1b14be758fae24bf977d5154a1",
+        "id": "batt_01903204fcb9782baff8994804f71832",
         "type": "metallb",
         "config": {
           "type": "metallb",
           "controller_image": "quay.io/metallb/controller:v0.13.12",
           "speaker_image": "quay.io/metallb/speaker:v0.13.12",
           "frrouting_image": "quay.io/frrouting/frr:8.5.4",
-          "controller_image_override": null,
           "speaker_image_override": null,
+          "controller_image_override": null,
           "frrouting_image_override": null
         },
         "group": "net_sec",
@@ -79,7 +79,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01902a1b14be7c82abff500e6a8804ed",
+        "id": "batt_01903204fcb975758ac31de391dbcf0e",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
@@ -91,7 +91,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01902a1b14be7cf2996ba6509ad38f06",
+        "id": "batt_01903204fcb9763abdee2ee829e9cf26",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -113,26 +113,26 @@
           "name": "control",
           "owner": "battery-control-user"
         },
-        "inserted_at": null,
-        "updated_at": null,
-        "project_id": null,
-        "users": [
-          {
-            "position": null,
-            "username": "battery-control-user",
-            "password": "4MPE6QOQATTOC537FR5CCR3C",
-            "roles": ["createdb", "login"],
-            "credential_namespaces": ["battery-core"]
-          }
-        ],
+        "storage_class": null,
         "cpu_requested": 500,
         "cpu_limits": 500,
         "memory_requested": 536870912,
         "memory_limits": 536870912,
-        "storage_class": null,
         "num_instances": 1,
         "virtual_size": "tiny",
+        "inserted_at": null,
+        "updated_at": null,
+        "users": [
+          {
+            "position": null,
+            "username": "battery-control-user",
+            "password": "BOSDHAAOXWFCRFZQN2SF3QP6",
+            "roles": ["createdb", "login"],
+            "credential_namespaces": ["battery-core"]
+          }
+        ],
         "storage_size": 536870912,
+        "project_id": null,
         "virtual_storage_size_range_value": 5035931120
       }
     ],
@@ -148,7 +148,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "2LWFXWD23CSGXNMD6446ZM4G25XPK7SW3Y2HNFGYS433ZKOCTLUA===="
+          "battery/hash": "U6YAOMCMQKNAMTMT4FMNOMSU7R3SOQXZTHRBLWVWUNZWGBSDSN7Q===="
         },
         "labels": {
           "app": "battery-core",
@@ -158,7 +158,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01902a1b14be74d7bf0276bf38789ae1",
+          "battery/owner": "batt_01903204fcb973c1a283c6d5b02f8603",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -181,7 +181,7 @@
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "3TEENBAUHTRNIG2INZTMV4JYJ44TAPX57RRSABA2J5MINTOTKOUA===="
+          "battery/hash": "6VWUUTD7MFK6P2ZH53FCHZM46SLYWLXW4JDT6LLT2QSFUAITPHLA===="
         },
         "labels": {
           "app": "battery-core",
@@ -191,7 +191,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01902a1b14be74d7bf0276bf38789ae1",
+          "battery/owner": "batt_01903204fcb973c1a283c6d5b02f8603",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -215,7 +215,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_01902a1b14be74d7bf0276bf38789ae1",
+              "battery/owner": "batt_01903204fcb973c1a283c6d5b02f8603",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -228,7 +228,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "OVOINYFFPVIPQ6PRS2YIIQQVFAGCSUAJ4X4LPALIVJK7BRMO5TCXORRDTKCFERZR"
+                    "value": "HH5NHDFXWON2FQELFC7YT7YF5SQB7IFQ4UJUPHSK5VUCKU25UUVLT2NFYELSUDLN"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -276,7 +276,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "V22SK752OLAHY6OMNAUQTUTYWGG5FGUONHANNCK3NAYTQJ24ZKLA===="
+          "battery/hash": "QS7RDBTWAXBLHEAZUWVE77WQCHJSGPGPLFFPU7XT6UPPCC2FHOUA===="
         },
         "labels": {
           "app": "battery-core",
@@ -286,7 +286,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01902a1b14be74d7bf0276bf38789ae1",
+          "battery/owner": "batt_01903204fcb973c1a283c6d5b02f8603",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -298,7 +298,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "PSKQ66H5O3TTYHXCJUK7PSHAUULLRPSOHD6HW5ALS7YPJM6DVOFQ===="
+          "battery/hash": "Y7XZMJPV627DCVNT65NQOM4P3BJ2MAWG7Z2P2UTBDMHTODUAGGOQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -308,7 +308,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01902a1b14be74d7bf0276bf38789ae1",
+          "battery/owner": "batt_01903204fcb973c1a283c6d5b02f8603",
           "version": "latest"
         },
         "name": "bootstrap",

--- a/bootstrap/team.json
+++ b/bootstrap/team.json
@@ -1,5 +1,5 @@
 {
-  "id": "batt_01902a1b147376018d018eca4ece4958",
+  "id": "batt_01903204fc4b7e8293da31c980058ac4",
   "name": "Batteries Included Team",
   "inserted_at": null,
   "updated_at": null,

--- a/platform_umbrella/apps/common_core/lib/common_core/et/hosts.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/et/hosts.ex
@@ -14,12 +14,18 @@ defmodule CommonCore.ET.URLs do
   end
 
   def usage_report_path(state_summary) do
-    install_id = CommonCore.StateSummary.Core.config_field(state_summary, :install_id)
-    "/installations/#{install_id}/usage_reports"
+    "/installations/#{install_id(state_summary)}/usage_reports"
   end
 
   def host_reports_path(state_summary) do
-    install_id = CommonCore.StateSummary.Core.config_field(state_summary, :install_id)
-    "/installations/#{install_id}/host_reports"
+    "/installations/#{install_id(state_summary)}/host_reports"
+  end
+
+  def status_path(state_summary) do
+    "/installations/#{install_id(state_summary)}/status"
+  end
+
+  defp install_id(state_summary) do
+    CommonCore.StateSummary.Core.config_field(state_summary, :install_id)
   end
 end

--- a/platform_umbrella/apps/common_core/lib/common_core/jwk/jwk.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/jwk/jwk.ex
@@ -45,6 +45,8 @@ defmodule CommonCore.JWK do
     jwk |> JOSE.JWT.sign(payload) |> elem(1)
   end
 
+  def verify!(nil), do: raise(CommonCore.JWK.BadKeyError.exception())
+
   def verify!(token) do
     case first_verified(token) do
       nil -> raise CommonCore.JWK.BadKeyError.exception()
@@ -52,8 +54,17 @@ defmodule CommonCore.JWK do
     end
   end
 
+  def verify(nil), do: {:error, CommonCore.JWK.BadKeyError.exception()}
+
+  def verify(token) do
+    case first_verified(token) do
+      nil -> {:error, CommonCore.JWK.BadKeyError.exception()}
+      value -> {:ok, value}
+    end
+  end
+
   defp first_verified(token) do
-    Enum.find_value(verify_keys(), fn key_name ->
+    Enum.find_value(verify_keys(), nil, fn key_name ->
       jwk = CommonCore.JWK.Cache.get(key_name)
       try_verify_single(jwk, token)
     end)

--- a/platform_umbrella/apps/common_core/lib/common_core/state_summary/core.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/state_summary/core.ex
@@ -11,7 +11,7 @@ defmodule CommonCore.StateSummary.Core do
   @spec config_field(CommonCore.StateSummary.t(), atom()) :: any() | nil
   def config_field(summary, key) do
     case battery_core_config(summary) do
-      %BatteryCoreConfig{} = config -> get_in(config, [Access.key(key)])
+      %BatteryCoreConfig{} = config -> Map.get(config, key)
       _ -> nil
     end
   end

--- a/platform_umbrella/apps/home_base_web/lib/home_base_web/controllers/installation_status_controller.ex
+++ b/platform_umbrella/apps/home_base_web/lib/home_base_web/controllers/installation_status_controller.ex
@@ -10,13 +10,33 @@ defmodule HomeBaseWeb.InstallationStatusContoller do
 
   def show(conn, %{"installation_id" => install_id}) do
     # For now just make sure the installation exists
-    _installation = CustomerInstalls.get_installation!(install_id)
+    installation = CustomerInstalls.get_installation!(install_id)
+    # One hour when everyone comes back in 9 minutes seems good
+    # Adjust when needed
+    exp = DateTime.utc_now() |> DateTime.add(1, :hour) |> DateTime.to_unix()
+
     # Everything is ok
-    status = InstallStatus.new!(status: :ok, message: "Installation is ok")
+    status = :ok
+
+    install_status =
+      InstallStatus.new!(
+        status: status,
+        message: message(status, Enum.random(0..3)),
+        iss: installation.id,
+        exp: exp
+      )
 
     conn
     |> put_status(:ok)
     |> put_view(json: HomeBaseWeb.InstallationStatusJSON)
-    |> render(:show, jwt: CommonCore.JWK.sign(status))
+    |> render(:show, jwt: CommonCore.JWK.sign(install_status))
   end
+
+  # Like the status says we're ok, not great, not bad, just ok.
+  #
+  # These are never seen but are burried in JWTs as some noise.
+  defp message(:ok, 0), do: "The cake is a lie."
+  defp message(:ok, 1), do: "Idiocracy (2006) was not supposed to be a documentary."
+  defp message(:ok, 2), do: "We've built economies on growth and now can't afford to stop growing."
+  defp message(:ok, _), do: "Cyberpunk was supposed to be a dystopian vision of the future, not a goal."
 end

--- a/platform_umbrella/apps/home_base_web/test/home_base_web/controllers/installation_status_controller_test.exs
+++ b/platform_umbrella/apps/home_base_web/test/home_base_web/controllers/installation_status_controller_test.exs
@@ -17,7 +17,7 @@ defmodule HomeBaseWeb.InstallationStatusControllerTest do
       conn = get(conn, ~p"/api/v1/installations/#{install.id}/status")
       jwt = json_response(conn, 200)["jwt"]
 
-      payload = CommonCore.JWK.verify!(jwt)
+      assert {:ok, payload} = CommonCore.JWK.verify(jwt)
       assert payload["status"] == "ok"
     end
   end

--- a/platform_umbrella/apps/kube_services/lib/kube_services/batteries/battery_core.ex
+++ b/platform_umbrella/apps/kube_services/lib/kube_services/batteries/battery_core.ex
@@ -12,7 +12,8 @@ defmodule KubeServices.Batteries.BatteryCore do
       {KubeServices.ET.HomeBaseClient, [home_url: CommonCore.ET.URLs.home_base_url(battery.config)]},
       {KubeServices.ET.Usage, [home_client_pid: KubeServices.ET.HomeBaseClient]},
       {KubeServices.ET.Hosts, [home_client_pid: KubeServices.ET.HomeBaseClient]},
-      {KubeServices.ET.InstallStatusWorker, [home_client_pid: KubeServices.ET.HomeBaseClient]}
+      {KubeServices.ET.InstallStatusWorker,
+       [home_client_pid: KubeServices.ET.HomeBaseClient, install_id: battery.config.install_id]}
     ]
 
     Supervisor.init(children, strategy: :one_for_one)


### PR DESCRIPTION
Summary:
- Add expire time(`exp`) and target install(`iss`) for install status
- InstallStatus.status_ok? respects expire times
- Add code to Get from control server
- Hook up InstallStatusWorker to use an unknown status on any errors
  (including networking)
- Polish up JWT validation methods

Test Plan:
- Validations methods are tested

```
iex(21)> KubeServices.ET.InstallStatusWorker.get_status
%CommonCore.ET.InstallStatus{
  status: :ok,
  iss: "batt_01902a1b147571debff6a45ae62a0285",
  exp: 1718843885,
  message: "Idiocracy (2006) was not supposed to be a documentary."
}
```
- CI
