### PR TITLE
feat: show timeline buttons when the battery is installed

### DIFF
--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/ferrretdb/show.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/ferrretdb/show.ex
@@ -8,6 +8,7 @@ defmodule ControlServerWeb.Live.FerretServiceShow do
 
   alias ControlServer.FerretDB
   alias KubeServices.KubeState
+  alias KubeServices.SystemState.SummaryBatteries
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
@@ -24,7 +25,12 @@ defmodule ControlServerWeb.Live.FerretServiceShow do
      |> assign_current_page()
      |> assign_ferret_service(service)
      |> assign_pods()
+     |> assign_timeline_installed()
      |> maybe_assign_edit_versions()}
+  end
+
+  defp assign_timeline_installed(socket) do
+    assign(socket, :timeline_installed, SummaryBatteries.battery_installed(:timeline))
   end
 
   defp assign_current_page(socket) do
@@ -81,11 +87,15 @@ defmodule ControlServerWeb.Live.FerretServiceShow do
           </:item>
         </.badge>
 
-        <.button variant="secondary" link={edit_versions_url(@ferret_service)}>
-          Edit History
-        </.button>
-
+        <.tooltip :if={@timeline_installed} target_id="history-tooltip">Edit History</.tooltip>
         <.flex gaps="0">
+          <.button
+            :if={@timeline_installed}
+            id="history-tooltip"
+            variant="icon"
+            icon={:clock}
+            link={edit_versions_url(@ferret_service)}
+          />
           <.button variant="icon" icon={:pencil} link={edit_url(@ferret_service)} />
           <.button variant="icon" icon={:trash} phx-click="delete" data-confirm="Are you sure?" />
         </.flex>
@@ -112,7 +122,12 @@ defmodule ControlServerWeb.Live.FerretServiceShow do
     ~H"""
     <%= case @live_action do %>
       <% :show -> %>
-        <.main_page ferret_service={@ferret_service} pods={@pods} page_title={@page_title} />
+        <.main_page
+          ferret_service={@ferret_service}
+          pods={@pods}
+          page_title={@page_title}
+          timeline_installed={@timeline_installed}
+        />
       <% :edit_versions -> %>
         <.edit_versions_page ferret_service={@ferret_service} edit_versions={@edit_versions} />
     <% end %>

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/projects/show.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/projects/show.ex
@@ -9,6 +9,7 @@ defmodule ControlServerWeb.Projects.ShowLive do
 
   alias ControlServer.Projects
   alias KubeServices.KubeState
+  alias KubeServices.SystemState.SummaryBatteries
 
   def mount(_params, _session, socket) do
     {:ok, socket}
@@ -18,8 +19,13 @@ defmodule ControlServerWeb.Projects.ShowLive do
     {:noreply,
      socket
      |> assign(:page_title, "Project Details")
+     |> assign_timeline_installed()
      |> assign_project(id)
      |> assign_pods()}
+  end
+
+  defp assign_timeline_installed(socket) do
+    assign(socket, :timeline_installed, SummaryBatteries.battery_installed(:timeline))
   end
 
   defp assign_project(socket, id) do
@@ -52,10 +58,17 @@ defmodule ControlServerWeb.Projects.ShowLive do
   def render(assigns) do
     ~H"""
     <.page_header title={@page_title <> ": " <> @project.name} back_link={~p"/projects"}>
-      <.flex class="items-center">
-        <.button variant="dark" icon={:clock} link={~p"/projects/#{@project.id}/timeline"}>
-          Project Timeline
-        </.button>
+      <.flex>
+        <.tooltip :if={@timeline_installed} target_id="history-tooltip">Project History</.tooltip>
+        <.flex gaps="0">
+          <.button
+            :if={@timeline_installed}
+            id="history-tooltip"
+            variant="icon"
+            icon={:clock}
+            link={~p"/projects/#{@project.id}/timeline"}
+          />
+        </.flex>
       </.flex>
     </.page_header>
 

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/redis/show.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/redis/show.ex
@@ -10,6 +10,7 @@ defmodule ControlServerWeb.Live.RedisShow do
   alias ControlServer.Redis
   alias EventCenter.KubeState, as: KubeEventCenter
   alias KubeServices.KubeState
+  alias KubeServices.SystemState.SummaryBatteries
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
@@ -23,12 +24,17 @@ defmodule ControlServerWeb.Live.RedisShow do
   def handle_params(%{"id" => id}, _, socket) do
     {:noreply,
      socket
+     |> assign_timeline_installed()
      |> assign(:id, id)
      |> assign(:page_title, page_title(socket.assigns.live_action))
      |> assign(:failover_cluster, Redis.get_failover_cluster!(id, preload: [:project]))
      |> assign(:k8_failover, k8_failover(id))
      |> assign(:k8_services, k8_services(id))
      |> assign(:k8_pods, k8_pods(id))}
+  end
+
+  defp assign_timeline_installed(socket) do
+    assign(socket, :timeline_installed, SummaryBatteries.battery_installed(:timeline))
   end
 
   @impl Phoenix.LiveView
@@ -57,19 +63,20 @@ defmodule ControlServerWeb.Live.RedisShow do
         </.badge>
       </:menu>
 
-      <div>
+      <.flex>
         <.tooltip target_id="edit-tooltip">Edit Cluster</.tooltip>
-        <.button id="edit-tooltip" variant="icon" icon={:pencil} link={edit_url(@failover_cluster)} />
-
         <.tooltip target_id="delete-tooltip">Delete Cluster</.tooltip>
-        <.button
-          id="delete-tooltip"
-          variant="icon"
-          icon={:trash}
-          phx-click="delete"
-          data-confirm="Are you sure?"
-        />
-      </div>
+        <.flex gaps="0">
+          <.button id="edit-tooltip" variant="icon" icon={:pencil} link={edit_url(@failover_cluster)} />
+          <.button
+            id="delete-tooltip"
+            variant="icon"
+            icon={:trash}
+            phx-click="delete"
+            data-confirm="Are you sure?"
+          />
+        </.flex>
+      </.flex>
     </.page_header>
 
     <.grid columns={%{sm: 1, lg: 2}}>

--- a/platform_umbrella/apps/control_server_web/test/unit/live/project_live_test.exs
+++ b/platform_umbrella/apps/control_server_web/test/unit/live/project_live_test.exs
@@ -44,7 +44,6 @@ defmodule ControlServerWeb.ProjectLiveTest do
     test "should display a project", %{conn: conn, project: project} do
       {:ok, _view, html} = live(conn, ~p"/projects/#{project}")
 
-      assert html =~ "Project Timeline"
       assert html =~ project.name
     end
   end


### PR DESCRIPTION
Summary:
Edit history should be shown when the timeline battery is installed. So
add that conditional everywhere

This will fix #22

Test Plan:
- Tests were updated where the state of the button changed
