### PR TITLE
fix: fix bootstrap binary path

### DIFF
--- a/bin/bix
+++ b/bin/bix
@@ -385,20 +385,20 @@ do_build_image() {
         docker build . -f docker/platform.dockerfile \
             -t "control-server:${version}" \
             --build-arg RELEASE=control_server \
-            --build-arg BINARY=bin/control_server
+            --build-arg BINARY=/app/bin/control_server
         ;;
     home-base)
         docker build . -f docker/platform.dockerfile \
             -t "home-base:${version}" \
             --build-arg RELEASE=home_base \
-            --build-arg BINARY=bin/home_base
+            --build-arg BINARY=/app/bin/home_base
         ;;
 
     kube-bootstrap)
         docker build . -f docker/platform.dockerfile \
             -t "kube-bootstrap:${version}" \
             --build-arg RELEASE=kube_bootstrap \
-            --build-arg BINARY=bin/kube_bootstrap
+            --build-arg BINARY=/app/bin/bootstrap
         ;;
     pastebin)
         docker build . -f docker/pastebin.dockerfile \


### PR DESCRIPTION
Summary:
kube bootstrap job wasn't working

Test Plan:
ls -al
