### PR TITLE
chore: have asdf use go.mod version

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -6,5 +6,7 @@ export LANG="en_US.UTF-8"
 export LC_ALL="en_US.UTF-8"
 export LC_CTYPE="en_US.UTF-8"
 
+export ASDF_GOLANG_MOD_VERSION_ENABLED=false
+
 ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 export PATH="$ROOT_DIR/bin:$PATH"


### PR DESCRIPTION
Silences this warning/error as we're specifying the go version in `.tool-versions`

```
Notice: Behaving like ASDF_GOLANG_MOD_VERSION_ENABLED=true
        In the future this will have to be set to continue
        reading from the go.mod and go.work files
```