### PR TITLE
feat: delete kubernetes resources before deleting the cluster

### DIFF
--- a/bi/cmd/stop.go
+++ b/bi/cmd/stop.go
@@ -4,14 +4,11 @@ Copyright © 2024 Elliott Clark <elliott@batteriesincl.com>
 package cmd
 
 import (
-	"path/filepath"
-
 	"bi/pkg/installs"
 	"bi/pkg/log"
 	"bi/pkg/stop"
 
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/util/homedir"
 )
 
 var stopCmd = &cobra.Command{
@@ -32,17 +29,16 @@ var stopCmd = &cobra.Command{
 			return err
 		}
 
-		return stop.StopInstall(ctx, env)
+		skipCleanKube, err := cmd.Flags().GetBool("skip-clean-kube")
+		if err != nil {
+			return err
+		}
+
+		return stop.StopInstall(ctx, env, skipCleanKube)
 	},
 }
 
 func init() {
 	RootCmd.AddCommand(stopCmd)
-	// The current user homedir
-	if dirname := homedir.HomeDir(); dirname == "" {
-		stopCmd.Flags().StringP("kubeconfig", "k", "/", "The kubeconfig to use")
-	} else {
-		defaultKubeConfig := filepath.Join(dirname, ".kube", "config")
-		stopCmd.PersistentFlags().StringP("kubeconfig", "k", defaultKubeConfig, "The kubeconfig to use")
-	}
+	stopCmd.Flags().Bool("skip-clean-kube", false, "Skip deleting kubernetes resources")
 }

--- a/bi/pkg/cluster/util/progress_reporter.go
+++ b/bi/pkg/cluster/util/progress_reporter.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"log/slog"
 	"strings"
-	"sync"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/auto/events"
 	"github.com/vbauerster/mpb/v8"
@@ -13,8 +12,7 @@ import (
 
 // ProgressReporter is a convenience wrapper around mpb.Progress.
 type ProgressReporter struct {
-	progress     *mpb.Progress
-	shutdownOnce sync.Once
+	progress *mpb.Progress
 }
 
 // NewProgressReporter creates a new ProgressReporter.
@@ -26,7 +24,7 @@ func NewProgressReporter() *ProgressReporter {
 
 // Shutdown stops all registered progress bars.
 func (pr *ProgressReporter) Shutdown() {
-	pr.shutdownOnce.Do(pr.progress.Shutdown)
+	pr.progress.Shutdown()
 }
 
 // ForPulumiEvents creates a new progress bar for Pulumi events. The returned

--- a/bi/pkg/start/start.go
+++ b/bi/pkg/start/start.go
@@ -55,7 +55,6 @@ func StartInstall(ctx context.Context, env *installs.InstallEnv) error {
 	// in the progress bar being printed over the access information.
 	if progressReporter != nil {
 		progressReporter.Shutdown()
-		progressReporter = nil
 	}
 
 	slog.Info("Displaying access information")


### PR DESCRIPTION
So that managed resources like LBs get cleaned up.

Currently clean-kube does not properly clean up karpenter and LB resources so this isn't yet ready for use.