### PR TITLE
feat: enable SSL for knative services

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/resources/cert_manager/certificates.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/resources/cert_manager/certificates.ex
@@ -33,13 +33,11 @@ defmodule CommonCore.Resources.CertManager.Certificates.Cert do
   alias CommonCore.Resources.FilterResource, as: F
   alias CommonCore.StateSummary.Hosts
 
-  resource(:certificate, battery, state) do
-    name = "#{sanitize(battery.type)}-ingress-cert"
+  resource(:certificate, %{type: type} = _battery, state) do
+    name = "#{sanitize(type)}-ingress-cert"
     namespace = istio_namespace(state)
 
-    host = Hosts.for_battery(state, battery.type)
-    issuer = find_state_resource(state, :certmanager_cluster_issuer, "lets-encrypt")
-    spec = build_cert_spec(name, host, issuer)
+    spec = spec(name, state, type)
 
     :certmanager_certificate
     |> B.build_resource()
@@ -49,13 +47,26 @@ defmodule CommonCore.Resources.CertManager.Certificates.Cert do
     |> F.require_non_empty(spec)
   end
 
-  defp build_cert_spec(_name, host, issuer) when is_nil(host) or is_nil(issuer), do: nil
+  defp spec(name, state, :knative) do
+    hosts = Enum.map(state.knative_services, &Hosts.knative_host(state, &1))
+    issuer = find_state_resource(state, :certmanager_cluster_issuer, "lets-encrypt")
+    build_cert_spec(name, hosts, issuer)
+  end
 
-  defp build_cert_spec(name, host, issuer) do
+  defp spec(name, state, battery_type) do
+    host = Hosts.for_battery(state, battery_type)
+    issuer = find_state_resource(state, :certmanager_cluster_issuer, "lets-encrypt")
+    build_cert_spec(name, host, issuer)
+  end
+
+  defp build_cert_spec(_name, host, issuer) when is_nil(host) or is_nil(issuer), do: nil
+  defp build_cert_spec(name, host, issuer) when is_binary(host), do: build_cert_spec(name, [host], issuer)
+
+  defp build_cert_spec(name, hosts, issuer) do
     issuer_ref = B.issuer_ref(group(issuer), kind(issuer), name(issuer))
 
     %{
-      "dnsNames" => [host],
+      "dnsNames" => hosts,
       "issuerRef" => issuer_ref,
       "secretName" => name
     }

--- a/platform_umbrella/apps/common_core/lib/common_core/resources/knative/serving.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/resources/knative/serving.ex
@@ -2,7 +2,9 @@ defmodule CommonCore.Resources.KnativeServing do
   @moduledoc false
   use CommonCore.Resources.ResourceGenerator, app_name: "knative-serving"
 
+  import CommonCore.Resources.MapUtils
   import CommonCore.StateSummary.Hosts
+  import CommonCore.StateSummary.SSL
 
   alias CommonCore.Resources.Builder, as: B
   alias CommonCore.Resources.Secret
@@ -321,8 +323,13 @@ defmodule CommonCore.Resources.KnativeServing do
     |> B.data(data)
   end
 
-  resource(:config_map_network, battery, _state) do
-    data = %{}
+  resource(:config_map_network, battery, state) do
+    ssl = ssl_enabled?(state)
+
+    data =
+      %{}
+      |> maybe_put(ssl, "external-domain-tls", "Enabled")
+      |> maybe_put(ssl, "http-protocol", "Redirected")
 
     :config_map
     |> B.build_resource()


### PR DESCRIPTION
I'm still trying to get 80 -> 443 redirection working but, otherwise, it's working!

https://voodoo-rider-morgan.battery-knative.webapp.3-13-28-192.ip.batteriesincl.com/