### PR TITLE
Add option to create knative and backend services in web projects

### DIFF
--- a/platform_umbrella/apps/common_ui/lib/common_ui/components/input.ex
+++ b/platform_umbrella/apps/common_ui/lib/common_ui/components/input.ex
@@ -19,14 +19,16 @@ defmodule CommonUI.Components.Input do
   attr :label_note, :string, default: nil
   attr :note, :string, default: nil
   attr :placeholder, :string, default: nil
-  attr :placeholder_selectable, :boolean, default: false
   attr :type, :string, default: "text"
   attr :icon, :atom, default: nil
-  attr :options, :list, default: []
   attr :multiple, :boolean, default: false
   attr :debounce, :any, default: "blur"
   attr :class, :string, default: nil
   attr :rest, :global, include: ~w(autocomplete autofocus step maxlength disabled required)
+
+  # Used for select field
+  attr :options, :list, default: []
+  attr :placeholder_selectable, :boolean, default: false
 
   # Used for range sliders
   attr :min, :any, default: 0

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/backend/form_component.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/backend/form_component.ex
@@ -2,6 +2,7 @@ defmodule ControlServerWeb.Live.Backend.FormComponent do
   @moduledoc false
   use ControlServerWeb, :live_component
 
+  import ControlServerWeb.BackendFormSubcomponents
   import ControlServerWeb.Containers.ContainersPanel
   import ControlServerWeb.Containers.EnvValuePanel
   import ControlServerWeb.Containers.HiddenForms
@@ -9,7 +10,6 @@ defmodule ControlServerWeb.Live.Backend.FormComponent do
   alias CommonCore.Backend.Service
   alias CommonCore.Containers.Container
   alias CommonCore.Containers.EnvValue
-  alias CommonCore.Util.Memory
   alias ControlServer.Backend
   alias Ecto.Changeset
   alias KubeServices.SystemState.SummaryBatteries
@@ -188,31 +188,6 @@ defmodule ControlServerWeb.Live.Backend.FormComponent do
     end
   end
 
-  defp main_panel(assigns) do
-    ~H"""
-    <.panel>
-      <.grid columns={[sm: 1, lg: 2]}>
-        <.input label="Name" field={@form[:name]} autofocus placeholder="Name" />
-        <.input
-          field={@form[:virtual_size]}
-          type="select"
-          label="Size"
-          options={Service.preset_options_for_select()}
-        />
-      </.grid>
-      <.data_list
-        :if={@form[:virtual_size].value != "custom"}
-        variant="horizontal-bolded"
-        class="mt-3 mb-5"
-        data={[
-          {"Memory limits:", Memory.humanize(@form[:memory_limits].value)},
-          {"CPU limits:", @form[:cpu_limits].value}
-        ]}
-      />
-    </.panel>
-    """
-  end
-
   @impl Phoenix.LiveComponent
   def render(assigns) do
     ~H"""
@@ -237,7 +212,9 @@ defmodule ControlServerWeb.Live.Backend.FormComponent do
           </.button>
         </.page_header>
         <.flex column>
-          <.main_panel form={@form} />
+          <.panel>
+            <.main_panel form={@form} />
+          </.panel>
 
           <.grid columns={[sm: 1, lg: 2]}>
             <.containers_panel

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/backend/form_subcomponents.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/backend/form_subcomponents.ex
@@ -1,0 +1,37 @@
+defmodule ControlServerWeb.BackendFormSubcomponents do
+  @moduledoc false
+  use ControlServerWeb, :html
+
+  alias CommonCore.Backend.Service
+  alias CommonCore.Util.Memory
+
+  attr :class, :any, default: nil
+  attr :form, Phoenix.HTML.Form, required: true
+
+  def main_panel(assigns) do
+    ~H"""
+    <div class={["contents", @class]}>
+      <.grid columns={[sm: 1, lg: 2]}>
+        <.input label="Name" field={@form[:name]} autofocus placeholder="Name" />
+
+        <.input
+          field={@form[:virtual_size]}
+          type="select"
+          label="Size"
+          options={Service.preset_options_for_select()}
+        />
+      </.grid>
+
+      <.data_list
+        :if={@form[:virtual_size].value != "custom"}
+        variant="horizontal-bolded"
+        class="mt-3 mb-5"
+        data={[
+          {"Memory limits:", Memory.humanize(@form[:memory_limits].value)},
+          {"CPU limits:", @form[:cpu_limits].value}
+        ]}
+      />
+    </div>
+    """
+  end
+end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/knative/form_component.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/knative/form_component.ex
@@ -5,7 +5,7 @@ defmodule ControlServerWeb.Live.Knative.FormComponent do
   import ControlServerWeb.Containers.ContainersPanel
   import ControlServerWeb.Containers.EnvValuePanel
   import ControlServerWeb.Containers.HiddenForms
-  import KubeServices.SystemState.SummaryHosts
+  import ControlServerWeb.KnativeFormSubcomponents
 
   alias CommonCore.Containers.Container
   alias CommonCore.Containers.EnvValue
@@ -13,7 +13,6 @@ defmodule ControlServerWeb.Live.Knative.FormComponent do
   alias ControlServer.Knative
   alias Ecto.Changeset
   alias KubeServices.SystemState.SummaryBatteries
-  alias Phoenix.HTML.Form
 
   @impl Phoenix.LiveComponent
   def mount(socket) do
@@ -74,10 +73,6 @@ defmodule ControlServerWeb.Live.Knative.FormComponent do
 
   def assign_env_value_idx(socket, idx) do
     assign(socket, env_value_idx: idx)
-  end
-
-  defp potential_url(%Form{} = form) do
-    "http://#{knative_host(Changeset.apply_changes(form.source))}"
   end
 
   @impl Phoenix.LiveComponent
@@ -266,20 +261,6 @@ defmodule ControlServerWeb.Live.Knative.FormComponent do
     """
   end
 
-  defp name_panel(assigns) do
-    ~H"""
-    <.input label="Name" field={@form[:name]} autofocus placeholder="Name" />
-    """
-  end
-
-  defp url_panel(assigns) do
-    ~H"""
-    <.flex class="justify-around items-center">
-      <.truncate_tooltip value={potential_url(@form)} length={72} />
-    </.flex>
-    """
-  end
-
   @impl Phoenix.LiveComponent
   def render(assigns) do
     ~H"""
@@ -304,21 +285,24 @@ defmodule ControlServerWeb.Live.Knative.FormComponent do
             Save Service
           </.button>
         </.page_header>
-        <.grid columns={[sm: 1, lg: 2]}>
-          <.name_panel form={@form} />
-          <.url_panel form={@form} />
-          <.containers_panel
-            target={@myself}
-            init_containers={@init_containers}
-            containers={@containers}
-          />
-          <.advanced_setting_panel form={@form} sso_enabled={@sso_enabled} projects={@projects} />
-          <.env_var_panel env_values={@env_values} editable target={@myself} />
-          <!-- Hidden inputs for embeds -->
-          <.containers_hidden_form field={@form[:containers]} />
-          <.containers_hidden_form field={@form[:init_containers]} />
-          <.env_values_hidden_form field={@form[:env_values]} />
-        </.grid>
+
+        <.flex column>
+          <.main_panel form={@form} />
+
+          <.grid columns={[sm: 1, lg: 2]}>
+            <.containers_panel
+              target={@myself}
+              init_containers={@init_containers}
+              containers={@containers}
+            />
+            <.advanced_setting_panel form={@form} sso_enabled={@sso_enabled} projects={@projects} />
+            <.env_var_panel env_values={@env_values} editable target={@myself} />
+            <!-- Hidden inputs for embeds -->
+            <.containers_hidden_form field={@form[:containers]} />
+            <.containers_hidden_form field={@form[:init_containers]} />
+            <.env_values_hidden_form field={@form[:env_values]} />
+          </.grid>
+        </.flex>
       </.form>
 
       <.live_component

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/knative/form_subcomponents.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/knative/form_subcomponents.ex
@@ -1,0 +1,30 @@
+defmodule ControlServerWeb.KnativeFormSubcomponents do
+  @moduledoc false
+  use ControlServerWeb, :html
+
+  import KubeServices.SystemState.SummaryHosts
+
+  alias Ecto.Changeset
+  alias Phoenix.HTML.Form
+
+  attr :class, :any, default: nil
+  attr :form, Form, required: true
+
+  def main_panel(assigns) do
+    ~H"""
+    <div class={["contents", @class]}>
+      <.grid columns={[sm: 1, lg: 2]}>
+        <.input label="Name" field={@form[:name]} autofocus placeholder="Name" />
+
+        <.flex class="justify-around items-center">
+          <.truncate_tooltip value={potential_url(@form)} length={72} />
+        </.flex>
+      </.grid>
+    </div>
+    """
+  end
+
+  defp potential_url(%Form{} = form) do
+    "http://#{knative_host(Changeset.apply_changes(form.source))}"
+  end
+end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/batteries_form.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/batteries_form.ex
@@ -241,6 +241,8 @@ defmodule ControlServerWeb.Projects.BatteriesForm do
           "postgres_ids" -> [:cloudnative_pg]
           "redis" -> [:redis]
           "jupyter" -> [:notebooks]
+          "knative" -> [:knative]
+          "backend" -> [:backend_services]
           _ -> nil
         end
       )

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/projects/new.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/projects/new.ex
@@ -4,8 +4,10 @@ defmodule ControlServerWeb.Projects.NewLive do
 
   alias CommonCore.Batteries.Catalog
   alias CommonCore.Batteries.CatalogBattery
+  alias ControlServer.Backend
   alias ControlServer.Batteries
   alias ControlServer.Batteries.Installer
+  alias ControlServer.Knative
   alias ControlServer.Notebooks
   alias ControlServer.Postgres
   alias ControlServer.Projects
@@ -92,7 +94,9 @@ defmodule ControlServerWeb.Projects.NewLive do
          {:ok, _} <- create_jupyter(project, form_data[AIForm]),
          {:ok, _} <- create_postgres(project, form_data[AIForm]),
          {:ok, _} <- create_postgres(project, form_data[WebForm]),
-         {:ok, _} <- create_redis(project, form_data[WebForm]) do
+         {:ok, _} <- create_redis(project, form_data[WebForm]),
+         {:ok, _} <- create_knative(project, form_data[WebForm]),
+         {:ok, _} <- create_backend(project, form_data[WebForm]) do
       {:noreply, push_navigate(socket, to: ~p"/projects/#{project.id}")}
     else
       err ->
@@ -170,6 +174,22 @@ defmodule ControlServerWeb.Projects.NewLive do
   end
 
   defp create_jupyter(_project, _jupyter_data), do: {:ok, nil}
+
+  defp create_knative(project, %{"knative" => knative_data}) do
+    knative_data
+    |> Map.put("project_id", project.id)
+    |> Knative.create_service()
+  end
+
+  defp create_knative(_project, _knative_data), do: {:ok, nil}
+
+  defp create_backend(project, %{"backend" => backend_data}) do
+    backend_data
+    |> Map.put("project_id", project.id)
+    |> Backend.create_service()
+  end
+
+  defp create_backend(_project, _backend_data), do: {:ok, nil}
 
   defp get_default_storage_class do
     case SummaryStorage.default_storage_class() do

--- a/platform_umbrella/apps/kube_services/lib/kube_services/smart_builder.ex
+++ b/platform_umbrella/apps/kube_services/lib/kube_services/smart_builder.ex
@@ -1,5 +1,6 @@
 defmodule KubeServices.SmartBuilder do
   @moduledoc false
+  alias CommonCore.Backend.Service, as: BackendService
   alias CommonCore.Notebooks.JupyterLabNotebook
   alias CommonCore.Postgres.Cluster, as: PGCluster
   alias CommonCore.Postgres.PGDatabase
@@ -48,5 +49,11 @@ defmodule KubeServices.SmartBuilder do
 
   def new_juptyer_params do
     %{virtual_size: Atom.to_string(SummaryBatteries.default_size())}
+  end
+
+  def new_backend_service do
+    %BackendService{
+      virtual_size: Atom.to_string(SummaryBatteries.default_size())
+    }
   end
 end


### PR DESCRIPTION
Implements https://github.com/batteries-included/batteries-included/issues/32 by adding a new option to the web projects form for creating an associated Knative or Backend Service and enabling the batteries if necessary.