### PR TITLE
fix: don't crash on transactions for Database watcher

### DIFF
--- a/platform_umbrella/apps/kube_services/lib/kube_services/timeline/database_watcher.ex
+++ b/platform_umbrella/apps/kube_services/lib/kube_services/timeline/database_watcher.ex
@@ -29,6 +29,10 @@ defmodule KubeServices.Timeline.DatabaseWatcher do
     {:noreply, state}
   end
 
+  # Installer uses a huge multi.
+  # Don't unwrap it here.
+  defp to_event(_type, :multi, _), do: {:ok, nil}
+
   defp to_event(type, action, %{name: name, id: id} = _object) do
     Logger.debug("Going to persist timeline event for #{type} action #{action}",
       type: type,


### PR DESCRIPTION
Summary:
Events about the database are usually create or update. Installer does a
multi and we don't have a match that will extract the relevant ID.

This should fix #181

Test Plan:
It doesn't error out when installing a battery any more
