### PR TITLE
refactor: don't clean the kubernetes cluster on all stops

### DIFF
--- a/bi/pkg/installs/env.go
+++ b/bi/pkg/installs/env.go
@@ -98,3 +98,10 @@ func readInstallEnv(slugOrURL string) (string, *InstallEnv, error) {
 
 	return "", nil, fmt.Errorf("No spec found")
 }
+
+func (env *InstallEnv) NeedsKubeCleanup() bool {
+	// Returns true if we should remove all resources in in an install
+	// Returns true if the cluster provider is in [provided, aws]
+	provider := env.Spec.KubeCluster.Provider
+	return provider == "provided" || provider == "aws"
+}

--- a/bi/pkg/stop/stop.go
+++ b/bi/pkg/stop/stop.go
@@ -19,7 +19,7 @@ func StopInstall(ctx context.Context, env *installs.InstallEnv, skipCleanKube bo
 		defer progressReporter.Shutdown()
 	}
 
-	if !skipCleanKube {
+	if !skipCleanKube && env.NeedsKubeCleanup() {
 		kubeClient, err := env.NewBatteryKubeClient()
 		if err != nil {
 			return err


### PR DESCRIPTION
Summary:
For clusters that are based on kind we don't need to remove the
resources in kubernetes.

Test Plan:
bix bootstrap && bix stop
