### PR TITLE
chore: remove nix ide as recommended addon

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,6 @@
     "astro-build.astro-vscode",
     "bradlc.vscode-tailwindcss",
     "JakeBecker.elixir-ls",
-    "jnoortheen.nix-ide",
     "phoenixframework.phoenix",
   ],
   "unwantedRecommendations": []


### PR DESCRIPTION
Summary:
Nix is out

Test Plan:
It stops telling me to install the vscode extension on ubuntu install
