### PR TITLE
refactor: collapse the dns hostnames

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/et/hosts.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/et/hosts.ex
@@ -2,7 +2,7 @@ defmodule CommonCore.ET.URLs do
   @moduledoc false
   alias CommonCore.Batteries.BatteryCoreConfig
 
-  @local_home "http://home.local.127.0.0.1.ip.batteriesincl.com:4100/api/v1"
+  @local_home "http://home.backend-service.127-0-0-1.ip.batteriesincl.com:4100/api/v1"
   @prod_home "https://home.prod.batteriesincl.com/api/v1"
 
   def home_base_url(%BatteryCoreConfig{} = config) do

--- a/platform_umbrella/apps/common_core/lib/common_core/state_summary/hosts.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/state_summary/hosts.ex
@@ -88,6 +88,11 @@ defmodule CommonCore.StateSummary.Hosts do
   defp host("", _name, _group), do: ""
 
   defp host(ip, name, group) do
+    # Rather than new hostnames for each octet of ips replace with -'s
+    # For one this makes lets encrypt happy, and it also speeds
+    # up dns look up traversal on the worst case.
+    ip = String.replace(ip, ".", "-")
+
     "#{name}.#{group}.#{ip}.ip.batteriesincl.com"
   end
 

--- a/platform_umbrella/apps/common_core/test/common_core/et/host_report_test.exs
+++ b/platform_umbrella/apps/common_core/test/common_core/et/host_report_test.exs
@@ -16,7 +16,7 @@ defmodule CommonCore.ET.HostReportTest do
   test "new/1 with StateSummary", %{state_summary: state_summary} do
     report = HostReport.new!(state_summary)
 
-    assert report.control_server_host == "control.core.127.0.0.1.ip.batteriesincl.com"
+    assert report.control_server_host == "control.core.127-0-0-1.ip.batteriesincl.com"
   end
 
   test "new/1 with options map" do

--- a/platform_umbrella/apps/common_core/test/common_core/open_api/oidc_test.exs
+++ b/platform_umbrella/apps/common_core/test/common_core/open_api/oidc_test.exs
@@ -5,16 +5,16 @@ defmodule CommonCore.OpenAPI.OIDCTest do
 
   @example_response """
     {
-    "issuer": "http://keycloak.core.172.18.128.1.ip.batteriesincl.com/realms/master",
-    "authorization_endpoint": "http://keycloak.core.172.18.128.1.ip.batteriesincl.com/realms/master/protocol/openid-connect/auth",
-    "token_endpoint": "http://keycloak.core.172.18.128.1.ip.batteriesincl.com/realms/master/protocol/openid-connect/token",
-    "introspection_endpoint": "http://keycloak.core.172.18.128.1.ip.batteriesincl.com/realms/master/protocol/openid-connect/token/introspect",
-    "userinfo_endpoint": "http://keycloak.core.172.18.128.1.ip.batteriesincl.com/realms/master/protocol/openid-connect/userinfo",
-    "end_session_endpoint": "http://keycloak.core.172.18.128.1.ip.batteriesincl.com/realms/master/protocol/openid-connect/logout",
+    "issuer": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master",
+    "authorization_endpoint": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/protocol/openid-connect/auth",
+    "token_endpoint": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/protocol/openid-connect/token",
+    "introspection_endpoint": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/protocol/openid-connect/token/introspect",
+    "userinfo_endpoint": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/protocol/openid-connect/userinfo",
+    "end_session_endpoint": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/protocol/openid-connect/logout",
     "frontchannel_logout_session_supported": true,
     "frontchannel_logout_supported": true,
-    "jwks_uri": "http://keycloak.core.172.18.128.1.ip.batteriesincl.com/realms/master/protocol/openid-connect/certs",
-    "check_session_iframe": "http://keycloak.core.172.18.128.1.ip.batteriesincl.com/realms/master/protocol/openid-connect/login-status-iframe.html",
+    "jwks_uri": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/protocol/openid-connect/certs",
+    "check_session_iframe": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/protocol/openid-connect/login-status-iframe.html",
     "grant_types_supported": [
       "authorization_code",
       "implicit",
@@ -135,7 +135,7 @@ defmodule CommonCore.OpenAPI.OIDCTest do
       "form_post.jwt",
       "jwt"
     ],
-    "registration_endpoint": "http://keycloak.core.172.18.128.1.ip.batteriesincl.com/realms/master/clients-registrations/openid-connect",
+    "registration_endpoint": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/clients-registrations/openid-connect",
     "token_endpoint_auth_methods_supported": [
       "private_key_jwt",
       "client_secret_basic",
@@ -241,7 +241,7 @@ defmodule CommonCore.OpenAPI.OIDCTest do
       "S256"
     ],
     "tls_client_certificate_bound_access_tokens": true,
-    "revocation_endpoint": "http://keycloak.core.172.18.128.1.ip.batteriesincl.com/realms/master/protocol/openid-connect/revoke",
+    "revocation_endpoint": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/protocol/openid-connect/revoke",
     "revocation_endpoint_auth_methods_supported": [
       "private_key_jwt",
       "client_secret_basic",
@@ -265,12 +265,12 @@ defmodule CommonCore.OpenAPI.OIDCTest do
     ],
     "backchannel_logout_supported": true,
     "backchannel_logout_session_supported": true,
-    "device_authorization_endpoint": "http://keycloak.core.172.18.128.1.ip.batteriesincl.com/realms/master/protocol/openid-connect/auth/device",
+    "device_authorization_endpoint": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/protocol/openid-connect/auth/device",
     "backchannel_token_delivery_modes_supported": [
       "poll",
       "ping"
     ],
-    "backchannel_authentication_endpoint": "http://keycloak.core.172.18.128.1.ip.batteriesincl.com/realms/master/protocol/openid-connect/ext/ciba/auth",
+    "backchannel_authentication_endpoint": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/protocol/openid-connect/ext/ciba/auth",
     "backchannel_authentication_request_signing_alg_values_supported": [
       "PS384",
       "ES384",
@@ -283,16 +283,16 @@ defmodule CommonCore.OpenAPI.OIDCTest do
       "RS512"
     ],
     "require_pushed_authorization_requests": false,
-    "pushed_authorization_request_endpoint": "http://keycloak.core.172.18.128.1.ip.batteriesincl.com/realms/master/protocol/openid-connect/ext/par/request",
+    "pushed_authorization_request_endpoint": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/protocol/openid-connect/ext/par/request",
     "mtls_endpoint_aliases": {
-      "token_endpoint": "http://keycloak.core.172.18.128.1.ip.batteriesincl.com/realms/master/protocol/openid-connect/token",
-      "revocation_endpoint": "http://keycloak.core.172.18.128.1.ip.batteriesincl.com/realms/master/protocol/openid-connect/revoke",
-      "introspection_endpoint": "http://keycloak.core.172.18.128.1.ip.batteriesincl.com/realms/master/protocol/openid-connect/token/introspect",
-      "device_authorization_endpoint": "http://keycloak.core.172.18.128.1.ip.batteriesincl.com/realms/master/protocol/openid-connect/auth/device",
-      "registration_endpoint": "http://keycloak.core.172.18.128.1.ip.batteriesincl.com/realms/master/clients-registrations/openid-connect",
-      "userinfo_endpoint": "http://keycloak.core.172.18.128.1.ip.batteriesincl.com/realms/master/protocol/openid-connect/userinfo",
-      "pushed_authorization_request_endpoint": "http://keycloak.core.172.18.128.1.ip.batteriesincl.com/realms/master/protocol/openid-connect/ext/par/request",
-      "backchannel_authentication_endpoint": "http://keycloak.core.172.18.128.1.ip.batteriesincl.com/realms/master/protocol/openid-connect/ext/ciba/auth"
+      "token_endpoint": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/protocol/openid-connect/token",
+      "revocation_endpoint": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/protocol/openid-connect/revoke",
+      "introspection_endpoint": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/protocol/openid-connect/token/introspect",
+      "device_authorization_endpoint": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/protocol/openid-connect/auth/device",
+      "registration_endpoint": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/clients-registrations/openid-connect",
+      "userinfo_endpoint": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/protocol/openid-connect/userinfo",
+      "pushed_authorization_request_endpoint": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/protocol/openid-connect/ext/par/request",
+      "backchannel_authentication_endpoint": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/protocol/openid-connect/ext/ciba/auth"
     }
   }
   """
@@ -316,7 +316,7 @@ defmodule CommonCore.OpenAPI.OIDCTest do
                |> OIDC.OIDCConfiguration.new()
 
       assert parsed.registration_endpoint ==
-               "http://keycloak.core.172.18.128.1.ip.batteriesincl.com/realms/master/clients-registrations/openid-connect"
+               "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/clients-registrations/openid-connect"
 
       assert parsed.claim_types_supported == ["normal"]
     end

--- a/platform_umbrella/apps/common_core/test/common_core/state_summary/urls_test.exs
+++ b/platform_umbrella/apps/common_core/test/common_core/state_summary/urls_test.exs
@@ -13,19 +13,19 @@ defmodule CommonCore.StateSummary.URLsTest do
 
     test "returns an HTTPS URI when :cert_manager is installed" do
       summary = build(:install_spec, usage: :kitchen_sink, kube_provider: :provided).target_summary
-      expected = URI.new!("https://keycloak.core.127.0.0.1.ip.batteriesincl.com")
+      expected = URI.new!("https://keycloak.core.127-0-0-1.ip.batteriesincl.com")
       assert expected == uri_for_battery(summary, :keycloak)
     end
 
     test "returns an HTTP URI when :cert_manager is not installed" do
       summary = build(:install_spec, usage: :internal_int_test, kube_provider: :provided).target_summary
-      expected = URI.new!("http://forgejo.core.127.0.0.1.ip.batteriesincl.com")
+      expected = URI.new!("http://forgejo.core.127-0-0-1.ip.batteriesincl.com")
       assert expected == uri_for_battery(summary, :forgejo)
     end
 
     test "returns an HTTP URI on Kind" do
       summary = build(:install_spec, usage: :kitchen_sink, kube_provider: :kind).target_summary
-      expected = URI.new!("http://keycloak.core.127.0.0.1.ip.batteriesincl.com")
+      expected = URI.new!("http://keycloak.core.127-0-0-1.ip.batteriesincl.com")
       assert expected == uri_for_battery(summary, :keycloak)
     end
   end
@@ -33,7 +33,7 @@ defmodule CommonCore.StateSummary.URLsTest do
   describe "keycloak_uri_for_realm/2" do
     test "returns the keycloak URI" do
       summary = build(:install_spec, usage: :kitchen_sink, kube_provider: :aws).target_summary
-      expected = URI.new!("https://keycloak.core.127.0.0.1.ip.batteriesincl.com/realms/test-realm")
+      expected = URI.new!("https://keycloak.core.127-0-0-1.ip.batteriesincl.com/realms/test-realm")
       assert expected == keycloak_uri_for_realm(summary, "test-realm")
     end
   end
@@ -43,7 +43,7 @@ defmodule CommonCore.StateSummary.URLsTest do
       summary = build(:install_spec, usage: :kitchen_sink, kube_provider: :aws).target_summary
 
       expected =
-        URI.new!("https://grafana.core.127.0.0.1.ip.batteriesincl.com/d/cloudnative-pg/cloudnativepg")
+        URI.new!("https://grafana.core.127-0-0-1.ip.batteriesincl.com/d/cloudnative-pg/cloudnativepg")
 
       assert expected == cloud_native_pg_dashboard(summary)
     end
@@ -52,7 +52,7 @@ defmodule CommonCore.StateSummary.URLsTest do
       summary = build(:install_spec, usage: :kitchen_sink, kube_provider: :kind).target_summary
 
       expected =
-        URI.new!("http://grafana.core.127.0.0.1.ip.batteriesincl.com/d/cloudnative-pg/cloudnativepg")
+        URI.new!("http://grafana.core.127-0-0-1.ip.batteriesincl.com/d/cloudnative-pg/cloudnativepg")
 
       assert expected == cloud_native_pg_dashboard(summary)
     end
@@ -63,7 +63,7 @@ defmodule CommonCore.StateSummary.URLsTest do
       summary = build(:install_spec, usage: :kitchen_sink, kube_provider: :aws).target_summary
 
       expected =
-        URI.new!("https://grafana.core.127.0.0.1.ip.batteriesincl.com/d/k8s_views_pods/kubernetes-views-pods")
+        URI.new!("https://grafana.core.127-0-0-1.ip.batteriesincl.com/d/k8s_views_pods/kubernetes-views-pods")
 
       assert expected == pod_dashboard(summary)
     end

--- a/platform_umbrella/apps/common_core/test/support/factory.ex
+++ b/platform_umbrella/apps/common_core/test/support/factory.ex
@@ -52,7 +52,7 @@ defmodule CommonCore.Factory do
   def host_report_factory(attrs \\ %{}) do
     attrs = Map.new(attrs)
 
-    control_server_host = Map.get(attrs, :control_server_host, "control.core.127.0.0.1.ip.batteriesincl.com")
+    control_server_host = Map.get(attrs, :control_server_host, "control.core.127-0-0-1.ip.batteriesincl.com")
 
     %CommonCore.ET.HostReport{control_server_host: control_server_host}
   end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/magic.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/magic.ex
@@ -83,7 +83,7 @@ defmodule ControlServerWeb.Live.MagicHome do
 
   defp battery_link_panel(%{battery: %{type: :battery_core}} = assigns) do
     ~H"""
-    <.a variant="bordered" href="http://home.127.0.0.1.ip.batteriesincl.com:4900/">
+    <.a variant="bordered" href="http://home.127-0-0-1.ip.batteriesincl.com:4900/">
       Batteries Included Home
     </.a>
     <.a variant="bordered" navigate={~p"/content_addressable"}>Content Addressable Storage</.a>

--- a/platform_umbrella/apps/control_server_web/test/__snapshots__/unit/components/keycloak/tables_test/test_keycloak_realms_table__1_with_master.heyya_snap
+++ b/platform_umbrella/apps/control_server_web/test/__snapshots__/unit/components/keycloak/tables_test/test_keycloak_realms_table__1_with_master.heyya_snap
@@ -26,10 +26,8 @@
           <div class="block py-4">
             <span class="">
               
-    <a href="http://keycloak.example.129.99.1.1.ip.batteriesincl.com/admin/master/console" target="_blank" class="font-medium text-primary-dark hover:underline flex">
-  <span class="flex-initial">
-    Keycloak Admin
-  </span>
+    <a href="http://keycloak.example.129-99-1-1.ip.batteriesincl.com/admin/master/console" target="_blank" class="font-medium text-primary-dark hover:underline flex">
+  <span class="flex-initial">Keycloak Admin</span>
   <svg xmlns="http://www.w3.org/2000/svg" class="ml-2 w-5 h-5 flex-none" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
   <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25"/>
 </svg>
@@ -43,7 +41,7 @@
   
             <div class="font-semibold leading-6 text-gray-darkest dark:text-gray-lightest p-4">
               
-    <a id="realm_show_link_00-00-00-00-00-00" href="/keycloak/realm/master" class="inline-flex items-center justify-center gap-2 font-semibold text-sm text-nowrap cursor-pointer disabled:cursor-not-allowed phx-submit-loading:opacity-75 text-gray-dark hover:text-gray disabled:text-gray-light dark:text-gray dark:hover:text-gray-light dark:disabled:text-gray-dark" data-phx-link="redirect" data-phx-link-state="push">
+    <a id="realm_show_link_00-00-00-00-00-00" class="inline-flex items-center justify-center gap-2 font-semibold text-sm text-nowrap cursor-pointer disabled:cursor-not-allowed phx-submit-loading:opacity-75 text-gray-dark hover:text-gray disabled:text-gray-light dark:text-gray dark:hover:text-gray-light dark:disabled:text-gray-dark" href="/keycloak/realm/master" data-phx-link="redirect" data-phx-link-state="push">
   <svg xmlns="http://www.w3.org/2000/svg" class="size-5 text-current stroke-2 pointer-events-none" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
   <path stroke-linecap="round" stroke-linejoin="round" d="M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178Z"/><path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"/>
 </svg>

--- a/platform_umbrella/apps/control_server_web/test/unit/components/keycloak/tables_test.exs
+++ b/platform_umbrella/apps/control_server_web/test/unit/components/keycloak/tables_test.exs
@@ -19,7 +19,7 @@ defmodule ControlServerWeb.Keycloak.TablesTest do
       ~H"""
       <.keycloak_realms_table
         rows={@realms}
-        keycloak_url="http://keycloak.example.129.99.1.1.ip.batteriesincl.com"
+        keycloak_url="http://keycloak.example.129-99-1-1.ip.batteriesincl.com"
       />
       """
     end

--- a/platform_umbrella/apps/kube_services/test/kube_services/system_state/summary_urls_test.exs
+++ b/platform_umbrella/apps/kube_services/test/kube_services/system_state/summary_urls_test.exs
@@ -15,18 +15,18 @@ defmodule KubeServices.SystemState.SummaryURLsTest do
       sepc = build(:install_spec, usage: :kitchen_sink, kube_provider: :aws)
       send(pid, sepc.target_summary)
 
-      assert "https://keycloak.core.127.0.0.1.ip.batteriesincl.com" == SummaryURLs.url_for_battery(pid, :keycloak)
-      assert "https://forgejo.core.127.0.0.1.ip.batteriesincl.com" == SummaryURLs.url_for_battery(pid, :forgejo)
-      assert "https://smtp4dev.core.127.0.0.1.ip.batteriesincl.com" == SummaryURLs.url_for_battery(pid, :smtp4dev)
+      assert "https://keycloak.core.127-0-0-1.ip.batteriesincl.com" == SummaryURLs.url_for_battery(pid, :keycloak)
+      assert "https://forgejo.core.127-0-0-1.ip.batteriesincl.com" == SummaryURLs.url_for_battery(pid, :forgejo)
+      assert "https://smtp4dev.core.127-0-0-1.ip.batteriesincl.com" == SummaryURLs.url_for_battery(pid, :smtp4dev)
     end
 
     test "returns an HTTP URL when :cert_manager is not installed", %{pid: pid} do
       spec = build(:install_spec, usage: :internal_int_test, kube_provider: :provided)
       send(pid, spec.target_summary)
 
-      assert "http://keycloak.core.127.0.0.1.ip.batteriesincl.com" == SummaryURLs.url_for_battery(pid, :keycloak)
-      assert "http://forgejo.core.127.0.0.1.ip.batteriesincl.com" == SummaryURLs.url_for_battery(pid, :forgejo)
-      assert "http://smtp4dev.core.127.0.0.1.ip.batteriesincl.com" == SummaryURLs.url_for_battery(pid, :smtp4dev)
+      assert "http://keycloak.core.127-0-0-1.ip.batteriesincl.com" == SummaryURLs.url_for_battery(pid, :keycloak)
+      assert "http://forgejo.core.127-0-0-1.ip.batteriesincl.com" == SummaryURLs.url_for_battery(pid, :forgejo)
+      assert "http://smtp4dev.core.127-0-0-1.ip.batteriesincl.com" == SummaryURLs.url_for_battery(pid, :smtp4dev)
     end
   end
 
@@ -35,7 +35,7 @@ defmodule KubeServices.SystemState.SummaryURLsTest do
       spec = build(:install_spec, usage: :kitchen_sink, kube_provider: :aws)
       send(pid, spec.target_summary)
 
-      assert "https://keycloak.core.127.0.0.1.ip.batteriesincl.com/realms/test-realm" ==
+      assert "https://keycloak.core.127-0-0-1.ip.batteriesincl.com/realms/test-realm" ==
                SummaryURLs.keycloak_url_for_realm(pid, "test-realm")
     end
   end


### PR DESCRIPTION
Summary:
Rather than .'s use -'s for hostnames. That reduces the segments and
could speed up un-cached dns look up time.

Test Plan:
`http://control.127-0-0-1.ip.batteriesincl.com:4000/`
