### PR TITLE
build: add dependabot for bi and pastebin-go

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,3 +29,11 @@ updates:
     directory: '/platform_umbrella/'
     schedule:
       interval: daily
+  - package-ecosystem: 'gomod'
+    directory: '/bi/'
+    schedule:
+      interval: daily
+  - package-ecosystem: 'gomod'
+    directory: '/pastebin-go/'
+    schedule:
+      interval: daily

--- a/bin/bix
+++ b/bin/bix
@@ -77,9 +77,9 @@ Available commands:
 - build-bi          Build the bi binary
 
 **Go Commands**
-- go-update-deps    Update go dependencies
 - go-test           Run go tests
 - go-test-int       Run go integration tests
+- go-update-deps    Update go dependencies
 
 **Elixir Commands**
 - ex-test-deep      Run all tests with coverage and reset the database

--- a/platform_umbrella/apps/common_core/lib/common_core/version.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/version.ex
@@ -1,12 +1,22 @@
 defmodule CommonCore.Version do
-  @moduledoc false
+  @moduledoc """
+  Module for getting the version and hash of the current build.
+
+  This uses git to get the hash and the version from the mix.exs file.
+  """
+
+  @args ["describe", "--match=\"badtagthatnevermatches\"", "--always", "--dirty"]
 
   @hash "git"
-        |> System.cmd(["describe", "--match=\"badtagthatnevermatches\"", "--always", "--dirty"])
+        |> System.cmd(@args)
         |> elem(0)
         |> String.trim()
+
   @version Mix.Project.config()[:version]
 
+  @spec version() :: String.t()
   def version, do: @version
+
+  @spec hash() :: String.t()
   def hash, do: @hash
 end


### PR DESCRIPTION
Summary:
Now that we're not using gomod2nix we can use dependabot to update the
deps

Test Plan:
dependabot comes around
