### PR TITLE
feat: home and control server version point at themself

### DIFF
--- a/bootstrap/damian.install.json
+++ b/bootstrap/damian.install.json
@@ -1,12 +1,12 @@
 {
-  "id": "batt_01905065e0b77a199e780c6fffc3b65c",
+  "id": "batt_01906f032995748a8fca15e688c2014a",
   "usage": "development",
   "default_size": "small",
   "control_jwk": {
     "crv": "Ed25519",
-    "d": "nHWMIiBtC3IsUKcNXsrP4hI2IaS2_htbcvSpyW2U3E4",
+    "d": "jgPKr-fxkEVLZcwyysW8YMUPidB_qCN0ovwRfdO4fao",
     "kty": "OKP",
-    "x": "VNhGzUDdcKS5LjcfuJ1fcMBi9rE2Mcrvt5DTFEq_nVU"
+    "x": "wfncFM3PbWDR9e4_0hCZ6HqdP2WJcC_lEtt3rpT5t7M"
   },
   "inserted_at": null,
   "updated_at": null,
@@ -16,5 +16,5 @@
   "sso_enabled": false,
   "initial_oauth_email": null,
   "user_id": null,
-  "team_id": "batt_01905065e03b7cc8b76d93a36d6395ce"
+  "team_id": "batt_01906f0329597b91b61a3f1779484d0d"
 }

--- a/bootstrap/damian.spec.json
+++ b/bootstrap/damian.spec.json
@@ -5,10 +5,11 @@
     "provider": "aws"
   },
   "target_summary": {
+    "knative_services": [],
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_01905065e0db7492a2d2bf70f1a5e11d",
+        "id": "batt_01906f03299c78bd92f148560538b971",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -22,12 +23,12 @@
           "default_size": "small",
           "cluster_name": "damian",
           "server_in_cluster": true,
-          "install_id": "batt_01905065e0b77a199e780c6fffc3b65c",
+          "install_id": "batt_01906f032995748a8fca15e688c2014a",
           "control_jwk": {
             "crv": "Ed25519",
-            "d": "nHWMIiBtC3IsUKcNXsrP4hI2IaS2_htbcvSpyW2U3E4",
+            "d": "jgPKr-fxkEVLZcwyysW8YMUPidB_qCN0ovwRfdO4fao",
             "kty": "OKP",
-            "x": "VNhGzUDdcKS5LjcfuJ1fcMBi9rE2Mcrvt5DTFEq_nVU"
+            "x": "wfncFM3PbWDR9e4_0hCZ6HqdP2WJcC_lEtt3rpT5t7M"
           },
           "image_override": null,
           "bootstrap_image_override": null
@@ -37,7 +38,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01905065e0db754bb8de30579be8bc63",
+        "id": "batt_01906f03299c7733947a71e30134d121",
         "type": "karpenter",
         "config": {
           "type": "karpenter",
@@ -52,19 +53,19 @@
         "updated_at": null
       },
       {
-        "id": "batt_01905065e0db725ca672fd820c11d192",
+        "id": "batt_01906f03299c703e8f020e735b41b45a",
         "type": "cert_manager",
         "config": {
           "type": "cert_manager",
           "email": null,
-          "acmesolver_image": "quay.io/jetstack/cert-manager-acmesolver:v1.14.6",
-          "cainjector_image": "quay.io/jetstack/cert-manager-cainjector:v1.14.6",
-          "controller_image": "quay.io/jetstack/cert-manager-controller:v1.14.6",
-          "ctl_image": "quay.io/jetstack/cert-manager-ctl:v1.14.6",
-          "webhook_image": "quay.io/jetstack/cert-manager-webhook:v1.14.6",
+          "acmesolver_image": "quay.io/jetstack/cert-manager-acmesolver:v1.14.7",
+          "cainjector_image": "quay.io/jetstack/cert-manager-cainjector:v1.14.7",
+          "controller_image": "quay.io/jetstack/cert-manager-controller:v1.14.7",
+          "ctl_image": "quay.io/jetstack/cert-manager-ctl:v1.14.7",
+          "webhook_image": "quay.io/jetstack/cert-manager-webhook:v1.14.7",
+          "controller_image_override": null,
           "acmesolver_image_override": null,
           "cainjector_image_override": null,
-          "controller_image_override": null,
           "ctl_image_override": null,
           "webhook_image_override": null
         },
@@ -73,7 +74,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01905065e0db74f8bdfe0d853ee952d3",
+        "id": "batt_01906f03299c74deb30eba9236f1c52a",
         "type": "battery_ca",
         "config": {
           "type": "battery_ca"
@@ -83,7 +84,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01905065e0db7104b580cae0f6b54abc",
+        "id": "batt_01906f03299c704092ee03ffdd7a14dd",
         "type": "aws_load_balancer_controller",
         "config": {
           "type": "aws_load_balancer_controller",
@@ -98,11 +99,11 @@
         "updated_at": null
       },
       {
-        "id": "batt_01905065e0db742e81af28f0e4542d37",
+        "id": "batt_01906f03299c7aac9c0c4ec764034692",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
-          "image": "ghcr.io/cloudnative-pg/cloudnative-pg:1.23.1",
+          "image": "ghcr.io/cloudnative-pg/cloudnative-pg:1.23.2",
           "image_override": null
         },
         "group": "data",
@@ -110,7 +111,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01905065e0db71808844dfd760c26a1c",
+        "id": "batt_01906f03299c7b13b40d417d69837312",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -124,7 +125,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01905065e0db7c46942ed1322603ec1b",
+        "id": "batt_01906f03299c7f728ac589ebd9e624a2",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -136,7 +137,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01905065e0db70e2be4d0e0e814a0b0c",
+        "id": "batt_01906f03299c77a38a313f9866295990",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -171,7 +172,7 @@
           {
             "position": null,
             "username": "battery-control-user",
-            "password": "JBBF6V6XD7PZHK325FWXP62D",
+            "password": "3LOTWCVFWWUATU3B4IOCV5ZG",
             "roles": ["createdb", "login"],
             "credential_namespaces": ["battery-core"]
           }
@@ -184,7 +185,6 @@
     "redis_clusters": [],
     "projects": [],
     "ferret_services": [],
-    "knative_services": [],
     "ip_address_pools": []
   },
   "initial_resources": {
@@ -193,7 +193,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "JG7EZ4SLLUWTCVHRUFEAKGHW4MMYKXNHO7WTRQPZETVODHGAFLSA===="
+          "battery/hash": "EN3QQW2U7NWGZTG2P2NTHVZDCW3YCDQYP7PUOJJNZJG3PXNW4APA===="
         },
         "labels": {
           "app": "battery-core",
@@ -203,7 +203,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01905065e0db7492a2d2bf70f1a5e11d",
+          "battery/owner": "batt_01906f03299c78bd92f148560538b971",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -226,7 +226,7 @@
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "4F6FIYM7LRPXBYLFKNGYEAAIWNMWM2JBOIMBSLROTY7NS4LQ3A7A===="
+          "battery/hash": "T2ALIH77KDJC6CJJMYYARCEWHX74RNS7SFICW4BLII6JVHWXJHAQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -236,7 +236,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01905065e0db7492a2d2bf70f1a5e11d",
+          "battery/owner": "batt_01906f03299c78bd92f148560538b971",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -260,7 +260,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_01905065e0db7492a2d2bf70f1a5e11d",
+              "battery/owner": "batt_01906f03299c78bd92f148560538b971",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -273,7 +273,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "LMGBQT6Z2AC6SXSBEJGZLMMIT3IGRYYJRMIRXC6KJBMZSYD2MHKABC3RCTIPMW5N"
+                    "value": "MA5DHNLUX4WM5B2KMFEGCETUL66CCRDSUYPG5YQQIPDN2I4R7Y6R7PKKDMOM4NPK"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -321,7 +321,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "RJ3QN6WXQGBW67I4GMIWSVP73ETP6M3UEVABOCIE2SO34MBEWAUQ===="
+          "battery/hash": "QKENEO7YKXQOJO463ZH6H7T2ZFWB44LQWJYKH6HPGK6NWDLQBRXQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -331,7 +331,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01905065e0db7492a2d2bf70f1a5e11d",
+          "battery/owner": "batt_01906f03299c78bd92f148560538b971",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -343,7 +343,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "XPT7FHO7X2UD4LN4TIXSPERBTL7WW6Y7J3EXO67IHRAMTYWHXS7Q===="
+          "battery/hash": "R67VRHHSF6DGCEVSEH2N36WVRJK6J53MRHGICNEZD646ZNRN7XNQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -353,7 +353,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01905065e0db7492a2d2bf70f1a5e11d",
+          "battery/owner": "batt_01906f03299c78bd92f148560538b971",
           "version": "latest"
         },
         "name": "bootstrap",
@@ -366,7 +366,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "TP7IZ32OFEJDLO5UKGAEI6MIKX6MWKCUVHO322FLF5CHRGBR3QYQ====",
+          "battery/hash": "XTQNGVEQAKRXHUH6HZQHRI3YHCEHENR74FKJXEU7MQX4HPQJD5DQ====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -377,7 +377,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01905065e0db7492a2d2bf70f1a5e11d",
+          "battery/owner": "batt_01906f03299c78bd92f148560538b971",
           "version": "latest"
         },
         "name": "gp2"
@@ -392,7 +392,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "V2J4N6RT4I26P5WJ2XL7ZSF4BE6MFAPE6GF44GOVMFIX4XE2LWDQ====",
+          "battery/hash": "MMHS5MQNIAN454AB2KAK3BCNWT4VV6K5OVVHELXFUEXMDH45KECA====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -403,7 +403,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01905065e0db7492a2d2bf70f1a5e11d",
+          "battery/owner": "batt_01906f03299c78bd92f148560538b971",
           "version": "latest"
         },
         "name": "gp2-90032408"
@@ -423,7 +423,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "TTIHIQJPNAV4ZI5ETEKJ7YBRED564FZYRSRHY2GWDBYUAXGJH6SA====",
+          "battery/hash": "CQOCKUAW7BK3DU4P4JKVT3TXXVP7KNQQQROGKCVLNZE4KLMBMQZQ====",
           "storageclass.kubernetes.io/is-default-class": "true"
         },
         "labels": {
@@ -434,7 +434,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01905065e0db7492a2d2bf70f1a5e11d",
+          "battery/owner": "batt_01906f03299c78bd92f148560538b971",
           "version": "latest"
         },
         "name": "gp3-105457460"

--- a/bootstrap/dev.install.json
+++ b/bootstrap/dev.install.json
@@ -1,12 +1,12 @@
 {
-  "id": "batt_01905065e06e76e6b82075e1babe33b8",
+  "id": "batt_01906f0329597ef4b3c51bed68afb601",
   "usage": "internal_dev",
   "default_size": "tiny",
   "control_jwk": {
     "crv": "Ed25519",
-    "d": "qDbM2t8eumuPVv_-n5PNnzsRm2v4W_ssKb014sFLzO0",
+    "d": "Bw8fpsiL1xjTYvi12iXfDZqqoZxzuPQY8FdcdYNausY",
     "kty": "OKP",
-    "x": "Fo-t5GpO-B-PwWFg3QFEVwUzs5Moqr34PuOn7bDQDFs"
+    "x": "yJJ6uR8ON7S1dNw964X79hUxObGoQcUIA3iOkVWlJFI"
   },
   "inserted_at": null,
   "updated_at": null,
@@ -16,5 +16,5 @@
   "sso_enabled": false,
   "initial_oauth_email": null,
   "user_id": null,
-  "team_id": "batt_01905065e03b7cc8b76d93a36d6395ce"
+  "team_id": "batt_01906f0329597b91b61a3f1779484d0d"
 }

--- a/bootstrap/dev.spec.json
+++ b/bootstrap/dev.spec.json
@@ -5,10 +5,11 @@
     "provider": "kind"
   },
   "target_summary": {
+    "knative_services": [],
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_01905065e0ba76a9b4d7dda24acb4102",
+        "id": "batt_01906f0329957c9bac3762bce0084952",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -22,7 +23,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01905065e0bc7740a7d6587d2fbda478",
+        "id": "batt_01906f03299579fcac3b98c01ddfc45c",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -34,7 +35,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01905065e0bd7e8f8c2e70a6de0c860a",
+        "id": "batt_01906f03299576d2a93c5468c0b27c89",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -48,12 +49,12 @@
           "default_size": "tiny",
           "cluster_name": "dev",
           "server_in_cluster": false,
-          "install_id": "batt_01905065e06e76e6b82075e1babe33b8",
+          "install_id": "batt_01906f0329597ef4b3c51bed68afb601",
           "control_jwk": {
             "crv": "Ed25519",
-            "d": "qDbM2t8eumuPVv_-n5PNnzsRm2v4W_ssKb014sFLzO0",
+            "d": "Bw8fpsiL1xjTYvi12iXfDZqqoZxzuPQY8FdcdYNausY",
             "kty": "OKP",
-            "x": "Fo-t5GpO-B-PwWFg3QFEVwUzs5Moqr34PuOn7bDQDFs"
+            "x": "yJJ6uR8ON7S1dNw964X79hUxObGoQcUIA3iOkVWlJFI"
           },
           "image_override": null,
           "bootstrap_image_override": null
@@ -63,15 +64,15 @@
         "updated_at": null
       },
       {
-        "id": "batt_01905065e0c1704d807b527e341ead04",
+        "id": "batt_01906f032997711780a036050f0b0b93",
         "type": "metallb",
         "config": {
           "type": "metallb",
           "controller_image": "quay.io/metallb/controller:v0.13.12",
           "speaker_image": "quay.io/metallb/speaker:v0.13.12",
           "frrouting_image": "quay.io/frrouting/frr:8.5.4",
-          "controller_image_override": null,
           "speaker_image_override": null,
+          "controller_image_override": null,
           "frrouting_image_override": null
         },
         "group": "net_sec",
@@ -79,11 +80,11 @@
         "updated_at": null
       },
       {
-        "id": "batt_01905065e0c1718292417e3c48798109",
+        "id": "batt_01906f032997774e93e533431a994cd3",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
-          "image": "ghcr.io/cloudnative-pg/cloudnative-pg:1.23.1",
+          "image": "ghcr.io/cloudnative-pg/cloudnative-pg:1.23.2",
           "image_override": null
         },
         "group": "data",
@@ -91,7 +92,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01905065e0c279159d89de4c05548081",
+        "id": "batt_01906f0329977e9695fb80bf01be34c6",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -133,7 +134,7 @@
           {
             "position": null,
             "username": "battery-control-user",
-            "password": "U3XKS5ZZPIIHTPBCRSKI6TAD",
+            "password": "VIRPBLDK7SCDRNOLEXJTLDJS",
             "roles": ["createdb", "login"],
             "credential_namespaces": ["battery-core"]
           }
@@ -146,7 +147,6 @@
     "redis_clusters": [],
     "projects": [],
     "ferret_services": [],
-    "knative_services": [],
     "ip_address_pools": []
   },
   "initial_resources": {
@@ -155,7 +155,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "HUYYPOXISS6KQLGBZ75TAW2VYA5TWMGBP43EKMXK2IPQN4HO72AA===="
+          "battery/hash": "WCIG2SR4LDE5FLITDZP2G45F4WLMDGJWPYFQAMHPDDMNH3HWU3EQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -165,7 +165,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01905065e0bd7e8f8c2e70a6de0c860a",
+          "battery/owner": "batt_01906f03299576d2a93c5468c0b27c89",
           "istio-injection": "enabled",
           "version": "latest"
         },

--- a/bootstrap/elliott.install.json
+++ b/bootstrap/elliott.install.json
@@ -1,12 +1,12 @@
 {
-  "id": "batt_01905065e0b7727d8e765f7b8a65c89f",
+  "id": "batt_01906f0329957de0b656974c442777d3",
   "usage": "development",
   "default_size": "small",
   "control_jwk": {
     "crv": "Ed25519",
-    "d": "po9ZUpUWLtbEME6Jme5eXN4kXJAq3Y5MbHZc2ND9Tkk",
+    "d": "TOf00sYZe26-75ToBznoiEMcRE7VY5NGhDVzkoxfTrE",
     "kty": "OKP",
-    "x": "rgxJQOt55jSrzUhYmzYCSOCqxKZPVwyrEOHkEqsVyOE"
+    "x": "kcT4TmkzclhjL8AT8lowqnBMl7CzVuWqEqttLpVL6tU"
   },
   "inserted_at": null,
   "updated_at": null,
@@ -16,5 +16,5 @@
   "sso_enabled": false,
   "initial_oauth_email": null,
   "user_id": null,
-  "team_id": "batt_01905065e03b7cc8b76d93a36d6395ce"
+  "team_id": "batt_01906f0329597b91b61a3f1779484d0d"
 }

--- a/bootstrap/elliott.spec.json
+++ b/bootstrap/elliott.spec.json
@@ -5,10 +5,11 @@
     "provider": "aws"
   },
   "target_summary": {
+    "knative_services": [],
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_01905065e0d77009bbedf5fb5f9fbe99",
+        "id": "batt_01906f03299b7f208a8ae19fe6627f6a",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -22,12 +23,12 @@
           "default_size": "small",
           "cluster_name": "elliott",
           "server_in_cluster": true,
-          "install_id": "batt_01905065e0b7727d8e765f7b8a65c89f",
+          "install_id": "batt_01906f0329957de0b656974c442777d3",
           "control_jwk": {
             "crv": "Ed25519",
-            "d": "po9ZUpUWLtbEME6Jme5eXN4kXJAq3Y5MbHZc2ND9Tkk",
+            "d": "TOf00sYZe26-75ToBznoiEMcRE7VY5NGhDVzkoxfTrE",
             "kty": "OKP",
-            "x": "rgxJQOt55jSrzUhYmzYCSOCqxKZPVwyrEOHkEqsVyOE"
+            "x": "kcT4TmkzclhjL8AT8lowqnBMl7CzVuWqEqttLpVL6tU"
           },
           "image_override": null,
           "bootstrap_image_override": null
@@ -37,7 +38,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01905065e0d77c01ba4ecb665742ff55",
+        "id": "batt_01906f03299b7bfc8c69edf5b7060498",
         "type": "karpenter",
         "config": {
           "type": "karpenter",
@@ -52,19 +53,19 @@
         "updated_at": null
       },
       {
-        "id": "batt_01905065e0d77350b727fe603388fd7b",
+        "id": "batt_01906f03299b762981ad3947d8f981b6",
         "type": "cert_manager",
         "config": {
           "type": "cert_manager",
           "email": null,
-          "acmesolver_image": "quay.io/jetstack/cert-manager-acmesolver:v1.14.6",
-          "cainjector_image": "quay.io/jetstack/cert-manager-cainjector:v1.14.6",
-          "controller_image": "quay.io/jetstack/cert-manager-controller:v1.14.6",
-          "ctl_image": "quay.io/jetstack/cert-manager-ctl:v1.14.6",
-          "webhook_image": "quay.io/jetstack/cert-manager-webhook:v1.14.6",
+          "acmesolver_image": "quay.io/jetstack/cert-manager-acmesolver:v1.14.7",
+          "cainjector_image": "quay.io/jetstack/cert-manager-cainjector:v1.14.7",
+          "controller_image": "quay.io/jetstack/cert-manager-controller:v1.14.7",
+          "ctl_image": "quay.io/jetstack/cert-manager-ctl:v1.14.7",
+          "webhook_image": "quay.io/jetstack/cert-manager-webhook:v1.14.7",
+          "controller_image_override": null,
           "acmesolver_image_override": null,
           "cainjector_image_override": null,
-          "controller_image_override": null,
           "ctl_image_override": null,
           "webhook_image_override": null
         },
@@ -73,7 +74,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01905065e0d87db1a9d860f1334c9a29",
+        "id": "batt_01906f03299b72c9b4adbecdccc284a8",
         "type": "battery_ca",
         "config": {
           "type": "battery_ca"
@@ -83,7 +84,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01905065e0d97c588d922b11cc8f61f8",
+        "id": "batt_01906f03299b7f089bdbb66a2c6d4c8f",
         "type": "aws_load_balancer_controller",
         "config": {
           "type": "aws_load_balancer_controller",
@@ -98,11 +99,11 @@
         "updated_at": null
       },
       {
-        "id": "batt_01905065e0d97a58b181443c0984d09d",
+        "id": "batt_01906f03299b7a45906461cdca676e2c",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
-          "image": "ghcr.io/cloudnative-pg/cloudnative-pg:1.23.1",
+          "image": "ghcr.io/cloudnative-pg/cloudnative-pg:1.23.2",
           "image_override": null
         },
         "group": "data",
@@ -110,7 +111,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01905065e0d9734b93f6ac9ea5a61134",
+        "id": "batt_01906f03299b7dceb7ab0f919ce0a8b1",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -124,7 +125,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01905065e0d972a5b7c8ae249eba24a8",
+        "id": "batt_01906f03299b7341809db4944c35e25b",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -136,7 +137,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01905065e0d97313aabc9f9dc4a49622",
+        "id": "batt_01906f03299b73a78f77c17fe6bd6c4e",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -171,7 +172,7 @@
           {
             "position": null,
             "username": "battery-control-user",
-            "password": "TCZWMGFRPGPULYTHH2QU6JRH",
+            "password": "DXJQYCTWOFYMHC5PXENVPORC",
             "roles": ["createdb", "login"],
             "credential_namespaces": ["battery-core"]
           }
@@ -184,7 +185,6 @@
     "redis_clusters": [],
     "projects": [],
     "ferret_services": [],
-    "knative_services": [],
     "ip_address_pools": []
   },
   "initial_resources": {
@@ -193,7 +193,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "C5PTM6IONNXI4H7J6EX7QPKG76H5EAZ4GF5SWHYLAQNDLQHXJ4HQ===="
+          "battery/hash": "EISZEM2VQ45HIM6TARMVU467MFXLZEHQAEDXAPEH4Y6QYXWPB7EA===="
         },
         "labels": {
           "app": "battery-core",
@@ -203,7 +203,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01905065e0d77009bbedf5fb5f9fbe99",
+          "battery/owner": "batt_01906f03299b7f208a8ae19fe6627f6a",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -226,7 +226,7 @@
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "3NPL6JNSJWKS4EJU65E2B3YP7WZJDQG22PLAZNHWVZDFQUSSADBQ===="
+          "battery/hash": "UQU3RYWBAZS54GFFE5DP76EFY3KUQ6OV3H7AWFAKRVG2NSGDXALQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -236,7 +236,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01905065e0d77009bbedf5fb5f9fbe99",
+          "battery/owner": "batt_01906f03299b7f208a8ae19fe6627f6a",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -260,7 +260,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_01905065e0d77009bbedf5fb5f9fbe99",
+              "battery/owner": "batt_01906f03299b7f208a8ae19fe6627f6a",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -273,7 +273,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "Y3L2MRQBXD44N2BS7NSBQVW2RZLAUP5ZRGLJMUP6L7BO64QWOSRKXHHTYMMJ2L2Q"
+                    "value": "KRE7VBTMHPW6YHMQYNPICEK4WFZBWFMUJGBYJIHBIDT7J423GN3ZQR77GBEVKCHU"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -321,7 +321,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "5YS46ZM5FTWFWW57BMNG3GYXN6MRUGD4X65RIA6TSIT6F3IPPJNQ===="
+          "battery/hash": "EBY4PQO5WDSLYKHLST2POFKDUAIEZNDXHZLPMLG26WVHDSOVE77Q===="
         },
         "labels": {
           "app": "battery-core",
@@ -331,7 +331,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01905065e0d77009bbedf5fb5f9fbe99",
+          "battery/owner": "batt_01906f03299b7f208a8ae19fe6627f6a",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -343,7 +343,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "FD7PJ4XRQQZRF53PKFOGDPVLC3POUXMFO7QVEEMOYTSCUFXCJAAQ===="
+          "battery/hash": "WMYJ5UJCXNBAI7WSJTINDV3SJTNKOKQSAXRREGQZUHCT6BYOTI2A===="
         },
         "labels": {
           "app": "battery-core",
@@ -353,7 +353,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01905065e0d77009bbedf5fb5f9fbe99",
+          "battery/owner": "batt_01906f03299b7f208a8ae19fe6627f6a",
           "version": "latest"
         },
         "name": "bootstrap",
@@ -366,7 +366,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "BSTDH5VMK3JZ7ZNQWIUTV6RWWZI4WXUEK4BMGPN7A7BNNXJYDYCA====",
+          "battery/hash": "CMLFDLJWKQU4YMSEDH5CKL6A5JUUAJKWJGLIHIK62Y6VAJ4BGQFA====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -377,7 +377,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01905065e0d77009bbedf5fb5f9fbe99",
+          "battery/owner": "batt_01906f03299b7f208a8ae19fe6627f6a",
           "version": "latest"
         },
         "name": "gp2"
@@ -392,7 +392,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "VCHQM6IDARYKKLBDVIYM4VEQ5NKMZVK5Q2HJ7UABUTN7TQXCMFIQ====",
+          "battery/hash": "KKGPYEKNJOVRCNY6RG4F5TYG4H3GORUNHI35YQ6B4YONVGWBBPWQ====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -403,7 +403,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01905065e0d77009bbedf5fb5f9fbe99",
+          "battery/owner": "batt_01906f03299b7f208a8ae19fe6627f6a",
           "version": "latest"
         },
         "name": "gp2-90032408"
@@ -423,7 +423,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "FK4E675VDFW62DXF4MW4WYBMG5UW73HRL2SWOYR5RRTKR5PDVUIQ====",
+          "battery/hash": "GR76S6VLVEFRRSKIER6KODIBIGLOIPUKDLR2DS222VYDGDOFDDNA====",
           "storageclass.kubernetes.io/is-default-class": "true"
         },
         "labels": {
@@ -434,7 +434,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01905065e0d77009bbedf5fb5f9fbe99",
+          "battery/owner": "batt_01906f03299b7f208a8ae19fe6627f6a",
           "version": "latest"
         },
         "name": "gp3-105457460"

--- a/bootstrap/integration-test.install.json
+++ b/bootstrap/integration-test.install.json
@@ -1,12 +1,12 @@
 {
-  "id": "batt_01905065e0b77e048f8e0dc73447f441",
+  "id": "batt_01906f0329957baca09c2eedf240d6e4",
   "usage": "internal_int_test",
   "default_size": "tiny",
   "control_jwk": {
     "crv": "Ed25519",
-    "d": "tF8Kv4_8onPd-ccG5S-tWYyQ554fBx8Kv1Oq3q_DmEo",
+    "d": "apyrdoWd-SQFUi6nWQYZc2U-8DyBJtWttmfYmspQYMw",
     "kty": "OKP",
-    "x": "6b7jY-Hn0CjlwdqeZ1PZ4br7HROEzyPL1cFGl4naRNY"
+    "x": "j0MyR7mSU9v6zFsGf_Cdb3Qao-PayjE2OGlMJcBX7Zk"
   },
   "inserted_at": null,
   "updated_at": null,
@@ -16,5 +16,5 @@
   "sso_enabled": false,
   "initial_oauth_email": null,
   "user_id": null,
-  "team_id": "batt_01905065e03b7cc8b76d93a36d6395ce"
+  "team_id": "batt_01906f0329597b91b61a3f1779484d0d"
 }

--- a/bootstrap/integration-test.spec.json
+++ b/bootstrap/integration-test.spec.json
@@ -5,10 +5,11 @@
     "provider": "kind"
   },
   "target_summary": {
+    "knative_services": [],
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_01905065e0dc78a999a9e6e1b83003dc",
+        "id": "batt_01906f03299c79c8a5f94d956b0215cf",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -22,12 +23,12 @@
           "default_size": "tiny",
           "cluster_name": "integration-test",
           "server_in_cluster": false,
-          "install_id": "batt_01905065e0b77e048f8e0dc73447f441",
+          "install_id": "batt_01906f0329957baca09c2eedf240d6e4",
           "control_jwk": {
             "crv": "Ed25519",
-            "d": "tF8Kv4_8onPd-ccG5S-tWYyQ554fBx8Kv1Oq3q_DmEo",
+            "d": "apyrdoWd-SQFUi6nWQYZc2U-8DyBJtWttmfYmspQYMw",
             "kty": "OKP",
-            "x": "6b7jY-Hn0CjlwdqeZ1PZ4br7HROEzyPL1cFGl4naRNY"
+            "x": "j0MyR7mSU9v6zFsGf_Cdb3Qao-PayjE2OGlMJcBX7Zk"
           },
           "image_override": null,
           "bootstrap_image_override": null
@@ -67,7 +68,7 @@
           {
             "position": null,
             "username": "battery-control-user",
-            "password": "24D32KI23F73QHTAZRB2WBHK",
+            "password": "CJ4XZZZ27UQX2AFHDP4FUEHH",
             "roles": ["createdb", "login"],
             "credential_namespaces": ["battery-core"]
           }
@@ -80,7 +81,6 @@
     "redis_clusters": [],
     "projects": [],
     "ferret_services": [],
-    "knative_services": [],
     "ip_address_pools": []
   },
   "initial_resources": {
@@ -89,7 +89,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "ZBY42DQ73RT47W6F53NLA7B6ZJJ56FJWV2GJTARIK6MEU5UCY7IQ===="
+          "battery/hash": "2FEDQHN4QWYLPUVL6TIKWNBNS64ZT5PZE5J6HAI3YXHS4XLI5QGA===="
         },
         "labels": {
           "app": "battery-core",
@@ -99,7 +99,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01905065e0dc78a999a9e6e1b83003dc",
+          "battery/owner": "batt_01906f03299c79c8a5f94d956b0215cf",
           "istio-injection": "enabled",
           "version": "latest"
         },

--- a/bootstrap/jason.install.json
+++ b/bootstrap/jason.install.json
@@ -1,12 +1,12 @@
 {
-  "id": "batt_01905065e0b775b7be5b88c78bb5a9c2",
+  "id": "batt_01906f0329957a8bb87e69d31e3ad000",
   "usage": "development",
   "default_size": "small",
   "control_jwk": {
     "crv": "Ed25519",
-    "d": "8-QCWVuop_gdi2pmrHpsJG94HNDLH1RaeR2yl2enHhQ",
+    "d": "qCBWtFLjr9AB4-_UDm3yhD2mCh_SqaoA6t8ds7YvXc8",
     "kty": "OKP",
-    "x": "oW_CySTmxZ22XsbAKb_v0AbuehGYr517Yq5n1ADJsfI"
+    "x": "JOZO4fZs2Ik3TXwgG4uBjaYccaRanpZs6Jqxu8nTGHI"
   },
   "inserted_at": null,
   "updated_at": null,
@@ -16,5 +16,5 @@
   "sso_enabled": false,
   "initial_oauth_email": null,
   "user_id": null,
-  "team_id": "batt_01905065e03b7cc8b76d93a36d6395ce"
+  "team_id": "batt_01906f0329597b91b61a3f1779484d0d"
 }

--- a/bootstrap/jason.spec.json
+++ b/bootstrap/jason.spec.json
@@ -5,10 +5,11 @@
     "provider": "aws"
   },
   "target_summary": {
+    "knative_services": [],
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_01905065e0da73fab2039423995c049e",
+        "id": "batt_01906f03299c7e40ab5b47d7b3ae2204",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -22,12 +23,12 @@
           "default_size": "small",
           "cluster_name": "jason",
           "server_in_cluster": true,
-          "install_id": "batt_01905065e0b775b7be5b88c78bb5a9c2",
+          "install_id": "batt_01906f0329957a8bb87e69d31e3ad000",
           "control_jwk": {
             "crv": "Ed25519",
-            "d": "8-QCWVuop_gdi2pmrHpsJG94HNDLH1RaeR2yl2enHhQ",
+            "d": "qCBWtFLjr9AB4-_UDm3yhD2mCh_SqaoA6t8ds7YvXc8",
             "kty": "OKP",
-            "x": "oW_CySTmxZ22XsbAKb_v0AbuehGYr517Yq5n1ADJsfI"
+            "x": "JOZO4fZs2Ik3TXwgG4uBjaYccaRanpZs6Jqxu8nTGHI"
           },
           "image_override": null,
           "bootstrap_image_override": null
@@ -37,7 +38,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01905065e0da7e9eaa8656de15a82d74",
+        "id": "batt_01906f03299c73a589c162d4b92bda20",
         "type": "karpenter",
         "config": {
           "type": "karpenter",
@@ -52,19 +53,19 @@
         "updated_at": null
       },
       {
-        "id": "batt_01905065e0da7e30b03b3b164b2027d6",
+        "id": "batt_01906f03299c799080925ca27feab772",
         "type": "cert_manager",
         "config": {
           "type": "cert_manager",
           "email": null,
-          "acmesolver_image": "quay.io/jetstack/cert-manager-acmesolver:v1.14.6",
-          "cainjector_image": "quay.io/jetstack/cert-manager-cainjector:v1.14.6",
-          "controller_image": "quay.io/jetstack/cert-manager-controller:v1.14.6",
-          "ctl_image": "quay.io/jetstack/cert-manager-ctl:v1.14.6",
-          "webhook_image": "quay.io/jetstack/cert-manager-webhook:v1.14.6",
+          "acmesolver_image": "quay.io/jetstack/cert-manager-acmesolver:v1.14.7",
+          "cainjector_image": "quay.io/jetstack/cert-manager-cainjector:v1.14.7",
+          "controller_image": "quay.io/jetstack/cert-manager-controller:v1.14.7",
+          "ctl_image": "quay.io/jetstack/cert-manager-ctl:v1.14.7",
+          "webhook_image": "quay.io/jetstack/cert-manager-webhook:v1.14.7",
+          "controller_image_override": null,
           "acmesolver_image_override": null,
           "cainjector_image_override": null,
-          "controller_image_override": null,
           "ctl_image_override": null,
           "webhook_image_override": null
         },
@@ -73,7 +74,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01905065e0da72cc93e98910b401366c",
+        "id": "batt_01906f03299c7be3824880cc9f4f741a",
         "type": "battery_ca",
         "config": {
           "type": "battery_ca"
@@ -83,7 +84,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01905065e0da7ca1899643d192a7a61b",
+        "id": "batt_01906f03299c7e0d8837e31f87e4d641",
         "type": "aws_load_balancer_controller",
         "config": {
           "type": "aws_load_balancer_controller",
@@ -98,11 +99,11 @@
         "updated_at": null
       },
       {
-        "id": "batt_01905065e0da72cab588734deb46cfdc",
+        "id": "batt_01906f03299c7f9a8e8b1c83b844f719",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
-          "image": "ghcr.io/cloudnative-pg/cloudnative-pg:1.23.1",
+          "image": "ghcr.io/cloudnative-pg/cloudnative-pg:1.23.2",
           "image_override": null
         },
         "group": "data",
@@ -110,7 +111,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01905065e0da75219569ba59cf209575",
+        "id": "batt_01906f03299c7700b0980b486c870cff",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -124,7 +125,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01905065e0da7eadac1cf0817fcf9bae",
+        "id": "batt_01906f03299c7d4396a3874cdb61b072",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -136,7 +137,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01905065e0da7586b0b37156935962d3",
+        "id": "batt_01906f03299c7f5283b2952535ad4a6f",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -171,7 +172,7 @@
           {
             "position": null,
             "username": "battery-control-user",
-            "password": "NQBHVRRPPDA4HUJAXDHQVEY6",
+            "password": "BY6WV7NLQOFI7VRKYP6JTNXS",
             "roles": ["createdb", "login"],
             "credential_namespaces": ["battery-core"]
           }
@@ -184,7 +185,6 @@
     "redis_clusters": [],
     "projects": [],
     "ferret_services": [],
-    "knative_services": [],
     "ip_address_pools": []
   },
   "initial_resources": {
@@ -193,7 +193,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "5H3N57JYNR2XOLG4VDSZS4M7MBTR2QHAAIGHPQS3Z5CN33GTABYQ===="
+          "battery/hash": "DQMRTDRCEJJBDCKLKAJGX53ZF6O7M45KYC6ZW26U6VC6KTCE7GLA===="
         },
         "labels": {
           "app": "battery-core",
@@ -203,7 +203,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01905065e0da73fab2039423995c049e",
+          "battery/owner": "batt_01906f03299c7e40ab5b47d7b3ae2204",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -226,7 +226,7 @@
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "BF67LFCJO6OKJPJ2G5OBLJ26O5TAT25KUPFJY7PPRSBGCQCJBT6A===="
+          "battery/hash": "ZPICKTNXVHNPWQI6PBVR3CTNCDPWEQ73SV7ZZPC4ZCBZYDO5EUXA===="
         },
         "labels": {
           "app": "battery-core",
@@ -236,7 +236,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01905065e0da73fab2039423995c049e",
+          "battery/owner": "batt_01906f03299c7e40ab5b47d7b3ae2204",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -260,7 +260,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_01905065e0da73fab2039423995c049e",
+              "battery/owner": "batt_01906f03299c7e40ab5b47d7b3ae2204",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -273,7 +273,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "PRUHUM2XDPHATXHS36DPHD7MJIYPOUTR3YWJPEAFOMDVHJKE2Q64JTH4PEI2J4KU"
+                    "value": "TQKL27HFCMKND46HBZ3E4JRU26YJ3OSA7S6GWAVBCPMYLPZIRQQOFRJ7A3E5LGJN"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -321,7 +321,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "5P25NYJAIZ3A25KMJSPB5G2YFAL3JGF2K6BZIWFMSYTINN7XQCQA===="
+          "battery/hash": "4K6KDZVG7XVNKEDEPTWVFYBUMQQQS2IPUEGYKCIVV6T75NVCWIFQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -331,7 +331,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01905065e0da73fab2039423995c049e",
+          "battery/owner": "batt_01906f03299c7e40ab5b47d7b3ae2204",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -343,7 +343,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "DPL5XAARJPO33ZL4G4FZPDVAEBHEBYHTCBFIRXCRUZU3UJQORAAA===="
+          "battery/hash": "CYBFQ42QFCNVQTC2NNY7OQJYV7IG5KY7YJOJFLY6UCIF2JEDRULA===="
         },
         "labels": {
           "app": "battery-core",
@@ -353,7 +353,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01905065e0da73fab2039423995c049e",
+          "battery/owner": "batt_01906f03299c7e40ab5b47d7b3ae2204",
           "version": "latest"
         },
         "name": "bootstrap",
@@ -366,7 +366,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "6PDWRFCSN5OBRHN4LKFDDDDSMYCYPD4R6IJCDAJTS7PIYBUG27AA====",
+          "battery/hash": "NUG3UDCIAKAII56ZYB6DB7Q4GNWO6E4WAUR455YG3UBXHUKKT26A====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -377,7 +377,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01905065e0da73fab2039423995c049e",
+          "battery/owner": "batt_01906f03299c7e40ab5b47d7b3ae2204",
           "version": "latest"
         },
         "name": "gp2"
@@ -392,7 +392,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "UFIRN5ZKT2MXYGYUKWOJSHK3CGAYMRJZCCHASINH5CN555IHJHUQ====",
+          "battery/hash": "JCYLBPH4Z2FFTGRP4FAXLVOOQJ4ZFF5PA4UDGMPA4NDGDDNLVCBQ====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -403,7 +403,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01905065e0da73fab2039423995c049e",
+          "battery/owner": "batt_01906f03299c7e40ab5b47d7b3ae2204",
           "version": "latest"
         },
         "name": "gp2-90032408"
@@ -423,7 +423,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "Z4ILVUF7JLA64JUGU5KD2SIDQQ5JI2NPPT6XKMS5YSXTXT63BQMA====",
+          "battery/hash": "QOLQDIXXSRXSGXZZITNINEKIETORLS4I6PC5IVVTOQBCBAGL2DXA====",
           "storageclass.kubernetes.io/is-default-class": "true"
         },
         "labels": {
@@ -434,7 +434,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01905065e0da73fab2039423995c049e",
+          "battery/owner": "batt_01906f03299c7e40ab5b47d7b3ae2204",
           "version": "latest"
         },
         "name": "gp3-105457460"

--- a/bootstrap/local.install.json
+++ b/bootstrap/local.install.json
@@ -1,12 +1,12 @@
 {
-  "id": "batt_01905065e0b774c2916d51f8ccf7a84c",
+  "id": "batt_01906f0329957d67a9f49ed0d4117687",
   "usage": "development",
   "default_size": "tiny",
   "control_jwk": {
     "crv": "Ed25519",
-    "d": "dtePO07dNLeqb_x9wnPO246RBl15KuImRNuFqpEkBWQ",
+    "d": "x7piXhKjskUrlbsI4uD2JIW6psL4f24d_hRie9CkPAg",
     "kty": "OKP",
-    "x": "RHfhjvPRHa4Lr4euk5ouVEoZd23ceILHICJ6RkycVnc"
+    "x": "uuTs9-8ng0AQldRuTjLOdDkLNZDhqwo5kQ2xJfjJNOw"
   },
   "inserted_at": null,
   "updated_at": null,
@@ -16,5 +16,5 @@
   "sso_enabled": false,
   "initial_oauth_email": null,
   "user_id": null,
-  "team_id": "batt_01905065e03b7cc8b76d93a36d6395ce"
+  "team_id": "batt_01906f0329597b91b61a3f1779484d0d"
 }

--- a/bootstrap/local.spec.json
+++ b/bootstrap/local.spec.json
@@ -5,10 +5,11 @@
     "provider": "kind"
   },
   "target_summary": {
+    "knative_services": [],
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_01905065e0d575fba4c2c75ad6f61204",
+        "id": "batt_01906f03299b7641939111a80fab4fdf",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -22,7 +23,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01905065e0d574f3b72136b681e5ea6f",
+        "id": "batt_01906f03299b7737b92b7202226d6de2",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -34,7 +35,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01905065e0d57775bde6cc7e1e8acd8b",
+        "id": "batt_01906f03299b7415aef5cd4fbc5af7c0",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -48,12 +49,12 @@
           "default_size": "tiny",
           "cluster_name": "local",
           "server_in_cluster": true,
-          "install_id": "batt_01905065e0b774c2916d51f8ccf7a84c",
+          "install_id": "batt_01906f0329957d67a9f49ed0d4117687",
           "control_jwk": {
             "crv": "Ed25519",
-            "d": "dtePO07dNLeqb_x9wnPO246RBl15KuImRNuFqpEkBWQ",
+            "d": "x7piXhKjskUrlbsI4uD2JIW6psL4f24d_hRie9CkPAg",
             "kty": "OKP",
-            "x": "RHfhjvPRHa4Lr4euk5ouVEoZd23ceILHICJ6RkycVnc"
+            "x": "uuTs9-8ng0AQldRuTjLOdDkLNZDhqwo5kQ2xJfjJNOw"
           },
           "image_override": null,
           "bootstrap_image_override": null
@@ -63,15 +64,15 @@
         "updated_at": null
       },
       {
-        "id": "batt_01905065e0d577f2a668ed67a4924522",
+        "id": "batt_01906f03299b7a06af44ce303d632c91",
         "type": "metallb",
         "config": {
           "type": "metallb",
           "controller_image": "quay.io/metallb/controller:v0.13.12",
           "speaker_image": "quay.io/metallb/speaker:v0.13.12",
           "frrouting_image": "quay.io/frrouting/frr:8.5.4",
-          "controller_image_override": null,
           "speaker_image_override": null,
+          "controller_image_override": null,
           "frrouting_image_override": null
         },
         "group": "net_sec",
@@ -79,11 +80,11 @@
         "updated_at": null
       },
       {
-        "id": "batt_01905065e0d57818a049fcaeefcec36d",
+        "id": "batt_01906f03299b773298c28ad6208d8e3e",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
-          "image": "ghcr.io/cloudnative-pg/cloudnative-pg:1.23.1",
+          "image": "ghcr.io/cloudnative-pg/cloudnative-pg:1.23.2",
           "image_override": null
         },
         "group": "data",
@@ -91,7 +92,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01905065e0d57a078b4e589f12c3793b",
+        "id": "batt_01906f03299b7b7e98742d9a9cf95b1b",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -126,7 +127,7 @@
           {
             "position": null,
             "username": "battery-control-user",
-            "password": "VSU42KTSXLAYAALE3CMKEPMG",
+            "password": "DW7YEM4WTFWRBNLCKQVKV6PN",
             "roles": ["createdb", "login"],
             "credential_namespaces": ["battery-core"]
           }
@@ -139,7 +140,6 @@
     "redis_clusters": [],
     "projects": [],
     "ferret_services": [],
-    "knative_services": [],
     "ip_address_pools": []
   },
   "initial_resources": {
@@ -148,7 +148,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "DSHSKZ4TBKYSY2H3IP5WPZE6MIULMQIPRF64T36YYRAFG2PJEZNQ===="
+          "battery/hash": "PS6C55QUYXIOG3D7MDOJACP3EZPBQXAAMB4RUGDEWZUCZVRTY2BA===="
         },
         "labels": {
           "app": "battery-core",
@@ -158,7 +158,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01905065e0d57775bde6cc7e1e8acd8b",
+          "battery/owner": "batt_01906f03299b7415aef5cd4fbc5af7c0",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -181,7 +181,7 @@
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "QGKGRBTJ4XQ7AQ72HPUAY4HHJSM5STDLCNDW7SIND2C6BXLREMCQ===="
+          "battery/hash": "4GGE3LCZTOENTFWWTVNLLWLCZ5KBE3GINWMRSSSFOLXEKDD67K2A===="
         },
         "labels": {
           "app": "battery-core",
@@ -191,7 +191,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01905065e0d57775bde6cc7e1e8acd8b",
+          "battery/owner": "batt_01906f03299b7415aef5cd4fbc5af7c0",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -215,7 +215,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_01905065e0d57775bde6cc7e1e8acd8b",
+              "battery/owner": "batt_01906f03299b7415aef5cd4fbc5af7c0",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -228,7 +228,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "2RJGKPDCQ3FTXVPPN754S52KAHHQPPGHEURN6GCFIKXCF6FRFWKRCXWAWIABQJD3"
+                    "value": "54G7LQNIE4P32JYPFXRT6SG2NK222UD3TNIWLCI7WWC62O3SPUH4TTGS7HHXS2V6"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -276,7 +276,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "27UQJAHJS5BSZON6EBEH4DCGCDLEYA747SS75YT7XHIGSIP5UANQ===="
+          "battery/hash": "U5VJXEDQTAHWBWIAIRLTRS6MLVVBMED5APOV4VFR7QFVE5Y36IDQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -286,7 +286,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01905065e0d57775bde6cc7e1e8acd8b",
+          "battery/owner": "batt_01906f03299b7415aef5cd4fbc5af7c0",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -298,7 +298,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "3KEIKSRG4AXXMVRMM2P6TWK447ROJHOMJRPF5XK2QHBULCHHJCCQ===="
+          "battery/hash": "WVUPGMWOU47SWBDOJYD5IVERIWYV5G5FEFNFHEBF2XFIZMUZXDXQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -308,7 +308,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01905065e0d57775bde6cc7e1e8acd8b",
+          "battery/owner": "batt_01906f03299b7415aef5cd4fbc5af7c0",
           "version": "latest"
         },
         "name": "bootstrap",

--- a/bootstrap/team.json
+++ b/bootstrap/team.json
@@ -1,5 +1,5 @@
 {
-  "id": "batt_01905065e03b7cc8b76d93a36d6395ce",
+  "id": "batt_01906f0329597b91b61a3f1779484d0d",
   "name": "Batteries Included Team",
   "inserted_at": null,
   "updated_at": null,

--- a/nix/mission-control.nix
+++ b/nix/mission-control.nix
@@ -32,9 +32,8 @@ _: {
             exec = ''
               [[ -z ''${TRACE:-""} ]] || set -x
               pushd platform_umbrella &> /dev/null
-              mix "do" clean, compile --force
               rm -rf ../bootstrap
-              mix gen.static.installations "../bootstrap"
+              VERSION_OVERRIDE=''${VERSION_OVERRIDE:-"latest"} mix "do" clean, compile --force, gen.static.installations "../bootstrap"
               popd &> /dev/null
               treefmt
             '';

--- a/nix/mix-command.nix
+++ b/nix/mix-command.nix
@@ -17,6 +17,7 @@
   hex,
   rebar3,
   command,
+  fakeGit,
   ...
 }:
 pkgs.stdenv.mkDerivation {
@@ -33,6 +34,7 @@ pkgs.stdenv.mkDerivation {
     cmake
     python312
     openssl
+    fakeGit
   ];
   inherit buildInputs;
 

--- a/nix/platform-release.nix
+++ b/nix/platform-release.nix
@@ -16,6 +16,7 @@
   hex,
   mixFodDeps,
   gitignoreSource,
+  fakeGit,
   ...
 }:
 let
@@ -53,6 +54,7 @@ beamPackages.mixRelease {
     pkg-config
     nodejs
     python312
+    fakeGit
   ];
 
   buildInputs = [ openssl ];

--- a/nix/platform.nix
+++ b/nix/platform.nix
@@ -1,4 +1,4 @@
-{ inputs, ... }:
+{ inputs, self, ... }:
 {
   perSystem =
     { lib, pkgs, ... }:
@@ -25,6 +25,9 @@
         doCheck = false;
         chechPhase = "";
       });
+
+      safeRev = self.shortRev or self.dirtyShortRev;
+      fakeGit = pkgs.writeScriptBin "git" "echo \"${safeRev}\"";
 
       npmlock2nix = pkgs.callPackages inputs.npmlock2nix { };
 
@@ -66,6 +69,7 @@
           src
           mixFodDeps
           pkgs
+          self
           ;
         inherit erlang elixir hex;
         inherit npmlock2nix nodejs;
@@ -75,6 +79,7 @@
           openssl
           cmake
           python312
+          fakeGit
           ;
         inherit gitignoreSource;
 
@@ -95,6 +100,7 @@
           pkg-config
           cmake
           python312
+          fakeGit
         ];
         buildInputs = [ openssl ];
         installPhase = ''
@@ -116,6 +122,7 @@
           openssl
           cmake
           python312
+          fakeGit
           ;
         inherit gitignoreSource;
 
@@ -132,6 +139,7 @@
           openssl
           cmake
           python312
+          fakeGit
           ;
         inherit rebar3;
 
@@ -150,6 +158,7 @@
           openssl
           cmake
           python312
+          fakeGit
           ;
         inherit rebar3;
 
@@ -167,6 +176,7 @@
           gcc
           openssl
           cmake
+          fakeGit
           ;
         inherit rebar3;
 

--- a/platform_umbrella/apps/common_core/lib/common_core/defaults/images.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/defaults/images.ex
@@ -1,59 +1,170 @@
 defmodule CommonCore.Defaults.Images do
   @moduledoc false
+  @batteries_included_base "#{CommonCore.Version.version()}-#{CommonCore.Version.hash()}"
   @cert_manager_image_tag "v1.14.7"
   @kiali_image_version "v1.85.0"
 
+  @spec cert_manager_image_version() :: String.t()
   def cert_manager_image_version, do: @cert_manager_image_tag
+
+  @spec vm_cluster_tag() :: String.t()
   def vm_cluster_tag, do: "v1.93.9-cluster"
+
+  @spec vm_tag() :: String.t()
   def vm_tag, do: "v1.93.9"
+
+  @spec kiali_image_version() :: String.t()
   def kiali_image_version, do: @kiali_image_version
 
+  @spec batteries_included_version() :: String.t()
+  def batteries_included_version do
+    override =
+      :common_core
+      |> Application.get_env(CommonCore.Defaults)
+      |> Keyword.get(:version_override, nil)
+
+    if override != nil do
+      override
+    else
+      @batteries_included_base
+    end
+  end
+
+  @spec control_server_image() :: String.t()
+  def control_server_image do
+    ver = batteries_included_version()
+    "public.ecr.aws/batteries-included/control-server:#{ver}"
+  end
+
+  @spec control_server_image() :: String.t()
+  def bootstrap_image do
+    ver = batteries_included_version()
+    "public.ecr.aws/batteries-included/kube-bootstrap:#{ver}"
+  end
+
+  @spec addon_resizer_image() :: String.t()
   def addon_resizer_image, do: "registry.k8s.io/autoscaling/addon-resizer:1.8.22"
+
+  @spec alertmanager_image() :: String.t()
   def alertmanager_image, do: "quay.io/prometheus/alertmanager:v0.27.0"
+
+  @spec aws_load_balancer_controller_image() :: String.t()
   def aws_load_balancer_controller_image, do: "public.ecr.aws/eks/aws-load-balancer-controller:v2.8.1"
-  def bootstrap_image, do: "public.ecr.aws/batteries-included/kube-bootstrap:latest"
+
+  @spec cert_manager_acmesolver_image() :: String.t()
   def cert_manager_acmesolver_image, do: "quay.io/jetstack/cert-manager-acmesolver:#{cert_manager_image_version()}"
+
+  @spec cert_manager_cainjector_image() :: String.t()
   def cert_manager_cainjector_image, do: "quay.io/jetstack/cert-manager-cainjector:#{cert_manager_image_version()}"
+  @spec cert_manager_controller_image() :: String.t()
   def cert_manager_controller_image, do: "quay.io/jetstack/cert-manager-controller:#{cert_manager_image_version()}"
+
+  @spec cert_manager_ctl_image() :: String.t()
   def cert_manager_ctl_image, do: "quay.io/jetstack/cert-manager-ctl:#{cert_manager_image_version()}"
+
+  @spec cert_manager_webhook_image() :: String.t()
   def cert_manager_webhook_image, do: "quay.io/jetstack/cert-manager-webhook:#{cert_manager_image_version()}"
+
+  @spec cloudnative_pg_image() :: String.t()
   def cloudnative_pg_image, do: "ghcr.io/cloudnative-pg/cloudnative-pg:1.23.2"
-  def control_server_image, do: "public.ecr.aws/batteries-included/control-server:latest"
+
+  @spec ferretdb_image() :: String.t()
   def ferretdb_image, do: "ghcr.io/ferretdb/ferretdb:1.22.0"
+
+  @spec forgejo_image() :: String.t()
   def forgejo_image, do: "codeberg.org/forgejo/forgejo:1.21.11-2"
+
+  @spec frrouting_frr_image() :: String.t()
   def frrouting_frr_image, do: "quay.io/frrouting/frr:8.5.4"
+
+  @spec grafana_image() :: String.t()
   def grafana_image, do: "grafana/grafana:10.4.5"
+
+  @spec istio_pilot_image() :: String.t()
   def istio_pilot_image, do: "docker.io/istio/pilot:1.22.1-distroless"
+
+  @spec istio_proxy_image() :: String.t()
   def istio_proxy_image, do: "docker.io/istio/proxyv2:1.22.1-distroless"
+
+  @spec karpenter_image() :: String.t()
   def karpenter_image, do: "public.ecr.aws/karpenter/controller:0.37.0"
+
+  @spec keycloak_image() :: String.t()
   def keycloak_image, do: "quay.io/keycloak/keycloak:24.0.5"
+
+  @spec kiali_image() :: String.t()
   def kiali_image, do: "quay.io/kiali/kiali:#{kiali_image_version()}"
+
+  @spec kiwigrid_sidecar_image() :: String.t()
   def kiwigrid_sidecar_image, do: "quay.io/kiwigrid/k8s-sidecar:1.27.4"
+
+  @spec kube_state_metrics_image() :: String.t()
   def kube_state_metrics_image, do: "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0"
+
+  @spec loki_image() :: String.t()
   def loki_image, do: "grafana/loki:2.9.8"
+
+  @spec metallb_controller_image() :: String.t()
   def metallb_controller_image, do: "quay.io/metallb/controller:v0.13.12"
+
+  @spec metallb_speaker_image() :: String.t()
   def metallb_speaker_image, do: "quay.io/metallb/speaker:v0.13.12"
+
+  @spec metrics_server_image() :: String.t()
   def metrics_server_image, do: "registry.k8s.io/metrics-server/metrics-server:v0.7.1"
+
+  @spec node_exporter_image() :: String.t()
   def node_exporter_image, do: "quay.io/prometheus/node-exporter:v1.8.1"
+
+  @spec oauth2_proxy_image() :: String.t()
   def oauth2_proxy_image, do: "quay.io/oauth2-proxy/oauth2-proxy:v7.6.0"
+
+  @spec promtail_image() :: String.t()
   def promtail_image, do: "grafana/promtail:2.9.8"
+
+  @spec redis_operator_image() :: String.t()
   def redis_operator_image, do: "quay.io/spotahome/redis-operator:v1.2.4"
+
+  @spec smtp4dev_image() :: String.t()
   def smtp4dev_image, do: "rnwood/smtp4dev:3.1.4"
-  def text_generation_webui_image, do: "atinoda/text-generation-webui:default-snapshot-2023-12-10"
+
+  @spec text_generation_webui_image() :: String.t()
+  def text_generation_webui_image, do: "atinoda/text-generation-webui:default-cpu-2024.06.23"
+
+  @spec trivy_operator_image() :: String.t()
   def trivy_operator_image, do: "ghcr.io/aquasecurity/trivy-operator:0.21.3"
+
+  @spec aqua_node_collector() :: String.t()
   def aqua_node_collector, do: "ghcr.io/aquasecurity/node-collector:0.2.1"
+
+  @spec aqua_trivy_checks() :: String.t()
   def aqua_trivy_checks, do: "ghcr.io/aquasecurity/trivy-checks:0.13.0"
 
+  @spec trust_manager_image() :: String.t()
   def trust_manager_image, do: "quay.io/jetstack/trust-manager:v0.11.0"
   def trust_manager_init_image, do: "quay.io/jetstack/cert-manager-package-debian:20210119.0"
+
+  @spec vm_operator_image() :: String.t()
   def vm_operator_image, do: "victoriametrics/operator:v0.44.0"
 
+  @spec knative_serving_queue_image() :: String.t()
   def knative_serving_queue_image, do: "gcr.io/knative-releases/knative.dev/serving/cmd/queue:v1.14.1"
+
+  @spec knative_serving_activator_image() :: String.t()
   def knative_serving_activator_image, do: "gcr.io/knative-releases/knative.dev/serving/cmd/activator:v1.14.1"
+
+  @spec knative_serving_autoscaler_image() :: String.t()
   def knative_serving_autoscaler_image, do: "gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler:v1.14.1"
+
+  @spec knative_serving_controller_image() :: String.t()
   def knative_serving_controller_image, do: "gcr.io/knative-releases/knative.dev/serving/cmd/controller:v1.14.1"
+
+  @spec knative_serving_webhook_image() :: String.t()
   def knative_serving_webhook_image, do: "gcr.io/knative-releases/knative.dev/serving/cmd/webhook:v1.14.1"
 
+  @spec knative_istio_controller_image() :: String.t()
   def knative_istio_controller_image, do: "gcr.io/knative-releases/knative.dev/net-istio/cmd/controller:v1.14.1"
+
+  @spec knative_istio_webhook_image() :: String.t()
   def knative_istio_webhook_image, do: "gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook:v1.14.1"
 end

--- a/platform_umbrella/apps/common_core/lib/common_core/version.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/version.ex
@@ -1,0 +1,9 @@
+defmodule CommonCore.Version do
+  @moduledoc false
+
+  @hash "git" |> System.cmd(["rev-parse", "--short", "HEAD"]) |> elem(0) |> String.trim()
+  @version Mix.Project.config()[:version]
+
+  def version, do: @version
+  def hash, do: @hash
+end

--- a/platform_umbrella/config/config.exs
+++ b/platform_umbrella/config/config.exs
@@ -111,6 +111,8 @@ config :common_core, CommonCore.JWK,
   sign_key: :test,
   verify_keys: [:test_pub, :home_a_pub, :home_b_pub]
 
+config :common_core, CommonCore.Defaults, version_override: System.get_env("VERSION_OVERRIDE", nil)
+
 config :tesla, adapter: {Tesla.Adapter.Finch, [timeout: 30_000, name: CommonCore.Finch]}
 
 config :swoosh, :api_client, Swoosh.ApiClient.Finch


### PR DESCRIPTION
Summary:
Add a way so that the current version requested is always the tag that
would build the current source. That way control server always tries to
run itself.

This also adds an environment variable VERSION_OVERRIDE that is used to
change that.

Test Plan:
```
iex(2)> CommonCore.Defaults.Images.control_server_image
"public.ecr.aws/batteries-included/control-server:0.13.0-77bba943"
```

tests added

re-generated specs
