### PR TITLE
Send correct method for signup form action trigger

### DIFF
--- a/platform_umbrella/apps/home_base_web/lib/home_base_web/live/signup_live.ex
+++ b/platform_umbrella/apps/home_base_web/lib/home_base_web/live/signup_live.ex
@@ -51,6 +51,7 @@ defmodule HomeBaseWeb.SignupLive do
     <.simple_form
       for={@form}
       id="signup-form"
+      method="post"
       action={~p"/login?action=registered"}
       phx-change="validate"
       phx-submit="save"


### PR DESCRIPTION
This started sending a PUT request by default at some point, causing a 404 🤨 Must be a bug in Phoenix with `action` and `phx-trigger-action`. It's supposed to default to a POST request.