### PR TITLE
Clean up resource tables and abridged views

### DIFF
--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/audit/edit_versions_table.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/audit/edit_versions_table.ex
@@ -9,19 +9,19 @@ defmodule ControlServerWeb.Audit.EditVersionsTable do
   attr :edit_versions, :list, required: true
   attr :id, :string, default: "edit_versions-table"
 
-  attr :abbridged, :boolean,
+  attr :abridged, :boolean,
     default: false,
-    doc: "the abbridged property control display of the entity type and entity id column"
+    doc: "the abridged property control display of the entity type and entity id column"
 
   attr :rest, :global
 
   def edit_versions_table(assigns) do
     ~H"""
     <.table id={@id} rows={@edit_versions} {@rest}>
-      <:col :let={edit_version} :if={!@abbridged} label="Entity ID">
+      <:col :let={edit_version} :if={!@abridged} label="Entity ID">
         <%= edit_version.entity_id %>
       </:col>
-      <:col :let={edit_version} :if={!@abbridged} label="Entity Type">
+      <:col :let={edit_version} :if={!@abridged} label="Entity Type">
         <%= edit_version.entity_schema %>
       </:col>
       <:col :let={edit_version} label="Action">

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/backend/backend_services_table.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/backend/backend_services_table.ex
@@ -8,24 +8,25 @@ defmodule ControlServerWeb.BackendServicesTable do
   alias CommonCore.Backend.Service
 
   attr :rows, :list, required: true
-  attr :abbridged, :boolean, default: false, doc: "the abbridged property control display of the id column and formatting"
+  attr :abridged, :boolean, default: false, doc: "the abridged property control display of the id column and formatting"
 
   def backend_services_table(assigns) do
     ~H"""
     <.table id="backend-display-table" rows={@rows} row_click={&JS.navigate(show_url(&1))}>
-      <:col :let={service} :if={!@abbridged} label="ID"><%= service.id %></:col>
+      <:col :let={service} :if={!@abridged} label="ID"><%= service.id %></:col>
       <:col :let={service} label="Name"><%= service.name %></:col>
+      <:col :let={service} :if={!@abridged} label="Instances"><%= service.num_instances %></:col>
       <:action :let={service}>
         <.flex class="justify-items-center">
           <.button
             variant="minimal"
-            link={show_url(service)}
-            icon={:eye}
-            id={"show_service_" <> service.id}
+            link={edit_url(service)}
+            icon={:pencil}
+            id={"edit_service_" <> service.id}
           />
 
-          <.tooltip target_id={"show_service_" <> service.id}>
-            Show Service <%= service.name %>
+          <.tooltip target_id={"edit_service_" <> service.id}>
+            Edit Backend Service
           </.tooltip>
 
           <.button
@@ -38,7 +39,7 @@ defmodule ControlServerWeb.BackendServicesTable do
           />
 
           <.tooltip target_id={"running_service_" <> service.id}>
-            Running Service
+            Open Backend Service
           </.tooltip>
         </.flex>
       </:action>
@@ -47,5 +48,6 @@ defmodule ControlServerWeb.BackendServicesTable do
   end
 
   defp show_url(%Service{} = service), do: ~p"/backend/services/#{service}/show"
+  defp edit_url(%Service{} = service), do: ~p"/backend/services/#{service}/edit"
   defp service_url(%Service{} = service), do: "//#{backend_host(service)}"
 end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/ferretdb/ferret_services_table.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/ferretdb/ferret_services_table.ex
@@ -2,51 +2,33 @@ defmodule ControlServerWeb.FerretServicesTable do
   @moduledoc false
   use ControlServerWeb, :html
 
-  defp show_url(ferret_service), do: ~p"/ferretdb/#{ferret_service}/show"
-  defp edit_url(ferret_service), do: ~p"/ferretdb/#{ferret_service}/edit"
-
   attr :rows, :list, default: []
-  attr :abbridged, :boolean, default: false
+  attr :abridged, :boolean, default: false
 
   def ferret_services_table(assigns) do
     ~H"""
     <.table id="ferret_services" rows={@rows} row_click={&JS.navigate(show_url(&1))}>
-      <:col :let={ferret_service} label="Name"><%= ferret_service.name %></:col>
-      <:col :let={ferret_service} label="Instances">
-        <%= ferret_service.instances %>
-      </:col>
-      <:col :let={ferret_service} :if={!@abbridged} label="Cpu requested">
-        <%= ferret_service.cpu_requested %>
-      </:col>
-      <:col :let={ferret_service} :if={!@abbridged} label="Memory requested">
-        <%= ferret_service.memory_requested %>
-      </:col>
-      <:action :let={ferret_service}>
+      <:col :let={service} :if={!@abridged} label="ID"><%= service.id %></:col>
+      <:col :let={service} label="Name"><%= service.name %></:col>
+      <:col :let={service} :if={!@abridged} label="Instances"><%= service.instances %></:col>
+      <:action :let={service}>
         <.flex class="justify-items-center align-middle">
           <.button
             variant="minimal"
-            link={show_url(ferret_service)}
-            icon={:eye}
-            id={"show_ferret_service_" <> ferret_service.id}
-          />
-
-          <.tooltip target_id={"show_ferret_service_" <> ferret_service.id}>
-            Show FerretDB Service <%= ferret_service.name %>
-          </.tooltip>
-
-          <.button
-            variant="minimal"
-            link={edit_url(ferret_service)}
+            link={edit_url(service)}
             icon={:pencil}
-            id={"edit_pool_" <> ferret_service.id}
+            id={"edit_service_" <> service.id}
           />
 
-          <.tooltip target_id={"edit_pool_" <> ferret_service.id}>
-            Edit FerretDB Service <%= ferret_service.name %>
+          <.tooltip target_id={"edit_service_" <> service.id}>
+            Edit FerretDB Service
           </.tooltip>
         </.flex>
       </:action>
     </.table>
     """
   end
+
+  defp show_url(service), do: ~p"/ferretdb/#{service}/show"
+  defp edit_url(service), do: ~p"/ferretdb/#{service}/edit"
 end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/ip_pools/ip_address_pools_table.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/ip_pools/ip_address_pools_table.ex
@@ -3,17 +3,28 @@ defmodule ControlServerWeb.IPAddressPoolsTable do
   use ControlServerWeb, :html
 
   attr :rows, :list, default: []
-  attr :abbridged, :boolean, default: false, doc: "the abbridged property control display of the id column and formatting"
+  attr :abridged, :boolean, default: false, doc: "the abridged property control display of the id column and formatting"
 
   def ip_address_pools_table(assigns) do
     ~H"""
     <.table rows={@rows}>
-      <:col :let={pool} :if={!@abbridged} label="ID"><%= pool.id %></:col>
+      <:col :let={pool} :if={!@abridged} label="ID"><%= pool.id %></:col>
       <:col :let={pool} label="Name"><%= pool.name %></:col>
       <:col :let={pool} label="Subnet"><%= pool.subnet %></:col>
 
       <:action :let={pool}>
         <.flex>
+          <.button
+            variant="minimal"
+            link={edit_url(pool)}
+            icon={:pencil}
+            id={"edit_pool_" <> pool.id}
+          />
+
+          <.tooltip target_id={"edit_pool_" <> pool.id}>
+            Edit IP Address Pool
+          </.tooltip>
+
           <.button
             variant="minimal"
             phx-click="delete"
@@ -25,17 +36,6 @@ defmodule ControlServerWeb.IPAddressPoolsTable do
 
           <.tooltip target_id={"delete_pool_" <> pool.id}>
             Delete IP Address Pool
-          </.tooltip>
-
-          <.button
-            variant="minimal"
-            link={edit_url(pool)}
-            icon={:pencil}
-            id={"edit_pool_" <> pool.id}
-          />
-
-          <.tooltip target_id={"edit_pool_" <> pool.id}>
-            Edit IP Address Pool
           </.tooltip>
         </.flex>
       </:action>

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/istio/virtual_services_table.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/istio/virtual_services_table.ex
@@ -4,34 +4,19 @@ defmodule ControlServerWeb.Istio.VirtualServicesTable do
   use ControlServerWeb, :html
 
   import CommonCore.Resources.FieldAccessors
-  import ControlServerWeb.ResourceHTMLHelper
 
   attr :rows, :list, default: []
-  attr :abbridged, :boolean, default: false, doc: "the abbridged property control display of the id column and formatting"
+  attr :abridged, :boolean, default: false, doc: "the abridged property control display of the id column and formatting"
 
   def virtual_services_table(assigns) do
     ~H"""
-    <.table rows={@rows}>
+    <.table rows={@rows} row_click={&JS.navigate(show_url(&1))}>
+      <:col :let={virtual_service} :if={!@abridged} label="ID"><%= virtual_service.id %></:col>
       <:col :let={virtual_service} label="Name"><%= name(virtual_service) %></:col>
       <:col :let={virtual_service} label="Namespace"><%= namespace(virtual_service) %></:col>
-      <:col :let={virtual_service} :if={!@abbridged} label="Hosts">
+      <:col :let={virtual_service} :if={!@abridged} label="Hosts">
         <%= format_hosts(virtual_service) %>
       </:col>
-
-      <:action :let={virtual_service}>
-        <.flex>
-          <.button
-            variant="minimal"
-            link={show_url(virtual_service)}
-            icon={:eye}
-            id={"show_vs_" <> to_html_id(virtual_service)}
-          />
-
-          <.tooltip target_id={"show_vs_" <> to_html_id(virtual_service)}>
-            Show Virtual Service
-          </.tooltip>
-        </.flex>
-      </:action>
     </.table>
     """
   end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/keycloak/realms_table.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/keycloak/realms_table.ex
@@ -4,15 +4,15 @@ defmodule ControlServerWeb.Keycloak.RealmsTable do
 
   attr :rows, :list, required: true
   attr :keycloak_url, :string, required: true
-  attr :abbridged, :boolean, default: false, doc: "the abbridged property control display of the id column and formatting"
+  attr :abridged, :boolean, default: false, doc: "the abridged property control display of the id column and formatting"
 
   def keycloak_realms_table(%{} = assigns) do
     ~H"""
     <.table id="keycloak-realms-table" rows={@rows} row_click={&JS.navigate(show_url(&1))}>
-      <:col :let={realm} :if={!@abbridged} label="ID"><%= realm.id %></:col>
+      <:col :let={realm} :if={!@abridged} label="ID"><%= realm.id %></:col>
       <:col :let={realm} label="Name"><%= realm.displayName %></:col>
 
-      <:col :let={realm} :if={!@abbridged} label="Admin">
+      <:col :let={realm} :if={!@abridged} label="Admin">
         <.a href={admin_url(@keycloak_url, realm)} variant="external">Keycloak Admin</.a>
       </:col>
 

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/knative/knative_services_table.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/knative/knative_services_table.ex
@@ -7,24 +7,27 @@ defmodule ControlServerWeb.KnativeServicesTable do
   alias CommonCore.Knative.Service
 
   attr :rows, :list, required: true
-  attr :abbridged, :boolean, default: false, doc: "the abbridged property control display of the id column and formatting"
+  attr :abridged, :boolean, default: false, doc: "the abridged property control display of the id column and formatting"
 
   def knative_services_table(assigns) do
     ~H"""
     <.table id="knative-display-table" rows={@rows} row_click={&JS.navigate(show_url(&1))}>
-      <:col :let={service} :if={!@abbridged} label="ID"><%= service.id %></:col>
+      <:col :let={service} :if={!@abridged} label="ID"><%= service.id %></:col>
       <:col :let={service} label="Name"><%= service.name %></:col>
+      <:col :let={service} :if={!@abridged} label="Rollout Duration">
+        <%= service.rollout_duration %>
+      </:col>
       <:action :let={service}>
         <.flex class="justify-items-center">
           <.button
             variant="minimal"
-            link={show_url(service)}
-            icon={:eye}
-            id={"show_service_" <> service.id}
+            link={edit_url(service)}
+            icon={:pencil}
+            id={"edit_service_" <> service.id}
           />
 
-          <.tooltip target_id={"show_service_" <> service.id}>
-            Show Service
+          <.tooltip target_id={"edit_service_" <> service.id}>
+            Edit Knative Service
           </.tooltip>
 
           <.button
@@ -33,11 +36,11 @@ defmodule ControlServerWeb.KnativeServicesTable do
             link_type="external"
             target="_blank"
             icon={:arrow_top_right_on_square}
-            id={"running_service_" <> service.id}
+            id={"open_service_" <> service.id}
           />
 
-          <.tooltip target_id={"running_service_" <> service.id}>
-            Running Service
+          <.tooltip target_id={"open_service_" <> service.id}>
+            Open Knative Service
           </.tooltip>
         </.flex>
       </:action>
@@ -46,6 +49,6 @@ defmodule ControlServerWeb.KnativeServicesTable do
   end
 
   defp show_url(%Service{} = service), do: ~p"/knative/services/#{service.id}/show"
-
+  defp edit_url(%Service{} = service), do: ~p"/knative/services/#{service.id}/edit"
   defp service_url(%Service{} = service), do: "http://#{knative_host(service)}"
 end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/notebooks/notebooks_table.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/notebooks/notebooks_table.ex
@@ -4,26 +4,30 @@ defmodule ControlServerWeb.NotebooksTable do
 
   import KubeServices.SystemState.SummaryHosts
 
+  alias CommonCore.Util.Memory
+
   attr :rows, :list, default: []
-  attr :abbridged, :boolean, default: false, doc: "the abbridged property control display of the id column and formatting"
+  attr :abridged, :boolean, default: false, doc: "the abridged property control display of the id column and formatting"
 
   def notebooks_table(assigns) do
     ~H"""
     <.table id="notebook-display-table" rows={@rows} row_click={&JS.navigate(show_url(&1))}>
-      <:col :let={notebook} :if={!@abbridged} label="ID"><%= notebook.id %></:col>
+      <:col :let={notebook} :if={!@abridged} label="ID"><%= notebook.id %></:col>
       <:col :let={notebook} label="Name"><%= notebook.name %></:col>
-      <:col :let={notebook} label="Image"><%= notebook.image %></:col>
+      <:col :let={notebook} :if={!@abridged} label="Storage Size">
+        <%= Memory.humanize(notebook.storage_size) %>
+      </:col>
       <:action :let={notebook}>
         <.flex class="justify-items-center">
           <.button
             variant="minimal"
-            link={show_url(notebook)}
-            icon={:eye}
-            id={"show_notebook_" <> notebook.id}
+            link={edit_url(notebook)}
+            icon={:pencil}
+            id={"edit_notebook_" <> notebook.id}
           />
 
-          <.tooltip target_id={"show_notebook_" <> notebook.id}>
-            Show Notebook
+          <.tooltip target_id={"edit_notebook_" <> notebook.id}>
+            Edit Notebook
           </.tooltip>
 
           <.button
@@ -45,6 +49,6 @@ defmodule ControlServerWeb.NotebooksTable do
   end
 
   defp show_url(notebook), do: ~p"/notebooks/#{notebook}"
-
+  defp edit_url(notebook), do: ~p"/notebooks/#{notebook}/edit"
   defp notebook_path(notebook), do: "//#{notebooks_host()}/#{notebook.name}"
 end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/postgres/postgres_cluster_table.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/postgres/postgres_cluster_table.ex
@@ -3,27 +3,25 @@ defmodule ControlServerWeb.PostgresClusterTable do
   use ControlServerWeb, :html
 
   alias CommonCore.Postgres.Cluster
+  alias CommonCore.Util.Memory
 
   attr :id, :string, default: "postgres-cluster-table"
   attr :rows, :list, required: true
-  attr :abbridged, :boolean, default: false, doc: "the abbridged property control display of the id column and formatting"
+  attr :abridged, :boolean, default: false, doc: "the abridged property control display of the id column and formatting"
 
-  @spec postgres_clusters_table(map()) :: Phoenix.LiveView.Rendered.t()
   def postgres_clusters_table(assigns) do
     ~H"""
     <.table id={@id} rows={@rows} row_click={&JS.navigate(show_url(&1))}>
-      <:col :let={pg} :if={!@abbridged} label="ID"><%= pg.id %></:col>
+      <:col :let={pg} :if={!@abridged} label="ID"><%= pg.id %></:col>
       <:col :let={pg} label="Name"><%= pg.name %></:col>
-      <:col :let={pg} label="Type"><%= pg.type %></:col>
-      <:col :let={pg} label="User Count"><%= length(pg.users) %></:col>
+      <:col :let={pg} :if={!@abridged} label="Type"><%= pg.type %></:col>
+      <:col :let={pg} :if={!@abridged} label="Instances"><%= pg.num_instances %></:col>
+      <:col :let={pg} :if={!@abridged} label="User Count"><%= length(pg.users) %></:col>
+      <:col :let={pg} :if={!@abridged} label="Storage Size">
+        <%= Memory.humanize(pg.storage_size) %>
+      </:col>
       <:action :let={pg}>
         <.flex class="justify-items-center">
-          <.button variant="minimal" link={show_url(pg)} icon={:eye} id={"show_postgres_" <> pg.id} />
-
-          <.tooltip target_id={"show_postgres_" <> pg.id}>
-            Show Postgres cluster <%= pg.name %>
-          </.tooltip>
-
           <.button
             variant="minimal"
             link={edit_url(pg)}
@@ -32,7 +30,7 @@ defmodule ControlServerWeb.PostgresClusterTable do
           />
 
           <.tooltip target_id={"edit_postgres_" <> pg.id}>
-            Edit cluster <%= pg.name %>
+            Edit Cluster
           </.tooltip>
         </.flex>
       </:action>
@@ -40,9 +38,6 @@ defmodule ControlServerWeb.PostgresClusterTable do
     """
   end
 
-  @spec show_url(Cluster.t()) :: String.t()
   defp show_url(%Cluster{} = cluster), do: ~p"/postgres/#{cluster}/show"
-
-  @spec edit_url(Cluster.t()) :: String.t()
   defp edit_url(%Cluster{} = cluster), do: ~p"/postgres/#{cluster}/edit"
 end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/batteries_form.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/batteries_form.ex
@@ -136,7 +136,7 @@ defmodule ControlServerWeb.Projects.BatteriesForm do
           </:tab>
         </.tab_bar>
 
-        <p :if={@tab == :required && @required == []} class="text-sm text-gray-light italic">
+        <p :if={@tab == :required && @required == []} class="text-sm text-gray-light">
           No batteries are required for this project.
         </p>
 

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/recent_projects.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/recent_projects.ex
@@ -13,7 +13,7 @@ defmodule ControlServerWeb.RecentProjectsPanel do
     <div class="lg:col-span-7">
       <.panel title="Projects" class="h-full">
         <:menu>
-          <.button variant="minimal" link={~p"/projects"}>View All</.button>
+          <.link navigate={~p"/projects"}>View All</.link>
         </:menu>
 
         <.table

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/redis/redis_table.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/redis/redis_table.ex
@@ -3,31 +3,25 @@ defmodule ControlServerWeb.RedisTable do
   use ControlServerWeb, :html
 
   alias CommonCore.Redis.FailoverCluster
+  alias CommonCore.Util.Memory
 
   attr :rows, :list, default: []
-  attr :abbridged, :boolean, default: false, doc: "the abbridged property control display of the id column and formatting"
+  attr :abridged, :boolean, default: false, doc: "the abridged property control display of the id column and formatting"
 
-  @spec redis_table(map()) :: Phoenix.LiveView.Rendered.t()
   def redis_table(assigns) do
     ~H"""
     <.table id="redis-display-table" rows={@rows} row_click={&JS.navigate(show_url(&1))}>
-      <:col :let={redis} :if={!@abbridged} label="ID"><%= redis.id %></:col>
+      <:col :let={redis} :if={!@abridged} label="ID"><%= redis.id %></:col>
       <:col :let={redis} label="Name"><%= redis.name %></:col>
-      <:col :let={redis} label="Instances"><%= redis.num_redis_instances %></:col>
-      <:col :let={redis} label="Sentinel Instances"><%= redis.num_sentinel_instances %></:col>
+      <:col :let={redis} :if={!@abridged} label="Instances"><%= redis.num_redis_instances %></:col>
+      <:col :let={redis} :if={!@abridged} label="Sentinel Instances">
+        <%= redis.num_sentinel_instances %>
+      </:col>
+      <:col :let={redis} :if={!@abridged} label="Memory Limits">
+        <%= Memory.humanize(redis.memory_limits) %>
+      </:col>
       <:action :let={redis}>
         <.flex>
-          <.button
-            variant="minimal"
-            link={show_url(redis)}
-            icon={:eye}
-            id={"show_redis_" <> redis.id}
-          />
-
-          <.tooltip target_id={"show_redis_" <> redis.id}>
-            Show Redis failover cluster <%= redis.name %>
-          </.tooltip>
-
           <.button
             variant="minimal"
             link={edit_url(redis)}
@@ -36,7 +30,7 @@ defmodule ControlServerWeb.RedisTable do
           />
 
           <.tooltip target_id={"edit_redis_" <> redis.id}>
-            Edit cluster <%= redis.name %>
+            Edit Cluster
           </.tooltip>
         </.flex>
       </:action>
@@ -44,9 +38,6 @@ defmodule ControlServerWeb.RedisTable do
     """
   end
 
-  @spec show_url(FailoverCluster.t()) :: String.t()
   def show_url(%FailoverCluster{} = cluster), do: ~p"/redis/#{cluster}/show"
-
-  @spec edit_url(FailoverCluster.t()) :: String.t()
   def edit_url(%FailoverCluster{} = cluster), do: ~p"/redis/#{cluster}/edit"
 end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/snapshot_apply/umbrella_snapshots_table.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/snapshot_apply/umbrella_snapshots_table.ex
@@ -3,13 +3,13 @@ defmodule ControlServerWeb.UmbrellaSnapshotsTable do
   use ControlServerWeb, :html
 
   attr :snapshots, :list, required: true
-  attr :abbridged, :boolean, default: false, doc: "the abbridged property control display of the id column and formatting"
-  attr :skip_date, :boolean, default: false, doc: "the abbridged property control display of the id column and formatting"
+  attr :abridged, :boolean, default: false, doc: "the abridged property control display of the id column and formatting"
+  attr :skip_date, :boolean, default: false, doc: "the abridged property control display of the id column and formatting"
 
   def umbrella_snapshots_table(assigns) do
     ~H"""
     <.table rows={@snapshots} row_click={&JS.navigate(show_url(&1))}>
-      <:col :let={snapshot} :if={!@abbridged} label="ID">
+      <:col :let={snapshot} :if={!@abridged} label="ID">
         <%= snapshot.id %>
       </:col>
       <:col :let={snapshot} :if={!@skip_date} label="Started">

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/ferrretdb/index.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/ferrretdb/index.ex
@@ -8,7 +8,10 @@ defmodule ControlServerWeb.Live.FerretServiceIndex do
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
-    {:ok, assign(socket, :ferret_services, FerretDB.list_ferret_services())}
+    {:ok,
+     socket
+     |> assign(:current_page, :data)
+     |> assign(:ferret_services, FerretDB.list_ferret_services())}
   end
 
   @impl Phoenix.LiveView

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/ferrretdb/show.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/ferrretdb/show.ex
@@ -142,7 +142,7 @@ defmodule ControlServerWeb.Live.FerretServiceShow do
     ~H"""
     <.page_header title="Edit History" back_link={show_url(@ferret_service)} />
     <.panel title="Edit History">
-      <.edit_versions_table edit_versions={@edit_versions} abbridged />
+      <.edit_versions_table edit_versions={@edit_versions} abridged />
     </.panel>
     """
   end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/ai.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/ai.ex
@@ -54,7 +54,7 @@ defmodule ControlServerWeb.Live.AIHome do
         </.flex>
       </:menu>
 
-      <.notebooks_table rows={@notebooks} abbridged />
+      <.notebooks_table rows={@notebooks} abridged />
     </.panel>
     """
   end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/data.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/data.ex
@@ -64,7 +64,7 @@ defmodule ControlServerWeb.Live.DataHome do
           <.link navigate={~p"/postgres"}>View All</.link>
         </.flex>
       </:menu>
-      <.postgres_clusters_table rows={@clusters} abbridged />
+      <.postgres_clusters_table rows={@clusters} abridged />
     </.panel>
     """
   end
@@ -80,7 +80,7 @@ defmodule ControlServerWeb.Live.DataHome do
           <.link navigate={~p"/redis"}>View All</.link>
         </.flex>
       </:menu>
-      <.redis_table rows={@clusters} abbridged />
+      <.redis_table rows={@clusters} abridged />
     </.panel>
     """
   end
@@ -96,7 +96,7 @@ defmodule ControlServerWeb.Live.DataHome do
           <.link navigate={~p"/ferretdb"}>View All</.link>
         </.flex>
       </:menu>
-      <.ferret_services_table rows={@ferret_services} abbridged />
+      <.ferret_services_table rows={@ferret_services} abridged />
     </.panel>
     """
   end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/devtools.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/devtools.ex
@@ -59,7 +59,7 @@ defmodule ControlServerWeb.Live.DevtoolsHome do
           <.link navigate={~p"/knative/services"}>View All</.link>
         </.flex>
       </:menu>
-      <.knative_services_table rows={@services} abbridged />
+      <.knative_services_table rows={@services} abridged />
     </.panel>
     """
   end
@@ -75,7 +75,7 @@ defmodule ControlServerWeb.Live.DevtoolsHome do
           <.link navigate={~p"/backend/services"}>View All</.link>
         </.flex>
       </:menu>
-      <.backend_services_table rows={@services} abbridged />
+      <.backend_services_table rows={@services} abridged />
     </.panel>
     """
   end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/magic.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/magic.ex
@@ -121,7 +121,7 @@ defmodule ControlServerWeb.Live.MagicHome do
         </.flex>
       </:menu>
       <.pause_alert :if={!@deploys_running} />
-      <.umbrella_snapshots_table abbridged snapshots={@snapshots} />
+      <.umbrella_snapshots_table abridged snapshots={@snapshots} />
     </.panel>
     """
   end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/net_sec.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/net_sec.ex
@@ -75,7 +75,7 @@ defmodule ControlServerWeb.Live.NetSecHome do
           <.link navigate={~p"/keycloak/realms"}>View All</.link>
         </.flex>
       </:menu>
-      <.keycloak_realms_table rows={@realms} keycloak_url={@keycloak_url} abbridged />
+      <.keycloak_realms_table rows={@realms} keycloak_url={@keycloak_url} abridged />
     </.panel>
     """
   end
@@ -88,7 +88,7 @@ defmodule ControlServerWeb.Live.NetSecHome do
           <.link navigate={~p"/ip_address_pools"}>View All</.link>
         </.flex>
       </:menu>
-      <.ip_address_pools_table rows={@ip_address_pools} abbridged />
+      <.ip_address_pools_table rows={@ip_address_pools} abridged />
     </.panel>
     """
   end
@@ -114,7 +114,7 @@ defmodule ControlServerWeb.Live.NetSecHome do
           <.link navigate={~p"/istio/virtual_services"}>View All</.link>
         </.flex>
       </:menu>
-      <.virtual_services_table abbridged rows={@virtual_services} />
+      <.virtual_services_table abridged rows={@virtual_services} />
     </.panel>
     """
   end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/ip_pools/index.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/ip_pools/index.ex
@@ -40,7 +40,7 @@ defmodule ControlServerWeb.Live.IPAddressPoolIndex do
         </.a>
       </:menu>
 
-      <.ip_address_pools_table abbridged rows={@ip_address_pools} />
+      <.ip_address_pools_table abridged rows={@ip_address_pools} />
     </.panel>
     """
   end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/istio/virtual_services.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/istio/virtual_services.ex
@@ -32,7 +32,7 @@ defmodule ControlServerWeb.Live.IstioVirtualServicesIndex do
     <.page_header title={@page_title} back_link={~p"/net_sec"} />
 
     <.panel title="Virtual Services">
-      <.virtual_services_table abbridged rows={@virtual_services} />
+      <.virtual_services_table abridged rows={@virtual_services} />
     </.panel>
     """
   end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/knative/edit.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/knative/edit.ex
@@ -9,7 +9,10 @@ defmodule ControlServerWeb.Live.KnativeEdit do
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
-    {:ok, assign(socket, :current_page, :devtools)}
+    {:ok,
+     socket
+     |> assign(:current_page, :devtools)
+     |> assign(:page_title, "Edit Knative Service")}
   end
 
   @impl Phoenix.LiveView

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/knative/show.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/knative/show.ex
@@ -257,7 +257,7 @@ defmodule ControlServerWeb.Live.KnativeShow do
     <.header service={@service} timeline_installed={@timeline_installed} />
 
     <.panel title="Edit History">
-      <.edit_versions_table edit_versions={@edit_versions} abbridged />
+      <.edit_versions_table edit_versions={@edit_versions} abridged />
     </.panel>
     """
   end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/notebooks/edit.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/notebooks/edit.ex
@@ -11,6 +11,7 @@ defmodule ControlServerWeb.Live.JupyterLabNotebookEdit do
     {:ok,
      socket
      |> assign(:current_page, :ai)
+     |> assign(:page_title, "Edit Jupyter Notebook")
      |> assign(:notebook, notebook)}
   end
 

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/notebooks/new.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/notebooks/new.ex
@@ -13,6 +13,7 @@ defmodule ControlServerWeb.Live.JupyterLabNotebookNew do
     {:ok,
      socket
      |> assign(:current_page, :ai)
+     |> assign(:page_title, "New Jupyter Notebook")
      |> assign(:project_id, params["project_id"])
      |> assign(:notebook, notebook)}
   end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/notebooks/show.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/notebooks/show.ex
@@ -12,6 +12,7 @@ defmodule ControlServerWeb.Live.JupyterLabNotebookShow do
 
     {:ok,
      socket
+     |> assign(:current_page, :ai)
      |> assign(:page_title, "Jupyter Notebook")
      |> assign(:notebook, notebook)}
   end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/postgres/show.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/postgres/show.ex
@@ -276,7 +276,7 @@ defmodule ControlServerWeb.Live.PostgresShow do
     ~H"""
     <.page_header title="Edit History" back_link={show_url(@cluster)} />
     <.panel title="Edit History">
-      <.edit_versions_table edit_versions={@edit_versions} abbridged />
+      <.edit_versions_table edit_versions={@edit_versions} abridged />
     </.panel>
     """
   end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/projects/show.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/projects/show.ex
@@ -199,42 +199,42 @@ defmodule ControlServerWeb.Projects.ShowLive do
         <:menu>
           <.link navigate={~p"/postgres"}>View All</.link>
         </:menu>
-        <.postgres_clusters_table abbridged rows={@project.postgres_clusters} />
+        <.postgres_clusters_table abridged rows={@project.postgres_clusters} />
       </.panel>
 
       <.panel :if={@project.redis_clusters != []} title="Redis">
         <:menu>
           <.link navigate={~p"/redis"}>View All</.link>
         </:menu>
-        <.redis_table abbridged rows={@project.redis_clusters} />
+        <.redis_table abridged rows={@project.redis_clusters} />
       </.panel>
 
       <.panel :if={@project.ferret_services != []} title="FerretDB/MongoDB">
         <:menu>
           <.link navigate={~p"/ferretdb"}>View All</.link>
         </:menu>
-        <.ferret_services_table abbridged rows={@project.ferret_services} />
+        <.ferret_services_table abridged rows={@project.ferret_services} />
       </.panel>
 
       <.panel :if={@project.jupyter_notebooks != []} title="Jupyter Notebooks">
         <:menu>
           <.link navigate={~p"/notebooks"}>View All</.link>
         </:menu>
-        <.notebooks_table abbridged rows={@project.jupyter_notebooks} />
+        <.notebooks_table abridged rows={@project.jupyter_notebooks} />
       </.panel>
 
       <.panel :if={@project.knative_services != []} title="Knative Services">
         <:menu>
           <.link navigate={~p"/knative/services"}>View All</.link>
         </:menu>
-        <.knative_services_table abbridged rows={@project.knative_services} />
+        <.knative_services_table abridged rows={@project.knative_services} />
       </.panel>
 
       <.panel :if={@project.backend_services != []} title="Backend Services">
         <:menu>
           <.link navigate={~p"/backend/services"}>View All</.link>
         </:menu>
-        <.backend_services_table abbridged rows={@project.backend_services} />
+        <.backend_services_table abridged rows={@project.backend_services} />
       </.panel>
 
       <.panel title="Pods" class="col-span-2">

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/redis/edit.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/redis/edit.ex
@@ -9,12 +9,15 @@ defmodule ControlServerWeb.Live.RedisEdit do
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
-    {:ok, socket}
+    {:ok, assign(socket, :current_page, :data)}
   end
 
   @impl Phoenix.LiveView
   def handle_params(%{"id" => id}, _, socket) do
-    {:noreply, socket |> assign_failover_cluster(id) |> assign_page_title()}
+    {:noreply,
+     socket
+     |> assign_failover_cluster(id)
+     |> assign_page_title()}
   end
 
   defp assign_failover_cluster(socket, id) do

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/redis/index.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/redis/index.ex
@@ -8,7 +8,11 @@ defmodule ControlServerWeb.Live.Redis do
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
-    {:ok, socket |> assign_failover_clusters() |> assign_page_title("Redis Clusters")}
+    {:ok,
+     socket
+     |> assign(current_page: :data)
+     |> assign_page_title("Redis Clusters")
+     |> assign_failover_clusters()}
   end
 
   @impl Phoenix.LiveView
@@ -17,9 +21,7 @@ defmodule ControlServerWeb.Live.Redis do
   end
 
   defp apply_action(socket, :index, _params) do
-    socket
-    |> assign(:page_title, "Listing Failover clusters")
-    |> assign(:failover_cluster, nil)
+    assign(socket, :failover_cluster, nil)
   end
 
   def assign_page_title(socket, page_title) do
@@ -49,10 +51,10 @@ defmodule ControlServerWeb.Live.Redis do
     ~H"""
     <.page_header title={@page_title} back_link={~p"/data"}>
       <.button variant="secondary" link={new_url()}>
-        New Redis Cluster
+        New Cluster
       </.button>
     </.page_header>
-    <.panel title="All Redis Clusters">
+    <.panel title="All Clusters">
       <.redis_table rows={@failover_clusters} />
     </.panel>
     """

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/redis/new.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/redis/new.ex
@@ -11,6 +11,7 @@ defmodule ControlServerWeb.Live.RedisNew do
     {:ok,
      socket
      |> assign(:project_id, params["project_id"])
+     |> assign(:current_page, :data)
      |> assign_failover_cluster()
      |> assign_page_title()}
   end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/redis/show.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/redis/show.ex
@@ -17,7 +17,11 @@ defmodule ControlServerWeb.Live.RedisShow do
     :ok = KubeEventCenter.subscribe(:pod)
     :ok = KubeEventCenter.subscribe(:service)
     :ok = KubeEventCenter.subscribe(:redis_failover)
-    {:ok, socket}
+
+    {:ok,
+     socket
+     |> assign(:current_page, :data)
+     |> assign(:page_title, "Redis Cluster")}
   end
 
   @impl Phoenix.LiveView

--- a/platform_umbrella/apps/control_server_web/test/unit/live/failover_cluster_live_test.exs
+++ b/platform_umbrella/apps/control_server_web/test/unit/live/failover_cluster_live_test.exs
@@ -15,7 +15,7 @@ defmodule ControlServerWeb.FailoverClusterLiveTest do
     test "lists all failover_clusters", %{conn: conn, failover_cluster: failover_cluster} do
       {:ok, _index_live, html} = live(conn, ~p"/redis")
 
-      assert html =~ "Listing Failover clusters"
+      assert html =~ "Redis Clusters"
       assert html =~ failover_cluster.name
     end
 
@@ -23,7 +23,7 @@ defmodule ControlServerWeb.FailoverClusterLiveTest do
       {:ok, index_live, _html} = live(conn, ~p"/redis")
 
       index_live
-      |> element("a", "New Redis Cluster")
+      |> element("a", "New Cluster")
       |> render_click()
       |> follow_redirect(conn, ~p"/redis/new")
     end


### PR DESCRIPTION
- Fixed "abbridged" misspelling
- Added "Edit" links to resource table rows where it was missing
- Removed "Show" links on the resource table rows, since they are the same as just clicking the row
- Made the resource table components more consistent for abridged tables (and full tables)
- Added missing `current_page` and `page_title` assignments