### PR TITLE
feat(knative): create keycloak realms and clients

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/actions/knative.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/actions/knative.ex
@@ -1,0 +1,53 @@
+defmodule CommonCore.Actions.Knative do
+  @moduledoc false
+  @behaviour CommonCore.Actions.ActionGenerator
+
+  alias CommonCore.Actions.FreshGeneratedAction
+  alias CommonCore.Actions.SSOClient
+  alias CommonCore.Batteries.SystemBattery
+  alias CommonCore.Knative.Service
+  alias CommonCore.StateSummary
+  alias CommonCore.StateSummary.KeycloakSummary
+  alias CommonCore.StateSummary.URLs
+
+  @spec materialize(SystemBattery.t(), StateSummary.t()) :: list(FreshGeneratedAction.t() | nil)
+  def materialize(%SystemBattery{} = _system_battery, %StateSummary{} = state_summary) do
+    ensure_knative_realms(state_summary) ++ ensure_knative_clients(state_summary)
+  end
+
+  # make sure we have a realm for every realm that knative services are using
+  defp ensure_knative_realms(%StateSummary{keycloak_state: key_state, knative_services: services} = _state_summary) do
+    services
+    |> Enum.filter(&Service.sso_configured_properly?/1)
+    |> MapSet.new(& &1.keycloak_realm)
+    |> Enum.map(fn realm ->
+      if KeycloakSummary.realm_member?(key_state, realm) do
+        nil
+      else
+        %FreshGeneratedAction{
+          action: :create,
+          type: :realm,
+          realm: nil,
+          value: %{
+            realm: realm,
+            displayName: "Batteries Included - #{realm}",
+            rememberMe: true,
+            social: false,
+            enabled: true
+          }
+        }
+      end
+    end)
+  end
+
+  defp ensure_knative_clients(%StateSummary{keycloak_state: key_state, knative_services: services} = state_summary) do
+    services
+    |> Enum.filter(&Service.sso_configured_properly?/1)
+    |> Enum.map(fn %{keycloak_realm: realm, name: name} = service ->
+      id = name |> Base.encode16() |> String.slice(0..35)
+      url = URLs.knative_url(state_summary, service)
+      client = SSOClient.default_client(id, name, URI.to_string(url))
+      SSOClient.determine_action(key_state, realm, client, SSOClient.default_client_fields())
+    end)
+  end
+end

--- a/platform_umbrella/apps/common_core/lib/common_core/actions/root.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/actions/root.ex
@@ -5,6 +5,7 @@ defmodule CommonCore.Actions.RootActionGenerator do
   alias CommonCore.Actions.FreshGeneratedAction
   alias CommonCore.Actions.Grafana
   alias CommonCore.Actions.Kiali
+  alias CommonCore.Actions.Knative
   alias CommonCore.Actions.Notebooks
   alias CommonCore.Actions.Smtp4dev
   alias CommonCore.Actions.SSO
@@ -18,6 +19,7 @@ defmodule CommonCore.Actions.RootActionGenerator do
     forgejo: Forgejo,
     grafana: Grafana,
     kiali: Kiali,
+    knative: Knative,
     notebooks: Notebooks,
     smtp4dev: Smtp4dev,
     sso: SSO,

--- a/platform_umbrella/apps/common_core/lib/common_core/state_summary/urls.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/state_summary/urls.ex
@@ -41,4 +41,13 @@ defmodule CommonCore.StateSummary.URLs do
     |> uri_for_battery(:grafana)
     |> URI.append_path("/d/k8s_views_pods/kubernetes-views-pods")
   end
+
+  @spec knative_url(StateSummary.t(), CommonCore.Knative.Service.t()) :: URI.t()
+  def knative_url(state, service) do
+    "http://#{Hosts.knative_host(state, service)}"
+    |> URI.new!()
+    |> then(fn uri ->
+      if SSL.ssl_enabled?(state), do: %URI{uri | scheme: "https", port: 443}, else: uri
+    end)
+  end
 end


### PR DESCRIPTION
This is the part of #167 that creates the keycloak realm(s) and client(s) for knative services that need them.