### PR TITLE
feat: allow setting the header on home pages with no batteries

### DIFF
--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/empty_home.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/empty_home.ex
@@ -4,6 +4,8 @@ defmodule ControlServerWeb.EmptyHome do
 
   attr :install_path, :string, required: true
 
+  slot :header
+
   @doc """
   This component is renders an empty state for when no services have been
   installed on the kubernetes cluster. It uses tailwindcss and the smiley-face icon
@@ -14,7 +16,12 @@ defmodule ControlServerWeb.EmptyHome do
     <.flex column class="items-center justify-center h-full text-gray-darkest dark:text-gray-lighter">
       <.icon name={:face_smile} class="h-10 lg:h-28 w-auto" />
 
-      <.h2>Welcome to Batteries Included</.h2>
+      <%= if @header != [] do %>
+        <%= render_slot(@header) %>
+      <% else %>
+        <.h2>Welcome to Batteries Included</.h2>
+      <% end %>
+
       <p class="max-w-lg mb-8">
         There are no batteries installed for this group. Each running battery brings a new feature, power, or service to the platform. Addtitionally new batteries will bring extra powers to previously installed batteries, thanks to the automatic integrations between batteries.
       </p>

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/data.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/data.ex
@@ -117,7 +117,11 @@ defmodule ControlServerWeb.Live.DataHome do
         <% end %>
       <% end %>
     </.grid>
-    <.empty_home :if={@batteries == []} install_path={install_path()} />
+    <.empty_home :if={@batteries == []} install_path={install_path()}>
+      <:header>
+        <.h2>Batteries Included Datastores</.h2>
+      </:header>
+    </.empty_home>
     """
   end
 end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/devtools.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/devtools.ex
@@ -113,7 +113,11 @@ defmodule ControlServerWeb.Live.DevtoolsHome do
       </.flex>
     </.grid>
 
-    <.empty_home :if={@batteries == []} install_path={install_path()} />
+    <.empty_home :if={@batteries == []} install_path={install_path()}>
+      <:header>
+        <.h2>Batteries Included Devtools</.h2>
+      </:header>
+    </.empty_home>
     """
   end
 end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/ml.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/ml.ex
@@ -77,7 +77,11 @@ defmodule ControlServerWeb.Live.MLHome do
         <.battery_link_panel :for={battery <- @batteries} battery={battery} />
       </.flex>
     </.grid>
-    <.empty_home :if={@batteries == []} install_path={install_path()} />
+    <.empty_home :if={@batteries == []} install_path={install_path()}>
+      <:header>
+        <.h2>Batteries Included AI Tools</.h2>
+      </:header>
+    </.empty_home>
     """
   end
 end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/monitoring.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/monitoring.ex
@@ -64,7 +64,11 @@ defmodule ControlServerWeb.Live.MonitoringHome do
     <.flex :if={@batteries && @batteries != []} column class="items-stretch justify-start">
       <.battery_link_panel :for={battery <- @batteries} battery={battery} />
     </.flex>
-    <.empty_home :if={@batteries == []} install_path={install_path()} />
+    <.empty_home :if={@batteries == []} install_path={install_path()}>
+      <:header>
+        <.h2>Batteries Included Monitoring</.h2>
+      </:header>
+    </.empty_home>
     """
   end
 end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/net_sec.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/net_sec.ex
@@ -146,7 +146,11 @@ defmodule ControlServerWeb.Live.NetSecHome do
         <.battery_link_panel :for={battery <- @batteries} battery={battery} />
       </.flex>
     </.grid>
-    <.empty_home :if={@batteries == []} install_path={install_path()} />
+    <.empty_home :if={@batteries == []} install_path={install_path()}>
+      <:header>
+        <.h2>Batteries Included Network & Security Tools</.h2>
+      </:header>
+    </.empty_home>
     """
   end
 end

--- a/platform_umbrella/apps/control_server_web/test/__snapshots__/unit/components/empty_home_test/test_with_header.heyya_snap
+++ b/platform_umbrella/apps/control_server_web/test/__snapshots__/unit/components/empty_home_test/test_with_header.heyya_snap
@@ -1,0 +1,29 @@
+<div class="gap-4 lg:gap-6 flex items-center justify-center h-full text-gray-darkest dark:text-gray-lighter flex-col">
+  
+  <svg xmlns="http://www.w3.org/2000/svg" class="h-10 lg:h-28 w-auto" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M15.182 15.182a4.5 4.5 0 0 1-6.364 0M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0ZM9.75 9.75c0 .414-.168.75-.375.75S9 10.164 9 9.75 9.168 9 9.375 9s.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Zm5.625 0c0 .414-.168.75-.375.75s-.375-.336-.375-.75.168-.75.375-.75.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Z"/>
+</svg>
+
+  
+    
+    <h2 class="text-xl sm:text-3xl font-semibold my-3 text-gray-darkest dark:text-gray-lighter ">
+  Custom Header
+</h2>
+  
+  
+
+  <p class="max-w-lg mb-8">
+    There are no batteries installed for this group. Each running battery brings a new feature, power, or service to the platform. Addtitionally new batteries will bring extra powers to previously installed batteries, thanks to the automatic integrations between batteries.
+  </p>
+
+  <a class="inline-flex items-center justify-center gap-2 font-semibold text-sm text-nowrap cursor-pointer disabled:cursor-not-allowed phx-submit-loading:opacity-75 min-w-36 px-5 py-3 rounded-lg whitespace-nowrap text-white bg-primary hover:bg-primary-dark disabled:bg-gray-lighter dark:disabled:bg-gray-darker/30" href="/batteries/monitoring" data-phx-link="redirect" data-phx-link-state="push">
+  
+
+  
+    Install Batteries
+  
+
+  
+</a>
+
+</div>

--- a/platform_umbrella/apps/control_server_web/test/unit/components/empty_home_test.exs
+++ b/platform_umbrella/apps/control_server_web/test/unit/components/empty_home_test.exs
@@ -1,6 +1,7 @@
 defmodule ControlServerWeb.Components.EmptyHomeTest do
   use Heyya.SnapshotCase
 
+  import CommonUI.Components.Typography
   import ControlServerWeb.EmptyHome
 
   component_snapshot_test "empty home" do
@@ -8,6 +9,18 @@ defmodule ControlServerWeb.Components.EmptyHomeTest do
 
     ~H"""
     <.empty_home install_path={@install_path} />
+    """
+  end
+
+  component_snapshot_test "with header" do
+    assigns = %{install_path: "/batteries/monitoring"}
+
+    ~H"""
+    <.empty_home install_path={@install_path}>
+      <:header>
+        <.h2>Custom Header</.h2>
+      </:header>
+    </.empty_home>
     """
   end
 end


### PR DESCRIPTION
Summary:
This is less generic and will help users know they have navigated from
one page to another on initial install.

Fixes: #172

Test Plan:
Tests added
