### PR TITLE
fix: allow knative services to reconcile successfully

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/resources/knative/net_istio.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/resources/knative/net_istio.ex
@@ -3,6 +3,7 @@ defmodule CommonCore.Resources.KnativeNetIstio do
   use CommonCore.Resources.ResourceGenerator, app_name: "knative-serving"
 
   import CommonCore.StateSummary.Hosts
+  import CommonCore.StateSummary.Namespaces
   import CommonCore.StateSummary.SSL
 
   alias CommonCore.Resources.Builder, as: B
@@ -27,8 +28,17 @@ defmodule CommonCore.Resources.KnativeNetIstio do
     |> B.rules(rules)
   end
 
-  resource(:config_map_istio, battery, _state) do
-    data = %{}
+  resource(:config_map_istio, battery, state) do
+    data = %{
+      "external-gateways" =>
+        Ymlr.document!([
+          %{
+            name: "knative-ingress-gateway",
+            namespace: battery.config.namespace,
+            service: "istio-ingressgateway.#{istio_namespace(state)}.svc.cluster.local"
+          }
+        ])
+    }
 
     :config_map
     |> B.build_resource()

--- a/platform_umbrella/apps/common_core/lib/common_core/resources/knative/serving.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/resources/knative/serving.ex
@@ -329,7 +329,7 @@ defmodule CommonCore.Resources.KnativeServing do
     data =
       %{}
       |> maybe_put(ssl, "external-domain-tls", "Enabled")
-      |> maybe_put(ssl, "http-protocol", "Redirected")
+      |> maybe_put(ssl, "http-protocol", "Enabled")
 
     :config_map
     |> B.build_resource()


### PR DESCRIPTION
I was seeing that the knative services had ingress reconciliation failures. This fixes that and allows them to reconcile fully.

```
NAME                     ...  LATESTCREATED                  LATESTREADY                    READY   REASON
malta-holiday-algebra    ...  malta-holiday-algebra-00001    malta-holiday-algebra-00001    True
```