### PR TITLE
chore(keycloak): be quieter when creating clients

### DIFF
--- a/platform_umbrella/apps/kube_services/lib/kube_services/snapshot_apply/apply_action.ex
+++ b/platform_umbrella/apps/kube_services/lib/kube_services/snapshot_apply/apply_action.ex
@@ -45,7 +45,7 @@ defmodule KubeServices.SnapshotApply.ApplyAction do
             }
           })
 
-        Logger.debug("Creating new client: #{inspect(value)}")
+        Logger.debug("Creating new client: #{inspect(value["name"])}")
         {:ok, nil}
 
       {:error, :already_exists} ->


### PR DESCRIPTION
They keycloak client representation is pretty large. We don't need to dump the whole thing when creating.