### PR TITLE
feat: allow selecting from options in knative env_vars

### DIFF
--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/containers/container_modal.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/containers/container_modal.ex
@@ -83,21 +83,19 @@ defmodule ControlServerWeb.Containers.ContainerModal do
         phx-submit="save_container"
         phx-target={@myself}
       >
-        <.modal show id={"#{@id}-modal"} on_cancel={JS.push("cancel", target: @myself)}>
+        <.modal show size="lg" id={"#{@id}-modal"} on_cancel={JS.push("cancel", target: @myself)}>
           <:title>Container</:title>
 
-          <.grid columns={[sm: 1, lg: 2]}>
+          <.flex column>
             <.input label="Name" field={@form[:name]} autofocus placeholder="Name" />
             <.input label="Image" field={@form[:image]} placeholder="Image" />
-            <div class="col-span-2">
-              <.input
-                name="container[command][]"
-                value={(@form.data.command || []) |> List.first(nil)}
-                label="Command"
-                placeholder="/bin/true"
-              />
-            </div>
-          </.grid>
+            <.input
+              name="container[command][]"
+              value={(@form.data.command || []) |> List.first(nil)}
+              label="Command (optional)"
+              placeholder="/bin/true"
+            />
+          </.flex>
 
           <:actions cancel="Cancel">
             <.button variant="primary" type="submit" phx-disable-with="Saving...">Save</.button>

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/containers/env_value_modal.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/containers/env_value_modal.ex
@@ -113,6 +113,13 @@ defmodule ControlServerWeb.Containers.EnvValueModal do
     extract_source_type(changeset) in [:secret, "secret"]
   end
 
+  defp extract_keys(resources, name) do
+    resources
+    |> Enum.find(%{}, fn r -> name(r) == name end)
+    |> Map.get("data", %{})
+    |> Map.keys()
+  end
+
   defp value_inputs(assigns) do
     ~H"""
     <.input label="Value" field={@form[:value]} placeholder="your.service.creds" />
@@ -129,7 +136,13 @@ defmodule ControlServerWeb.Containers.EnvValueModal do
         placeholder="Select Source"
         options={Enum.map(@resources, &name/1)}
       />
-      <.input label="Key" field={@form[:source_key]} />
+      <.input
+        label="Key"
+        field={@form[:source_key]}
+        type="select"
+        placeholder="Select Key"
+        options={extract_keys(@resources, @form[:source_name].value || "")}
+      />
     </.flex>
     """
   end
@@ -145,7 +158,7 @@ defmodule ControlServerWeb.Containers.EnvValueModal do
         phx-submit="save_env_value"
         phx-target={@myself}
       >
-        <.modal show id={"#{@id}-modal"} on_cancel={JS.push("cancel", target: @myself)}>
+        <.modal show size="lg" id={"#{@id}-modal"} on_cancel={JS.push("cancel", target: @myself)}>
           <:title>Environment Variable</:title>
 
           <.flex column>


### PR DESCRIPTION
Summary:
When starting a service it's really nice to be able to choose from what
key to use rather than having to know. So this pipes all that through.

- KubeServices.KubeState now cleans configmaps and secrets to only keep
  the keys. This should reduce some security issues and greatly reduce
  the size of data we keep in extreme cases.
- Changed knative modals to be larger
- Changed knative env_value modal to select from keys

Test Plan:
- Tried it
- Existing tests
