### PR TITLE
refactor: switch to different dns hostname

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -115,11 +115,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1719075281,
-        "narHash": "sha256-CyyxvOwFf12I91PBWz43iGT1kjsf5oi6ax7CrvaMyAo=",
+        "lastModified": 1719254875,
+        "narHash": "sha256-ECni+IkwXjusHsm9Sexdtq8weAq/yUyt1TWIemXt3Ko=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a71e967ef3694799d0c418c98332f7ff4cc5f6af",
+        "rev": "2893f56de08021cffd9b6b6dfc70fd9ccd51eb60",
         "type": "github"
       },
       "original": {

--- a/nix/bi.nix
+++ b/nix/bi.nix
@@ -11,7 +11,7 @@
       pname = "bi";
       modules = ../bi/gomod2nix.toml;
       safeRev = self.shortRev or self.dirtyShortRev;
-      version = "0.12.5";
+      version = "0.13.0";
       taggedVersion = "${version}-${safeRev}";
     in
     {

--- a/nix/pastebin-containers.nix
+++ b/nix/pastebin-containers.nix
@@ -4,7 +4,7 @@
     { self', pkgs, ... }:
     let
       safeRev = self.shortRev or self.dirtyShortRev;
-      version = "0.12.5";
+      version = "0.13.0";
       taggedVersion = "${version}-${safeRev}";
       # These are the same contents in all our containers
       contents = [

--- a/nix/pastebin-static.nix
+++ b/nix/pastebin-static.nix
@@ -7,7 +7,7 @@
 
       nodejs = pkgs.nodejs_22;
       npmlock2nix = pkgs.callPackages inputs.npmlock2nix { };
-      version = "0.12.5";
+      version = "0.13.0";
     in
     {
       packages.pastebin-static = npmlock2nix.v2.build {

--- a/nix/pastebin.nix
+++ b/nix/pastebin.nix
@@ -10,7 +10,7 @@
       pwd = ./../pastebin-go;
       src = gitignoreSource pwd;
       modules = pwd + "/gomod2nix.toml";
-      version = "0.12.5";
+      version = "0.13.0";
     in
     {
       packages.pastebin = buildGoApplication {

--- a/nix/platform-containers.nix
+++ b/nix/platform-containers.nix
@@ -4,7 +4,7 @@
     { self', pkgs, ... }:
     let
       safeRev = self.shortRev or self.dirtyShortRev;
-      version = "0.12.5";
+      version = "0.13.0";
       taggedVersion = "${version}-${safeRev}";
       additionalContents = [
         pkgs.bash

--- a/nix/platform.nix
+++ b/nix/platform.nix
@@ -15,7 +15,7 @@
 
       LANG = "C.UTF-8";
       src = gitignoreSource ./../platform_umbrella;
-      version = "0.12.5";
+      version = "0.13.0";
 
       beamPackages = beam.packagesWith beam.interpreters.erlang_27;
       inherit (beamPackages) erlang;

--- a/platform_umbrella/apps/common_core/lib/common_core/et/hosts.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/et/hosts.ex
@@ -2,7 +2,7 @@ defmodule CommonCore.ET.URLs do
   @moduledoc false
   alias CommonCore.Batteries.BatteryCoreConfig
 
-  @local_home "http://home.backend-service.127-0-0-1.ip.batteriesincl.com:4100/api/v1"
+  @local_home "http://home.backend-service.127-0-0-1.batrsinc.co:4100/api/v1"
   @prod_home "https://home.prod.batteriesincl.com/api/v1"
 
   def home_base_url(%BatteryCoreConfig{} = config) do

--- a/platform_umbrella/apps/common_core/lib/common_core/state_summary/access_spec.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/state_summary/access_spec.ex
@@ -33,7 +33,7 @@ defmodule CommonCore.StateSummary.AccessSpec do
   defp valid_host?(host) do
     host != nil and
       String.length(host) > 0 and
-      !String.contains?(host, "..ip.batteriesincl.com") and
+      !String.contains?(host, "..batrsinc.co") and
       !String.contains?(host, "127-0-0-1") and
       valid_uri?(host)
   end

--- a/platform_umbrella/apps/common_core/lib/common_core/state_summary/hosts.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/state_summary/hosts.ex
@@ -93,7 +93,7 @@ defmodule CommonCore.StateSummary.Hosts do
     # up dns look up traversal on the worst case.
     ip = String.replace(ip, ".", "-")
 
-    "#{name}.#{ip}.ip.batteriesincl.com"
+    "#{name}.#{ip}.batrsinc.co"
   end
 
   defp ingress_ips(%StateSummary{} = summary) do

--- a/platform_umbrella/apps/common_core/mix.exs
+++ b/platform_umbrella/apps/common_core/mix.exs
@@ -4,7 +4,7 @@ defmodule CommonCore.MixProject do
   def project do
     [
       app: :common_core,
-      version: "0.12.5",
+      version: "0.13.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/platform_umbrella/apps/common_core/test/common_core/et/host_report_test.exs
+++ b/platform_umbrella/apps/common_core/test/common_core/et/host_report_test.exs
@@ -16,7 +16,7 @@ defmodule CommonCore.ET.HostReportTest do
   test "new/1 with StateSummary", %{state_summary: state_summary} do
     report = HostReport.new!(state_summary)
 
-    assert report.control_server_host == "control.127-0-0-1.ip.batteriesincl.com"
+    assert report.control_server_host == "control.127-0-0-1.batrsinc.co"
   end
 
   test "new/1 with options map" do

--- a/platform_umbrella/apps/common_core/test/common_core/open_api/oidc_test.exs
+++ b/platform_umbrella/apps/common_core/test/common_core/open_api/oidc_test.exs
@@ -5,16 +5,16 @@ defmodule CommonCore.OpenAPI.OIDCTest do
 
   @example_response """
     {
-    "issuer": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master",
-    "authorization_endpoint": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/protocol/openid-connect/auth",
-    "token_endpoint": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/protocol/openid-connect/token",
-    "introspection_endpoint": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/protocol/openid-connect/token/introspect",
-    "userinfo_endpoint": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/protocol/openid-connect/userinfo",
-    "end_session_endpoint": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/protocol/openid-connect/logout",
+    "issuer": "http://keycloak.172-18-128-1.batrsinc.co/realms/master",
+    "authorization_endpoint": "http://keycloak.172-18-128-1.batrsinc.co/realms/master/protocol/openid-connect/auth",
+    "token_endpoint": "http://keycloak.172-18-128-1.batrsinc.co/realms/master/protocol/openid-connect/token",
+    "introspection_endpoint": "http://keycloak.172-18-128-1.batrsinc.co/realms/master/protocol/openid-connect/token/introspect",
+    "userinfo_endpoint": "http://keycloak.172-18-128-1.batrsinc.co/realms/master/protocol/openid-connect/userinfo",
+    "end_session_endpoint": "http://keycloak.172-18-128-1.batrsinc.co/realms/master/protocol/openid-connect/logout",
     "frontchannel_logout_session_supported": true,
     "frontchannel_logout_supported": true,
-    "jwks_uri": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/protocol/openid-connect/certs",
-    "check_session_iframe": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/protocol/openid-connect/login-status-iframe.html",
+    "jwks_uri": "http://keycloak.172-18-128-1.batrsinc.co/realms/master/protocol/openid-connect/certs",
+    "check_session_iframe": "http://keycloak.172-18-128-1.batrsinc.co/realms/master/protocol/openid-connect/login-status-iframe.html",
     "grant_types_supported": [
       "authorization_code",
       "implicit",
@@ -135,7 +135,7 @@ defmodule CommonCore.OpenAPI.OIDCTest do
       "form_post.jwt",
       "jwt"
     ],
-    "registration_endpoint": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/clients-registrations/openid-connect",
+    "registration_endpoint": "http://keycloak.172-18-128-1.batrsinc.co/realms/master/clients-registrations/openid-connect",
     "token_endpoint_auth_methods_supported": [
       "private_key_jwt",
       "client_secret_basic",
@@ -241,7 +241,7 @@ defmodule CommonCore.OpenAPI.OIDCTest do
       "S256"
     ],
     "tls_client_certificate_bound_access_tokens": true,
-    "revocation_endpoint": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/protocol/openid-connect/revoke",
+    "revocation_endpoint": "http://keycloak.172-18-128-1.batrsinc.co/realms/master/protocol/openid-connect/revoke",
     "revocation_endpoint_auth_methods_supported": [
       "private_key_jwt",
       "client_secret_basic",
@@ -265,12 +265,12 @@ defmodule CommonCore.OpenAPI.OIDCTest do
     ],
     "backchannel_logout_supported": true,
     "backchannel_logout_session_supported": true,
-    "device_authorization_endpoint": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/protocol/openid-connect/auth/device",
+    "device_authorization_endpoint": "http://keycloak.172-18-128-1.batrsinc.co/realms/master/protocol/openid-connect/auth/device",
     "backchannel_token_delivery_modes_supported": [
       "poll",
       "ping"
     ],
-    "backchannel_authentication_endpoint": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/protocol/openid-connect/ext/ciba/auth",
+    "backchannel_authentication_endpoint": "http://keycloak.172-18-128-1.batrsinc.co/realms/master/protocol/openid-connect/ext/ciba/auth",
     "backchannel_authentication_request_signing_alg_values_supported": [
       "PS384",
       "ES384",
@@ -283,16 +283,16 @@ defmodule CommonCore.OpenAPI.OIDCTest do
       "RS512"
     ],
     "require_pushed_authorization_requests": false,
-    "pushed_authorization_request_endpoint": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/protocol/openid-connect/ext/par/request",
+    "pushed_authorization_request_endpoint": "http://keycloak.172-18-128-1.batrsinc.co/realms/master/protocol/openid-connect/ext/par/request",
     "mtls_endpoint_aliases": {
-      "token_endpoint": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/protocol/openid-connect/token",
-      "revocation_endpoint": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/protocol/openid-connect/revoke",
-      "introspection_endpoint": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/protocol/openid-connect/token/introspect",
-      "device_authorization_endpoint": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/protocol/openid-connect/auth/device",
-      "registration_endpoint": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/clients-registrations/openid-connect",
-      "userinfo_endpoint": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/protocol/openid-connect/userinfo",
-      "pushed_authorization_request_endpoint": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/protocol/openid-connect/ext/par/request",
-      "backchannel_authentication_endpoint": "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/protocol/openid-connect/ext/ciba/auth"
+      "token_endpoint": "http://keycloak.172-18-128-1.batrsinc.co/realms/master/protocol/openid-connect/token",
+      "revocation_endpoint": "http://keycloak.172-18-128-1.batrsinc.co/realms/master/protocol/openid-connect/revoke",
+      "introspection_endpoint": "http://keycloak.172-18-128-1.batrsinc.co/realms/master/protocol/openid-connect/token/introspect",
+      "device_authorization_endpoint": "http://keycloak.172-18-128-1.batrsinc.co/realms/master/protocol/openid-connect/auth/device",
+      "registration_endpoint": "http://keycloak.172-18-128-1.batrsinc.co/realms/master/clients-registrations/openid-connect",
+      "userinfo_endpoint": "http://keycloak.172-18-128-1.batrsinc.co/realms/master/protocol/openid-connect/userinfo",
+      "pushed_authorization_request_endpoint": "http://keycloak.172-18-128-1.batrsinc.co/realms/master/protocol/openid-connect/ext/par/request",
+      "backchannel_authentication_endpoint": "http://keycloak.172-18-128-1.batrsinc.co/realms/master/protocol/openid-connect/ext/ciba/auth"
     }
   }
   """
@@ -316,7 +316,7 @@ defmodule CommonCore.OpenAPI.OIDCTest do
                |> OIDC.OIDCConfiguration.new()
 
       assert parsed.registration_endpoint ==
-               "http://keycloak.core.172-18-128-1.ip.batteriesincl.com/realms/master/clients-registrations/openid-connect"
+               "http://keycloak.172-18-128-1.batrsinc.co/realms/master/clients-registrations/openid-connect"
 
       assert parsed.claim_types_supported == ["normal"]
     end

--- a/platform_umbrella/apps/common_core/test/common_core/state_summary/urls_test.exs
+++ b/platform_umbrella/apps/common_core/test/common_core/state_summary/urls_test.exs
@@ -13,19 +13,19 @@ defmodule CommonCore.StateSummary.URLsTest do
 
     test "returns an HTTPS URI when :cert_manager is installed" do
       summary = build(:install_spec, usage: :kitchen_sink, kube_provider: :provided).target_summary
-      expected = URI.new!("https://keycloak.127-0-0-1.ip.batteriesincl.com")
+      expected = URI.new!("https://keycloak.127-0-0-1.batrsinc.co")
       assert expected == uri_for_battery(summary, :keycloak)
     end
 
     test "returns an HTTP URI when :cert_manager is not installed" do
       summary = build(:install_spec, usage: :internal_int_test, kube_provider: :provided).target_summary
-      expected = URI.new!("http://forgejo.127-0-0-1.ip.batteriesincl.com")
+      expected = URI.new!("http://forgejo.127-0-0-1.batrsinc.co")
       assert expected == uri_for_battery(summary, :forgejo)
     end
 
     test "returns an HTTP URI on Kind" do
       summary = build(:install_spec, usage: :kitchen_sink, kube_provider: :kind).target_summary
-      expected = URI.new!("http://keycloak.127-0-0-1.ip.batteriesincl.com")
+      expected = URI.new!("http://keycloak.127-0-0-1.batrsinc.co")
       assert expected == uri_for_battery(summary, :keycloak)
     end
   end
@@ -33,7 +33,7 @@ defmodule CommonCore.StateSummary.URLsTest do
   describe "keycloak_uri_for_realm/2" do
     test "returns the keycloak URI" do
       summary = build(:install_spec, usage: :kitchen_sink, kube_provider: :aws).target_summary
-      expected = URI.new!("https://keycloak.127-0-0-1.ip.batteriesincl.com/realms/test-realm")
+      expected = URI.new!("https://keycloak.127-0-0-1.batrsinc.co/realms/test-realm")
       assert expected == keycloak_uri_for_realm(summary, "test-realm")
     end
   end
@@ -43,7 +43,7 @@ defmodule CommonCore.StateSummary.URLsTest do
       summary = build(:install_spec, usage: :kitchen_sink, kube_provider: :aws).target_summary
 
       expected =
-        URI.new!("https://grafana.127-0-0-1.ip.batteriesincl.com/d/cloudnative-pg/cloudnativepg")
+        URI.new!("https://grafana.127-0-0-1.batrsinc.co/d/cloudnative-pg/cloudnativepg")
 
       assert expected == cloud_native_pg_dashboard(summary)
     end
@@ -52,7 +52,7 @@ defmodule CommonCore.StateSummary.URLsTest do
       summary = build(:install_spec, usage: :kitchen_sink, kube_provider: :kind).target_summary
 
       expected =
-        URI.new!("http://grafana.127-0-0-1.ip.batteriesincl.com/d/cloudnative-pg/cloudnativepg")
+        URI.new!("http://grafana.127-0-0-1.batrsinc.co/d/cloudnative-pg/cloudnativepg")
 
       assert expected == cloud_native_pg_dashboard(summary)
     end
@@ -63,7 +63,7 @@ defmodule CommonCore.StateSummary.URLsTest do
       summary = build(:install_spec, usage: :kitchen_sink, kube_provider: :aws).target_summary
 
       expected =
-        URI.new!("https://grafana.127-0-0-1.ip.batteriesincl.com/d/k8s_views_pods/kubernetes-views-pods")
+        URI.new!("https://grafana.127-0-0-1.batrsinc.co/d/k8s_views_pods/kubernetes-views-pods")
 
       assert expected == pod_dashboard(summary)
     end

--- a/platform_umbrella/apps/common_core/test/support/factory.ex
+++ b/platform_umbrella/apps/common_core/test/support/factory.ex
@@ -52,7 +52,7 @@ defmodule CommonCore.Factory do
   def host_report_factory(attrs \\ %{}) do
     attrs = Map.new(attrs)
 
-    control_server_host = Map.get(attrs, :control_server_host, "control.core.127-0-0-1.ip.batteriesincl.com")
+    control_server_host = Map.get(attrs, :control_server_host, "control.127-0-0-1.batrsinc.co")
 
     %CommonCore.ET.HostReport{control_server_host: control_server_host}
   end

--- a/platform_umbrella/apps/common_ui/mix.exs
+++ b/platform_umbrella/apps/common_ui/mix.exs
@@ -4,7 +4,7 @@ defmodule CommonUI.MixProject do
   def project do
     [
       app: :common_ui,
-      version: "0.12.5",
+      version: "0.13.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/platform_umbrella/apps/control_server/mix.exs
+++ b/platform_umbrella/apps/control_server/mix.exs
@@ -4,7 +4,7 @@ defmodule ControlServer.MixProject do
   def project do
     [
       app: :control_server,
-      version: "0.12.5",
+      version: "0.13.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/csp.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/csp.ex
@@ -5,29 +5,41 @@ defmodule ControlServerWeb.CSP do
       "self",
       "unsafe-eval",
       "unsafe-inline",
-      {:url, "http://*.ip.batteriesincl.com"},
-      {:url, "http://*.ip.batteriesincl.com:4000"}
+      {:url, "http://*.batrsinc.co"},
+      {:url, "http://*.batrsinc.co:4000"},
+      {:url, "http://*.batteriesincl.com"},
+      {:url, "http://*.ip.batteriesincl.com:4100"}
     ],
     "default-src" => [
       "self",
-      {:url, "https://rsms.me"},
       "unsafe-inline",
-      {:url, "http://*.ip.batteriesincl.com"},
-      {:url, "http://*.ip.batteriesincl.com:4000"}
+      {:url, "http://*.batrsinc.co"},
+      {:url, "http://*.batrsinc.co:4000"},
+      {:url, "http://*.batteriesincl.com"},
+      {:url, "http://*.ip.batteriesincl.com:4100"}
     ],
     "img-src" => [
       "self",
       {:url, "data:"},
-      {:url, "https://images.unsplash.com"},
-      {:url, "https://robohash.org/"},
-      {:url, "http://*.ip.batteriesincl.com"},
-      {:url, "http://*.ip.batteriesincl.com:4000"}
+      {:url, "http://*.batrsinc.co"},
+      {:url, "http://*.batrsinc.co:4000"},
+      {:url, "http://*.batteriesincl.com"},
+      {:url, "http://*.ip.batteriesincl.com:4100"}
     ],
-    "font-src" => ["self", {:url, "data:"}, {:url, "https://rsms.me"}],
+    "font-src" => [
+      "self",
+      {:url, "data:"},
+      {:url, "http://*.batrsinc.co"},
+      {:url, "http://*.batrsinc.co:4000"},
+      {:url, "http://*.batteriesincl.com"},
+      {:url, "http://*.ip.batteriesincl.com:4100"}
+    ],
     "frame-src" => [
       "self",
-      {:url, "http://*.ip.batteriesincl.com"},
-      {:url, "http://*.ip.batteriesincl.com:4000"},
+      {:url, "http://*.batrsinc.co"},
+      {:url, "http://*.batrsinc.co:4000"},
+      {:url, "http://*.batteriesincl.com"},
+      {:url, "http://*.ip.batteriesincl.com:4100"},
       {:url, "https://www.youtube.com"}
     ]
   }

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/magic.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/magic.ex
@@ -83,7 +83,7 @@ defmodule ControlServerWeb.Live.MagicHome do
 
   defp battery_link_panel(%{battery: %{type: :battery_core}} = assigns) do
     ~H"""
-    <.a variant="bordered" href="http://home.127-0-0-1.ip.batteriesincl.com:4900/">
+    <.a variant="bordered" href="http://home.127-0-0-1.batrsinc.co:4900/">
       Batteries Included Home
     </.a>
     <.a variant="bordered" navigate={~p"/content_addressable"}>Content Addressable Storage</.a>

--- a/platform_umbrella/apps/control_server_web/mix.exs
+++ b/platform_umbrella/apps/control_server_web/mix.exs
@@ -4,7 +4,7 @@ defmodule ControlServerWeb.MixProject do
   def project do
     [
       app: :control_server_web,
-      version: "0.12.5",
+      version: "0.13.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/platform_umbrella/apps/control_server_web/test/__snapshots__/unit/components/keycloak/tables_test/test_keycloak_realms_table__1_with_master.heyya_snap
+++ b/platform_umbrella/apps/control_server_web/test/__snapshots__/unit/components/keycloak/tables_test/test_keycloak_realms_table__1_with_master.heyya_snap
@@ -25,42 +25,42 @@
         </td><td phx-click="[[&quot;navigate&quot;,{&quot;replace&quot;:false,&quot;href&quot;:&quot;/keycloak/realm/master&quot;}]]" class="p-0 px-2 align-top hover:cursor-pointer">
           <div class="block py-4">
             <span class="">
-              
-    <a href="http://keycloak.example.129-99-1-1.ip.batteriesincl.com/admin/master/console" target="_blank" class="font-medium text-primary-dark hover:underline flex">
+
+    <a href="http://keycloak.example.129-99-1-1.batrsinc.co/admin/master/console" target="_blank" class="font-medium text-primary-dark hover:underline flex">
   <span class="flex-initial">Keycloak Admin</span>
   <svg xmlns="http://www.w3.org/2000/svg" class="ml-2 w-5 h-5 flex-none" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
   <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25"/>
 </svg>
 </a>
-  
+
             </span>
           </div>
         </td>
         <td class="w-14 p-0">
           <div class="gap-4 lg:gap-6 flex whitespace-nowrap text-sm font-medium justify-around">
-  
+
             <div class="font-semibold leading-6 text-gray-darkest dark:text-gray-lightest p-4">
-              
+
     <a id="realm_show_link_00-00-00-00-00-00" class="inline-flex items-center justify-center gap-2 font-semibold text-sm text-nowrap cursor-pointer disabled:cursor-not-allowed phx-submit-loading:opacity-75 text-gray-dark hover:text-gray disabled:text-gray-light dark:text-gray dark:hover:text-gray-light dark:disabled:text-gray-dark" href="/keycloak/realm/master" data-phx-link="redirect" data-phx-link-state="push">
   <svg xmlns="http://www.w3.org/2000/svg" class="size-5 text-current stroke-2 pointer-events-none" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
   <path stroke-linecap="round" stroke-linejoin="round" d="M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178Z"/><path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"/>
 </svg>
 
-  
 
-  
+
+
 </a>
 
     <div class="hidden" id="tooltip-realm_show_link_00-00-00-00-00-00" phx-hook="Tooltip" data-target="realm_show_link_00-00-00-00-00-00" data-tippy-options="{}">
   <div>
-    
+
       Show realm Keycloak
-    
+
   </div>
 </div>
-  
+
             </div>
-          
+
 </div>
         </td>
       </tr>

--- a/platform_umbrella/apps/control_server_web/test/unit/components/keycloak/tables_test.exs
+++ b/platform_umbrella/apps/control_server_web/test/unit/components/keycloak/tables_test.exs
@@ -19,7 +19,7 @@ defmodule ControlServerWeb.Keycloak.TablesTest do
       ~H"""
       <.keycloak_realms_table
         rows={@realms}
-        keycloak_url="http://keycloak.example.129-99-1-1.ip.batteriesincl.com"
+        keycloak_url="http://keycloak.example.129-99-1-1.batrsinc.co"
       />
       """
     end

--- a/platform_umbrella/apps/event_center/mix.exs
+++ b/platform_umbrella/apps/event_center/mix.exs
@@ -4,7 +4,7 @@ defmodule EventCenter.MixProject do
   def project do
     [
       app: :event_center,
-      version: "0.12.5",
+      version: "0.13.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/platform_umbrella/apps/home_base/mix.exs
+++ b/platform_umbrella/apps/home_base/mix.exs
@@ -4,7 +4,7 @@ defmodule HomeBase.MixProject do
   def project do
     [
       app: :home_base,
-      version: "0.12.5",
+      version: "0.13.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/platform_umbrella/apps/home_base_web/mix.exs
+++ b/platform_umbrella/apps/home_base_web/mix.exs
@@ -4,7 +4,7 @@ defmodule HomeBaseWeb.MixProject do
   def project do
     [
       app: :home_base_web,
-      version: "0.12.5",
+      version: "0.13.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/platform_umbrella/apps/kube_services/mix.exs
+++ b/platform_umbrella/apps/kube_services/mix.exs
@@ -4,7 +4,7 @@ defmodule KubeServices.MixProject do
   def project do
     [
       app: :kube_services,
-      version: "0.12.5",
+      version: "0.13.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/platform_umbrella/apps/kube_services/test/kube_services/system_state/summary_urls_test.exs
+++ b/platform_umbrella/apps/kube_services/test/kube_services/system_state/summary_urls_test.exs
@@ -15,18 +15,18 @@ defmodule KubeServices.SystemState.SummaryURLsTest do
       sepc = build(:install_spec, usage: :kitchen_sink, kube_provider: :aws)
       send(pid, sepc.target_summary)
 
-      assert "https://keycloak.127-0-0-1.ip.batteriesincl.com" == SummaryURLs.url_for_battery(pid, :keycloak)
-      assert "https://forgejo.127-0-0-1.ip.batteriesincl.com" == SummaryURLs.url_for_battery(pid, :forgejo)
-      assert "https://smtp4dev.127-0-0-1.ip.batteriesincl.com" == SummaryURLs.url_for_battery(pid, :smtp4dev)
+      assert "https://keycloak.127-0-0-1.batrsinc.co" == SummaryURLs.url_for_battery(pid, :keycloak)
+      assert "https://forgejo.127-0-0-1.batrsinc.co" == SummaryURLs.url_for_battery(pid, :forgejo)
+      assert "https://smtp4dev.127-0-0-1.batrsinc.co" == SummaryURLs.url_for_battery(pid, :smtp4dev)
     end
 
     test "returns an HTTP URL when :cert_manager is not installed", %{pid: pid} do
       spec = build(:install_spec, usage: :internal_int_test, kube_provider: :provided)
       send(pid, spec.target_summary)
 
-      assert "http://keycloak.127-0-0-1.ip.batteriesincl.com" == SummaryURLs.url_for_battery(pid, :keycloak)
-      assert "http://forgejo.127-0-0-1.ip.batteriesincl.com" == SummaryURLs.url_for_battery(pid, :forgejo)
-      assert "http://smtp4dev.127-0-0-1.ip.batteriesincl.com" == SummaryURLs.url_for_battery(pid, :smtp4dev)
+      assert "http://keycloak.127-0-0-1.batrsinc.co" == SummaryURLs.url_for_battery(pid, :keycloak)
+      assert "http://forgejo.127-0-0-1.batrsinc.co" == SummaryURLs.url_for_battery(pid, :forgejo)
+      assert "http://smtp4dev.127-0-0-1.batrsinc.co" == SummaryURLs.url_for_battery(pid, :smtp4dev)
     end
   end
 
@@ -35,7 +35,7 @@ defmodule KubeServices.SystemState.SummaryURLsTest do
       spec = build(:install_spec, usage: :kitchen_sink, kube_provider: :aws)
       send(pid, spec.target_summary)
 
-      assert "https://keycloak.127-0-0-1.ip.batteriesincl.com/realms/test-realm" ==
+      assert "https://keycloak.127-0-0-1.batrsinc.co/realms/test-realm" ==
                SummaryURLs.keycloak_url_for_realm(pid, "test-realm")
     end
   end

--- a/platform_umbrella/mix.exs
+++ b/platform_umbrella/mix.exs
@@ -4,7 +4,7 @@ defmodule ControlServer.Umbrella.MixProject do
   def project do
     [
       apps_path: "apps",
-      version: "0.12.5",
+      version: "0.13.0",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       releases: releases(),

--- a/static/src/content/doc/our_tools.md
+++ b/static/src/content/doc/our_tools.md
@@ -180,7 +180,7 @@ changed based on your code changes. This is nice for a fast, inner-loop.
 
 Example
 
-```
+```sh
 bix ex-test
 ```
 
@@ -193,7 +193,7 @@ of time.
 
 Example
 
-```
+```sh
 bix ex-test-quick
 ```
 
@@ -208,7 +208,7 @@ This is also the command that is used in CI.
 
 Example
 
-```
+```sh
 bix ex-test-deep
 ```
 
@@ -243,13 +243,13 @@ any directory in the repo.
 Example:
 
 ```sh
-cd cli && bix m help test
+cd bi && bix m help test
 ```
 
 ## Dashboard
 
 Example: The URL is usually
-[http://control.127.0.0.1.ip.batteriesincl.com:4000/dashboard/home](http://control.127.0.0.1.ip.batteriesincl.com:4000/dashboard/home)
+[http://control.127-0-0-1.batrsinc.co:4000/dashboard/home](http://control.127-0-0-1.batrsinc.co:4000/dashboard/home)
 
 `/dashboard` will get you a view into the ecto db, the Erlang VM, the process
 trees, and HTTP request logger for Phoenix. It's super cool stuff.


### PR DESCRIPTION
Summary:
We don't want our prod hostnames to share cookies with customer
installs. So move installs to `batrsinc.co`

Test Plan:
- Tests updated
- Will land when `dig 127-0-0-1.batrsinc.co @8.8.8.8` shows the correct
  result
