### PR TITLE
fix: change tini location for ubuntu

### DIFF
--- a/docker/pastebin.dockerfile
+++ b/docker/pastebin.dockerfile
@@ -78,7 +78,7 @@ RUN apt update && \
 COPY --from=assets /source/dist /static
 COPY --from=go-build /source/pastebin-go /usr/bin/pastebin-go
 
-ENTRYPOINT [ "/sbin/tini", "--" ]
+ENTRYPOINT [ "/usr/bin/tini", "--" ]
 
 CMD [ "/usr/bin/pastebin-go" ]
 

--- a/docker/platform.dockerfile
+++ b/docker/platform.dockerfile
@@ -233,6 +233,6 @@ COPY --from=release --chown="$APP_USER:$APP_GROUP" "/source/platform_umbrella/_b
 
 EXPOSE $PORT
 
-ENTRYPOINT ["/sbin/tini", "--" ]
+ENTRYPOINT ["/usr/bin/tini", "--" ]
 
 CMD ["${BINARY}", "start"]


### PR DESCRIPTION
Summary:
/usr/bin/tini

Test Plan:
/shrug
