### PR TITLE
Add more stuff to project page and clean up resource types

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/projects/project.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/projects/project.ex
@@ -44,4 +44,15 @@ defmodule CommonCore.Projects.Project do
   def type_name(:db), do: "Database Only"
   def type_name(:empty), do: "Empty Project"
   def type_name(type), do: Atom.to_string(type)
+
+  def resource_types do
+    [
+      :postgres_clusters,
+      :redis_clusters,
+      :ferret_services,
+      :jupyter_notebooks,
+      :knative_services,
+      :backend_services
+    ]
+  end
 end

--- a/platform_umbrella/apps/common_core/lib/common_core/state_summary/urls.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/state_summary/urls.ex
@@ -28,6 +28,13 @@ defmodule CommonCore.StateSummary.URLs do
     |> URI.append_path("/admin/#{realm}/console")
   end
 
+  @spec project_dashboard(StateSummary.t()) :: URI.t()
+  def project_dashboard(state) do
+    state
+    |> uri_for_battery(:grafana)
+    |> URI.append_path("/d/projects/projects")
+  end
+
   @spec cloud_native_pg_dashboard(StateSummary.t()) :: URI.t()
   def cloud_native_pg_dashboard(state) do
     state

--- a/platform_umbrella/apps/common_ui/lib/common_ui/components/data_list.ex
+++ b/platform_umbrella/apps/common_ui/lib/common_ui/components/data_list.ex
@@ -50,17 +50,17 @@ defmodule CommonUI.Components.DataList do
     ~H"""
     <div
       class={[
-        "grid grid-cols-[auto,1fr] items-center text-darker dark:text-gray-lighter gap-x-12 gap-y-4",
+        "grid grid-cols-[auto,1fr] items-start text-darker dark:text-gray-lighter gap-x-12 gap-y-4",
         @class
       ]}
       {@rest}
     >
       <%= for item <- @item do %>
-        <div class="text-xl font-medium leading-4">
+        <div class="text-gray-light text-md font-medium leading-5">
           <%= item.title %>
         </div>
 
-        <div class="text-base leading-4">
+        <div class="text-base leading-5">
           <%= render_slot(item) %>
         </div>
       <% end %>

--- a/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/data_list_test/test_default_datalist.heyya_snap
+++ b/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/data_list_test/test_default_datalist.heyya_snap
@@ -1,26 +1,26 @@
-<div class="grid grid-cols-[auto,1fr] items-center text-darker dark:text-gray-lighter gap-x-12 gap-y-4 ">
+<div class="grid grid-cols-[auto,1fr] items-start text-darker dark:text-gray-lighter gap-x-12 gap-y-4 ">
   
-    <div class="text-xl font-medium leading-4">
+    <div class="text-gray-light text-md font-medium leading-5">
       First
     </div>
 
-    <div class="text-base leading-4">
+    <div class="text-base leading-5">
       Main Text
     </div>
   
-    <div class="text-xl font-medium leading-4">
+    <div class="text-gray-light text-md font-medium leading-5">
       Field Name
     </div>
 
-    <div class="text-base leading-4">
+    <div class="text-base leading-5">
       More Text
     </div>
   
-    <div class="text-xl font-medium leading-4">
+    <div class="text-gray-light text-md font-medium leading-5">
       Views
     </div>
 
-    <div class="text-base leading-4">
+    <div class="text-base leading-5">
       200
     </div>
   

--- a/platform_umbrella/apps/control_server/lib/control_server/projects.ex
+++ b/platform_umbrella/apps/control_server/lib/control_server/projects.ex
@@ -11,14 +11,7 @@ defmodule ControlServer.Projects do
 
   def get_project!(id) do
     Project
-    |> preload([
-      :postgres_clusters,
-      :redis_clusters,
-      :ferret_services,
-      :jupyter_notebooks,
-      :knative_services,
-      :backend_services
-    ])
+    |> preload(^Project.resource_types())
     |> Repo.get!(id)
   end
 

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/k8/pod/show.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/k8/pod/show.ex
@@ -92,7 +92,7 @@ defmodule ControlServerWeb.PodLive.Show do
   defp assign_grafana_dashboard(%{assigns: %{resource: resource}} = socket) do
     url =
       if SummaryBatteries.battery_installed(:grafana) do
-        SummaryURLs.pod_dasboard_url(resource)
+        SummaryURLs.pod_dashboard_url(resource)
       end
 
     assign(socket, grafana_dashboard_url: url)
@@ -252,7 +252,7 @@ defmodule ControlServerWeb.PodLive.Show do
       <.a variant="bordered" navigate={resource_path(@resource, :events)}>Events</.a>
       <.a variant="bordered" navigate={resource_path(@resource, :labels)}>Labels/Annotations</.a>
       <.a variant="bordered" navigate={raw_resource_path(@resource)}>Raw Kubernetes</.a>
-      <.a :if={@grafana_dashboard_url != nil} variant="bordered" navigate={@grafana_dashboard_url}>
+      <.a :if={@grafana_dashboard_url != nil} variant="bordered" href={@grafana_dashboard_url}>
         Grafana Dashboard
       </.a>
       <.a :if={@trivy_enabled} variant="bordered" navigate={resource_path(@resource, :security)}>

--- a/platform_umbrella/apps/kube_services/lib/kube_services/system_state/summary_urls.ex
+++ b/platform_umbrella/apps/kube_services/lib/kube_services/system_state/summary_urls.ex
@@ -46,6 +46,19 @@ defmodule KubeServices.SystemState.SummaryURLs do
     {:noreply, new_state}
   end
 
+  @impl GenServer
+  def handle_call({:project_dashboard_url, %{} = project}, _from, %{summary: summary} = state) do
+    query = URI.encode_query(%{"var-project-id" => project.id})
+
+    url =
+      summary
+      |> CommonCore.StateSummary.URLs.project_dashboard()
+      |> URI.append_query(query)
+      |> URI.to_string()
+
+    {:reply, url, state}
+  end
+
   # For a given postgres cluster, return the URL to the cloud native pg dashboard in grafana
   @impl GenServer
   def handle_call({:pg_dashboard_url, %{} = cluster}, _from, %{summary: summary} = state) do
@@ -99,11 +112,15 @@ defmodule KubeServices.SystemState.SummaryURLs do
     URI.to_string(result)
   end
 
+  def project_dashboard_url(target \\ @me, project) do
+    GenServer.call(target, {:project_dashboard_url, project})
+  end
+
   def pg_dashboard_url(target \\ @me, cluster) do
     GenServer.call(target, {:pg_dashboard_url, cluster})
   end
 
-  def pod_dasboard_url(target \\ @me, pod_resource) do
+  def pod_dashboard_url(target \\ @me, pod_resource) do
     GenServer.call(target, {:pod_dashboard_url, pod_resource})
   end
 end


### PR DESCRIPTION
This closes https://github.com/batteries-included/batteries-included/issues/16 by adding a resource count, pod count, grafana link, and other links to the show project page. I used the URL `/d/projects/projects?var-project-id=PROJECT_ID` for a future Grafana dashboard that needs to be created--I'll open a separate issue for this.

## Other Changes

- Cleaned up how project resource types are used so the list of types doesn't have to be repeated
- Fixed text color and spacing in data list component so values stand out more

---

<img width="982" alt="Screenshot 2024-07-11 at 15 01 14" src="https://github.com/batteries-included/batteries-included/assets/911274/154e5305-bb37-48c8-848d-2bff0646059c">