### PR TITLE
Allow an empty project to be created

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/projects/project.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/projects/project.ex
@@ -9,7 +9,7 @@ defmodule CommonCore.Projects.Project do
     field :name, :string
     field :description, :string
 
-    field :type, Ecto.Enum, values: [:ai, :web, :db], virtual: true
+    field :type, Ecto.Enum, values: [:ai, :web, :db, :empty], virtual: true
 
     has_many :postgres_clusters, CommonCore.Postgres.Cluster
     has_many :redis_clusters, CommonCore.Redis.FailoverCluster
@@ -42,5 +42,6 @@ defmodule CommonCore.Projects.Project do
   def type_name(:ai), do: "AI"
   def type_name(:web), do: "Web"
   def type_name(:db), do: "Database Only"
+  def type_name(:empty), do: "Empty Project"
   def type_name(type), do: Atom.to_string(type)
 end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/batteries_form.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/batteries_form.ex
@@ -113,7 +113,6 @@ defmodule ControlServerWeb.Projects.BatteriesForm do
 
         <.tab_bar variant="secondary">
           <:tab
-            :if={@required != []}
             phx-click="tab"
             phx-target={@myself}
             phx-value-id={:required}
@@ -136,6 +135,10 @@ defmodule ControlServerWeb.Projects.BatteriesForm do
             All Batteries
           </:tab>
         </.tab_bar>
+
+        <p :if={@tab == :required && @required == []} class="text-sm text-gray-light italic">
+          No batteries are required for this project.
+        </p>
 
         <.battery_toggle
           :for={battery <- search_filter(@required, @form[:search].value)}

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/projects/new.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/projects/new.ex
@@ -308,5 +308,6 @@ defmodule ControlServerWeb.Projects.NewLive do
   defp steps(:web), do: [ProjectForm, WebForm, BatteriesForm]
   defp steps(:ai), do: [ProjectForm, AIForm, BatteriesForm]
   defp steps(:db), do: [ProjectForm, DatabaseForm, BatteriesForm]
-  defp steps, do: [ProjectForm, BatteriesForm]
+  defp steps(:empty), do: [ProjectForm, BatteriesForm]
+  defp steps, do: steps(:empty)
 end


### PR DESCRIPTION
In the future, it might make sense to rework the project forms so any existing resource can be added during creation (not just existing pg clusters). But this is a quick fix to allow the creation of empty projects so existing resources can be added to it afterwards.