### PR TITLE
Don't attempt to clean non-existent kube installs

### DIFF
--- a/bi/pkg/installs/env.go
+++ b/bi/pkg/installs/env.go
@@ -100,7 +100,7 @@ func readInstallEnv(slugOrURL string) (string, *InstallEnv, error) {
 	return "", nil, errors.New("no spec found")
 }
 
-// NeedsKubeCleanup returns true if we should remove all resources in in an install
+// NeedsKubeCleanup returns true if we should remove all resources in an install
 func (env *InstallEnv) NeedsKubeCleanup() bool {
 	// Returns true if the cluster provider is in [provided, aws]
 	provider := env.Spec.KubeCluster.Provider


### PR DESCRIPTION
Nothing crazy, just confirm we have a kubeconfig in the install state directory.