### PR TITLE
refactor: remove concept of a group in dns names

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/state_summary/hosts.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/state_summary/hosts.ex
@@ -47,7 +47,7 @@ defmodule CommonCore.StateSummary.Hosts do
   end
 
   def knative_base_host(%StateSummary{} = summary) do
-    summary |> ip() |> host("webapp", "user")
+    summary |> ip() |> host("webapp")
   end
 
   def knative_host(%StateSummary{} = summary, service) do
@@ -56,7 +56,7 @@ defmodule CommonCore.StateSummary.Hosts do
   end
 
   def notebooks_host(%StateSummary{} = summary) do
-    summary |> ip() |> host("notebooks", "user")
+    summary |> ip() |> host("notebooks")
   end
 
   # NOTE: This isn't exclusive - some batteries don't have host mappings, some may have multiple in the future.
@@ -81,19 +81,19 @@ defmodule CommonCore.StateSummary.Hosts do
     summary |> ingress_ips() |> List.first()
   end
 
-  defp host(ip, name, group \\ "core")
+  defp host(ip, name)
 
-  defp host(nil, _name, _group), do: ""
+  defp host(nil, _name), do: ""
 
-  defp host("", _name, _group), do: ""
+  defp host("", _name), do: ""
 
-  defp host(ip, name, group) do
+  defp host(ip, name) do
     # Rather than new hostnames for each octet of ips replace with -'s
     # For one this makes lets encrypt happy, and it also speeds
     # up dns look up traversal on the worst case.
     ip = String.replace(ip, ".", "-")
 
-    "#{name}.#{group}.#{ip}.ip.batteriesincl.com"
+    "#{name}.#{ip}.ip.batteriesincl.com"
   end
 
   defp ingress_ips(%StateSummary{} = summary) do

--- a/platform_umbrella/apps/common_core/test/common_core/et/host_report_test.exs
+++ b/platform_umbrella/apps/common_core/test/common_core/et/host_report_test.exs
@@ -16,7 +16,7 @@ defmodule CommonCore.ET.HostReportTest do
   test "new/1 with StateSummary", %{state_summary: state_summary} do
     report = HostReport.new!(state_summary)
 
-    assert report.control_server_host == "control.core.127-0-0-1.ip.batteriesincl.com"
+    assert report.control_server_host == "control.127-0-0-1.ip.batteriesincl.com"
   end
 
   test "new/1 with options map" do

--- a/platform_umbrella/apps/common_core/test/common_core/state_summary/urls_test.exs
+++ b/platform_umbrella/apps/common_core/test/common_core/state_summary/urls_test.exs
@@ -13,19 +13,19 @@ defmodule CommonCore.StateSummary.URLsTest do
 
     test "returns an HTTPS URI when :cert_manager is installed" do
       summary = build(:install_spec, usage: :kitchen_sink, kube_provider: :provided).target_summary
-      expected = URI.new!("https://keycloak.core.127-0-0-1.ip.batteriesincl.com")
+      expected = URI.new!("https://keycloak.127-0-0-1.ip.batteriesincl.com")
       assert expected == uri_for_battery(summary, :keycloak)
     end
 
     test "returns an HTTP URI when :cert_manager is not installed" do
       summary = build(:install_spec, usage: :internal_int_test, kube_provider: :provided).target_summary
-      expected = URI.new!("http://forgejo.core.127-0-0-1.ip.batteriesincl.com")
+      expected = URI.new!("http://forgejo.127-0-0-1.ip.batteriesincl.com")
       assert expected == uri_for_battery(summary, :forgejo)
     end
 
     test "returns an HTTP URI on Kind" do
       summary = build(:install_spec, usage: :kitchen_sink, kube_provider: :kind).target_summary
-      expected = URI.new!("http://keycloak.core.127-0-0-1.ip.batteriesincl.com")
+      expected = URI.new!("http://keycloak.127-0-0-1.ip.batteriesincl.com")
       assert expected == uri_for_battery(summary, :keycloak)
     end
   end
@@ -33,7 +33,7 @@ defmodule CommonCore.StateSummary.URLsTest do
   describe "keycloak_uri_for_realm/2" do
     test "returns the keycloak URI" do
       summary = build(:install_spec, usage: :kitchen_sink, kube_provider: :aws).target_summary
-      expected = URI.new!("https://keycloak.core.127-0-0-1.ip.batteriesincl.com/realms/test-realm")
+      expected = URI.new!("https://keycloak.127-0-0-1.ip.batteriesincl.com/realms/test-realm")
       assert expected == keycloak_uri_for_realm(summary, "test-realm")
     end
   end
@@ -43,7 +43,7 @@ defmodule CommonCore.StateSummary.URLsTest do
       summary = build(:install_spec, usage: :kitchen_sink, kube_provider: :aws).target_summary
 
       expected =
-        URI.new!("https://grafana.core.127-0-0-1.ip.batteriesincl.com/d/cloudnative-pg/cloudnativepg")
+        URI.new!("https://grafana.127-0-0-1.ip.batteriesincl.com/d/cloudnative-pg/cloudnativepg")
 
       assert expected == cloud_native_pg_dashboard(summary)
     end
@@ -52,7 +52,7 @@ defmodule CommonCore.StateSummary.URLsTest do
       summary = build(:install_spec, usage: :kitchen_sink, kube_provider: :kind).target_summary
 
       expected =
-        URI.new!("http://grafana.core.127-0-0-1.ip.batteriesincl.com/d/cloudnative-pg/cloudnativepg")
+        URI.new!("http://grafana.127-0-0-1.ip.batteriesincl.com/d/cloudnative-pg/cloudnativepg")
 
       assert expected == cloud_native_pg_dashboard(summary)
     end
@@ -63,7 +63,7 @@ defmodule CommonCore.StateSummary.URLsTest do
       summary = build(:install_spec, usage: :kitchen_sink, kube_provider: :aws).target_summary
 
       expected =
-        URI.new!("https://grafana.core.127-0-0-1.ip.batteriesincl.com/d/k8s_views_pods/kubernetes-views-pods")
+        URI.new!("https://grafana.127-0-0-1.ip.batteriesincl.com/d/k8s_views_pods/kubernetes-views-pods")
 
       assert expected == pod_dashboard(summary)
     end

--- a/platform_umbrella/apps/kube_services/test/kube_services/system_state/summary_urls_test.exs
+++ b/platform_umbrella/apps/kube_services/test/kube_services/system_state/summary_urls_test.exs
@@ -15,18 +15,18 @@ defmodule KubeServices.SystemState.SummaryURLsTest do
       sepc = build(:install_spec, usage: :kitchen_sink, kube_provider: :aws)
       send(pid, sepc.target_summary)
 
-      assert "https://keycloak.core.127-0-0-1.ip.batteriesincl.com" == SummaryURLs.url_for_battery(pid, :keycloak)
-      assert "https://forgejo.core.127-0-0-1.ip.batteriesincl.com" == SummaryURLs.url_for_battery(pid, :forgejo)
-      assert "https://smtp4dev.core.127-0-0-1.ip.batteriesincl.com" == SummaryURLs.url_for_battery(pid, :smtp4dev)
+      assert "https://keycloak.127-0-0-1.ip.batteriesincl.com" == SummaryURLs.url_for_battery(pid, :keycloak)
+      assert "https://forgejo.127-0-0-1.ip.batteriesincl.com" == SummaryURLs.url_for_battery(pid, :forgejo)
+      assert "https://smtp4dev.127-0-0-1.ip.batteriesincl.com" == SummaryURLs.url_for_battery(pid, :smtp4dev)
     end
 
     test "returns an HTTP URL when :cert_manager is not installed", %{pid: pid} do
       spec = build(:install_spec, usage: :internal_int_test, kube_provider: :provided)
       send(pid, spec.target_summary)
 
-      assert "http://keycloak.core.127-0-0-1.ip.batteriesincl.com" == SummaryURLs.url_for_battery(pid, :keycloak)
-      assert "http://forgejo.core.127-0-0-1.ip.batteriesincl.com" == SummaryURLs.url_for_battery(pid, :forgejo)
-      assert "http://smtp4dev.core.127-0-0-1.ip.batteriesincl.com" == SummaryURLs.url_for_battery(pid, :smtp4dev)
+      assert "http://keycloak.127-0-0-1.ip.batteriesincl.com" == SummaryURLs.url_for_battery(pid, :keycloak)
+      assert "http://forgejo.127-0-0-1.ip.batteriesincl.com" == SummaryURLs.url_for_battery(pid, :forgejo)
+      assert "http://smtp4dev.127-0-0-1.ip.batteriesincl.com" == SummaryURLs.url_for_battery(pid, :smtp4dev)
     end
   end
 
@@ -35,7 +35,7 @@ defmodule KubeServices.SystemState.SummaryURLsTest do
       spec = build(:install_spec, usage: :kitchen_sink, kube_provider: :aws)
       send(pid, spec.target_summary)
 
-      assert "https://keycloak.core.127-0-0-1.ip.batteriesincl.com/realms/test-realm" ==
+      assert "https://keycloak.127-0-0-1.ip.batteriesincl.com/realms/test-realm" ==
                SummaryURLs.keycloak_url_for_realm(pid, "test-realm")
     end
   end


### PR DESCRIPTION
Summary:
We had the idea of a group of hostnames, to put core functionality and
user functionality on different domains but hopefully sharing oauth.
That didn't work out that way. So now it's just visual noise. Remove it.

Test Plan:
Tests updated
