### PR TITLE
fix: don't allow 127-0-0-1 as a hostname for access now

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/state_summary/access_spec.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/state_summary/access_spec.ex
@@ -34,7 +34,7 @@ defmodule CommonCore.StateSummary.AccessSpec do
     host != nil and
       String.length(host) > 0 and
       !String.contains?(host, "..ip.batteriesincl.com") and
-      !String.contains?(host, "127.0.0.1") and
+      !String.contains?(host, "127-0-0-1") and
       valid_uri?(host)
   end
 

--- a/platform_umbrella/apps/common_core/test/common_core/state_summary/access_spec_test.exs
+++ b/platform_umbrella/apps/common_core/test/common_core/state_summary/access_spec_test.exs
@@ -1,0 +1,36 @@
+defmodule CommonCore.StateSummary.AccessSpecTest do
+  use ExUnit.Case
+
+  defp state_summary(ip) do
+    ingress_service = %{
+      "metadata" => %{"name" => "istio-ingressgateway", "namespace" => "battery-istio"},
+      "status" => %{
+        "loadBalancer" => %{
+          "ingress" => [%{"ip" => ip}]
+        }
+      }
+    }
+
+    %CommonCore.StateSummary{
+      kube_state: %{service: [ingress_service]},
+      batteries: [
+        %CommonCore.Batteries.SystemBattery{
+          type: :istio,
+          config: %CommonCore.Batteries.IstioConfig{namespace: "battery-istio"}
+        }
+      ]
+    }
+  end
+
+  describe "new" do
+    test "won't create a new AccessSpec if the hostname is invalid" do
+      state_summary = state_summary("127.0.0.1")
+      assert {:error, "Invalid hostname"} == CommonCore.StateSummary.AccessSpec.new(state_summary)
+    end
+
+    test "works with a valid hostname" do
+      state_summary = state_summary("100.0.0.1")
+      assert {:ok, _} = CommonCore.StateSummary.AccessSpec.new(state_summary)
+    end
+  end
+end


### PR DESCRIPTION
Summary:
Now that we went with dashes for ips this needs to be changed.

Test Plan:
test added
