### PR TITLE
Edit project page and link in project navigation

### DIFF
--- a/platform_umbrella/apps/common_ui/lib/common_ui/components/form.ex
+++ b/platform_umbrella/apps/common_ui/lib/common_ui/components/form.ex
@@ -66,7 +66,7 @@ defmodule CommonUI.Components.Form do
       <%= render_slot(@inner_block) %>
     </div>
 
-    <div class="flex items-center justify-end gap-2 mt-6">
+    <div :if={@actions != []} class="flex items-center justify-end gap-2 mt-6">
       <%= render_slot(@actions) %>
     </div>
     """
@@ -81,7 +81,7 @@ defmodule CommonUI.Components.Form do
 
         <%= render_slot(@inner_block) %>
 
-        <:actions>
+        <:actions :if={@actions != []}>
           <%= render_slot(@actions) %>
         </:actions>
       </.simple_form>

--- a/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/form_test/test_stepped_form.heyya_snap
+++ b/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/form_test/test_stepped_form.heyya_snap
@@ -46,9 +46,7 @@
         
 </div>
 
-<div class="flex items-center justify-end gap-2 mt-6">
-  
-</div>
+
       
   </div>
 </div>

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/projects/edit.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/projects/edit.ex
@@ -1,0 +1,74 @@
+defmodule ControlServerWeb.Projects.EditLive do
+  @moduledoc false
+  use ControlServerWeb, {:live_view, layout: :sidebar}
+
+  alias CommonCore.Projects.Project
+  alias ControlServer.Projects
+
+  def mount(%{"id" => id}, _session, socket) do
+    project = Projects.get_project!(id)
+    changeset = Projects.change_project(project)
+
+    {:ok,
+     socket
+     |> assign(:page_title, "Edit Project")
+     |> assign(:form, to_form(changeset))
+     |> assign(:project, project)}
+  end
+
+  def handle_event("validate", %{"project" => params}, socket) do
+    changeset =
+      socket.assigns.project
+      |> Projects.change_project(params)
+      |> Map.put(:action, :validate)
+
+    {:noreply, assign(socket, :form, to_form(changeset))}
+  end
+
+  def handle_event("save", %{"project" => params}, socket) do
+    case Projects.update_project(socket.assigns.project, params) do
+      {:ok, project} ->
+        {:noreply,
+         socket
+         |> put_flash(:global_success, "Project updated successfully")
+         |> push_navigate(to: ~p"/projects/#{project.id}")}
+
+      {:error, changeset} ->
+        {:noreply, assign(socket, :form, to_form(changeset))}
+    end
+  end
+
+  def render(assigns) do
+    ~H"""
+    <.page_header title={@page_title} back_link={~p"/projects/#{@project.id}"}>
+      <.button variant="dark" type="submit" form="edit-project-form" phx-disable-with="Saving…">
+        Save Project
+      </.button>
+    </.page_header>
+
+    <.panel>
+      <.simple_form for={@form} id="edit-project-form" phx-change="validate" phx-submit="save">
+        <.grid variant="col-2">
+          <.input field={@form[:name]} label="Project Name" placeholder="Enter project name" />
+
+          <.input
+            field={@form[:type]}
+            type="select"
+            label="Project Type"
+            placeholder="Select project type"
+            options={Project.type_options_for_select()}
+          />
+        </.grid>
+
+        <.input
+          field={@form[:description]}
+          type="textarea"
+          label="Project Description"
+          placeholder="Enter a project description (optional)"
+          maxlength={1000}
+        />
+      </.simple_form>
+    </.panel>
+    """
+  end
+end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/projects/index.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/projects/index.ex
@@ -41,6 +41,17 @@ defmodule ControlServerWeb.Projects.IndexLive do
           <.flex class="justify-items-center">
             <.button
               variant="minimal"
+              link={~p"/projects/#{project.id}/edit"}
+              icon={:pencil}
+              id={"edit_project_" <> project.id}
+            />
+
+            <.tooltip target_id={"edit_project_" <> project.id}>
+              Edit Project
+            </.tooltip>
+
+            <.button
+              variant="minimal"
               phx-click="delete"
               phx-value-id={project.id}
               data-confirm={"Are you sure you want to delete the \"#{project.name}\" project?"}

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/projects/show.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/projects/show.ex
@@ -62,6 +62,7 @@ defmodule ControlServerWeb.Projects.ShowLive do
     <.page_header title={@page_title <> ": " <> @project.name} back_link={~p"/projects"}>
       <.flex>
         <.tooltip target_id="add-tooltip">Add Resources</.tooltip>
+        <.tooltip target_id="edit-tooltip">Edit Project</.tooltip>
         <.tooltip :if={@timeline_installed} target_id="history-tooltip">Project History</.tooltip>
         <.flex gaps="0">
           <.dropdown>
@@ -81,6 +82,13 @@ defmodule ControlServerWeb.Projects.ShowLive do
               FerretDB
             </.dropdown_link>
           </.dropdown>
+
+          <.button
+            id="edit-tooltip"
+            variant="icon"
+            icon={:pencil}
+            link={~p"/projects/#{@project.id}/edit"}
+          />
 
           <.button
             :if={@timeline_installed}

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/router.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/router.ex
@@ -64,6 +64,7 @@ defmodule ControlServerWeb.Router do
     live "/", IndexLive
     live "/new", NewLive
     live "/:id", ShowLive
+    live "/:id/edit", EditLive
     live "/:id/timeline", TimelineLive
   end
 

--- a/platform_umbrella/apps/control_server_web/test/unit/live/project_live_test.exs
+++ b/platform_umbrella/apps/control_server_web/test/unit/live/project_live_test.exs
@@ -47,4 +47,20 @@ defmodule ControlServerWeb.ProjectLiveTest do
       assert html =~ project.name
     end
   end
+
+  describe "/projects/:id/edit" do
+    @tag :slow
+    test "should edit a project", %{conn: conn, project: project} do
+      {:ok, view, _} = live(conn, ~p"/projects/#{project}/edit")
+
+      {:ok, _, html} =
+        view
+        |> element("#edit-project-form")
+        |> render_submit(%{project: %{name: "New Name", description: "New Description"}})
+        |> follow_redirect(conn, ~p"/projects/#{project}")
+
+      assert html =~ "New Name"
+      assert html =~ "New Description"
+    end
+  end
 end


### PR DESCRIPTION
This adds a new page for editing a project, and a link to it in the project page navigation.

---

<img width="1003" alt="Screenshot 2024-06-24 at 15 02 02" src="https://github.com/batteries-included/batteries-included/assets/911274/d766775d-fcf0-4621-bdde-2b03442f1702">

<img width="989" alt="Screenshot 2024-06-24 at 15 01 28" src="https://github.com/batteries-included/batteries-included/assets/911274/9d56a25f-e008-454b-878a-389700a5ecc4">