### PR TITLE
Get Knative working with projects

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/catalog.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/catalog.ex
@@ -97,7 +97,7 @@ defmodule CommonCore.Batteries.Catalog do
       group: :devtools,
       type: :knative,
       dependencies: [:battery_core],
-      name: "KNative",
+      name: "Knative",
       description:
         "Knative Kubernetes operator that provides a declarative API for managing Knative Serving and Eventing. " <>
           "Knative serving is ascale-to-zero, request-driven compute platform that lets you run stateless containers " <>

--- a/platform_umbrella/apps/common_core/lib/common_core/projects/project.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/projects/project.ex
@@ -13,8 +13,8 @@ defmodule CommonCore.Projects.Project do
     has_many :postgres_clusters, CommonCore.Postgres.Cluster
     has_many :redis_clusters, CommonCore.Redis.FailoverCluster
     has_many :ferret_services, CommonCore.FerretDB.FerretService
-    has_many :knative_services, CommonCore.Knative.Service
     has_many :jupyter_notebooks, CommonCore.Notebooks.JupyterLabNotebook
+    has_many :knative_services, CommonCore.Knative.Service
 
     timestamps()
   end

--- a/platform_umbrella/apps/control_server/lib/control_server/knative.ex
+++ b/platform_umbrella/apps/control_server/lib/control_server/knative.ex
@@ -33,7 +33,11 @@ defmodule ControlServer.Knative do
       ** (Ecto.NoResultsError)
 
   """
-  def get_service!(id), do: Repo.get!(Service, id)
+  def get_service!(id, opts \\ []) do
+    Service
+    |> preload(^Keyword.get(opts, :preload, []))
+    |> Repo.get!(id)
+  end
 
   @doc """
   Creates a service.

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/knative/form_component.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/knative/form_component.ex
@@ -81,7 +81,8 @@ defmodule ControlServerWeb.Live.Knative.FormComponent do
 
   @impl Phoenix.LiveComponent
   def update(%{service: service} = assigns, socket) do
-    changeset = Knative.change_service(service)
+    project_id = Map.get(service, :project_id) || assigns[:project_id]
+    changeset = Knative.change_service(service, %{project_id: project_id})
 
     {:ok,
      socket
@@ -265,7 +266,7 @@ defmodule ControlServerWeb.Live.Knative.FormComponent do
           field={@form[:project_id]}
           type="select"
           label="Project"
-          placeholder="Choose Project"
+          placeholder="No Project"
           placeholder_selectable={true}
           options={Enum.map(@projects, &{&1.name, &1.id})}
         />
@@ -300,9 +301,16 @@ defmodule ControlServerWeb.Live.Knative.FormComponent do
         phx-submit="save"
         phx-target={@myself}
       >
-        <.page_header title={@title} back_link={~p"/knative/services"}>
+        <.page_header
+          title={@title}
+          back_link={
+            if @action == :new,
+              do: ~p"/knative/services",
+              else: ~p"/knative/services/#{@service}/show"
+          }
+        >
           <.button variant="dark" type="submit" phx-disable-with="Saving…">
-            Save Serverless
+            Save Service
           </.button>
         </.page_header>
         <.grid columns={[sm: 1, lg: 2]}>

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/knative/knative_services_table.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/knative/knative_services_table.ex
@@ -11,25 +11,35 @@ defmodule ControlServerWeb.KnativeServicesTable do
 
   def knative_services_table(assigns) do
     ~H"""
-    <.table id="knative-display-table" rows={@rows}>
+    <.table id="knative-display-table" rows={@rows} row_click={&JS.navigate(show_url(&1))}>
       <:col :let={service} :if={!@abbridged} label="ID"><%= service.id %></:col>
       <:col :let={service} label="Name"><%= service.name %></:col>
-      <:col :let={service} label="Link">
-        <.a href={service_url(service)} variant="external">
-          Running Service
-        </.a>
-      </:col>
       <:action :let={service}>
-        <.button
-          variant="minimal"
-          link={show_url(service)}
-          icon={:eye}
-          id={"show_service_" <> service.id}
-        />
+        <.flex class="justify-items-center">
+          <.button
+            variant="minimal"
+            link={show_url(service)}
+            icon={:eye}
+            id={"show_service_" <> service.id}
+          />
 
-        <.tooltip target_id={"show_service_" <> service.id}>
-          Show Service <%= service.name %>
-        </.tooltip>
+          <.tooltip target_id={"show_service_" <> service.id}>
+            Show Service
+          </.tooltip>
+
+          <.button
+            variant="minimal"
+            link={service_url(service)}
+            link_type="external"
+            target="_blank"
+            icon={:arrow_top_right_on_square}
+            id={"running_service_" <> service.id}
+          />
+
+          <.tooltip target_id={"running_service_" <> service.id}>
+            Running Service
+          </.tooltip>
+        </.flex>
       </:action>
     </.table>
     """
@@ -37,5 +47,5 @@ defmodule ControlServerWeb.KnativeServicesTable do
 
   defp show_url(%Service{} = service), do: ~p"/knative/services/#{service.id}/show"
 
-  defp service_url(%Service{} = service), do: "//#{knative_host(service)}"
+  defp service_url(%Service{} = service), do: "http://#{knative_host(service)}"
 end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/controllers/knative/service_controller.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/controllers/knative/service_controller.ex
@@ -1,4 +1,4 @@
-defmodule ControlServerWeb.KNativeServiceController do
+defmodule ControlServerWeb.KnativeServiceController do
   use ControlServerWeb, :controller
 
   alias CommonCore.Knative.Service

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/controllers/knative/service_json.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/controllers/knative/service_json.ex
@@ -1,4 +1,4 @@
-defmodule ControlServerWeb.KNativeServiceJSON do
+defmodule ControlServerWeb.KnativeServiceJSON do
   alias CommonCore.Containers.Container
   alias CommonCore.Containers.EnvValue
   alias CommonCore.Knative.Service

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/devtools.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/devtools.ex
@@ -38,11 +38,11 @@ defmodule ControlServerWeb.Live.DevtoolsHome do
 
   defp knative_panel(assigns) do
     ~H"""
-    <.panel title="Serverless Services">
+    <.panel title="Knative Services">
       <:menu>
         <.flex>
           <.a navigate={~p"/knative/services/new"}>
-            <.icon name={:plus} class="inline-flex h-5 w-auto my-auto" /> New Knative
+            <.icon name={:plus} class="inline-flex h-5 w-auto my-auto" /> New Service
           </.a>
           <.link navigate={~p"/knative/services"}>View All</.link>
         </.flex>

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/knative/edit.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/knative/edit.ex
@@ -9,7 +9,7 @@ defmodule ControlServerWeb.Live.KnativeEdit do
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
-    {:ok, socket}
+    {:ok, assign(socket, :current_page, :devtools)}
   end
 
   @impl Phoenix.LiveView
@@ -26,7 +26,7 @@ defmodule ControlServerWeb.Live.KnativeEdit do
         service={@service}
         id="service-form"
         action={:edit}
-        title="Edit Serverless Service"
+        title="Edit Knative Service"
       />
     </div>
     """

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/knative/index.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/knative/index.ex
@@ -7,7 +7,11 @@ defmodule ControlServerWeb.Live.KnativeServicesIndex do
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
-    {:ok, socket |> assign_services() |> assign_current_page()}
+    {:ok,
+     socket
+     |> assign_services()
+     |> assign_current_page()
+     |> assign(:current_page, :devtools)}
   end
 
   @impl Phoenix.LiveView
@@ -16,7 +20,7 @@ defmodule ControlServerWeb.Live.KnativeServicesIndex do
   end
 
   defp apply_action(socket, :index, _params) do
-    assign(socket, :page_title, "Listing Services")
+    assign(socket, :page_title, "Knative Services")
   end
 
   defp assign_services(socket) do
@@ -38,7 +42,7 @@ defmodule ControlServerWeb.Live.KnativeServicesIndex do
       </.button>
     </.page_header>
 
-    <.panel title="Serverless Services">
+    <.panel title="All Services">
       <.knative_services_table rows={@services} />
     </.panel>
     """

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/knative/new.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/knative/new.ex
@@ -9,12 +9,14 @@ defmodule ControlServerWeb.Live.KnativeNew do
   require Logger
 
   @impl Phoenix.LiveView
-  def mount(_params, _session, socket) do
+  def mount(params, _session, socket) do
     service = %Service{}
     changeset = Knative.change_service(service)
 
     {:ok,
      socket
+     |> assign(:current_page, :devtools)
+     |> assign(:project_id, params["project_id"])
      |> assign(:service, service)
      |> assign(:changeset, changeset)}
   end
@@ -32,7 +34,8 @@ defmodule ControlServerWeb.Live.KnativeNew do
       service={@service}
       id="service-form"
       action={:new}
-      title="New Serverless Service"
+      title="New Knative Service"
+      project_id={@project_id}
     />
     """
   end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/router.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/router.ex
@@ -196,7 +196,7 @@ defmodule ControlServerWeb.Router do
     get "/system_state", SystemStateController, :index
     resources "/postgres/clusters", ClusterController, except: [:new, :edit]
     resources "/redis/clusters", FailoverClusterController, except: [:new, :edit]
-    resources "/knative/services", KNativeServiceController, except: [:new, :edit]
+    resources "/knative/services", KnativeServiceController, except: [:new, :edit]
     resources "/backend/services", BackendServiceController, except: [:new, :edit]
     resources "/notebooks/jupyter_lab_notebooks", JupyterLabNotebookController, except: [:new, :edit]
   end

--- a/platform_umbrella/apps/control_server_web/test/unit/controllers/service_controller_test.exs
+++ b/platform_umbrella/apps/control_server_web/test/unit/controllers/service_controller_test.exs
@@ -1,4 +1,4 @@
-defmodule ControlServerWeb.KNativeServiceControllerTest do
+defmodule ControlServerWeb.KnativeServiceControllerTest do
   use ControlServerWeb.ConnCase
 
   import ControlServer.Factory

--- a/platform_umbrella/apps/control_server_web/test/unit/live/knative/knative_service_live_test.exs
+++ b/platform_umbrella/apps/control_server_web/test/unit/live/knative/knative_service_live_test.exs
@@ -15,7 +15,7 @@ defmodule ControlServerWeb.ServiceLiveTest do
     test "lists all services", %{conn: conn, service: service} do
       {:ok, _index_live, html} = live(conn, ~p"/knative/services")
 
-      assert html =~ "Listing Services"
+      assert html =~ "Knative Services"
       assert html =~ service.name
     end
   end


### PR DESCRIPTION
- Adds a new Knative Service link and panel to the project page
- Restructures Knative pages to be consistent with other resource pages
- Shows abridged tables in project page so we can have two panels per row
- Fixes consistency with Knative casing and wording