### PR TITLE
ci: cache dialyzer

### DIFF
--- a/.github/workflows/bix_elixir.yml
+++ b/.github/workflows/bix_elixir.yml
@@ -123,5 +123,19 @@ jobs:
       - name: Reshim ASDF
         shell: bash
         run: asdf reshim
+
+      - name: Cache dialyzer
+        uses: actions/cache@v4
+        id: dialyzer-cache
+        with:
+          path: |
+            platform_umbrella/deps
+            platform_umbrella/_build
+            platform_umbrella/.dialyzer
+          key: ${{ runner.os }}-dialyzer-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-dialyzer-
+          save-always: true
+
       - name: Dialyzer Type Analysis
         run: bin/bix ex-dialyzer

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .nix-elixir.cache
 .flock
 platform_umbrella/.iex.exs
+platform_umbrella/.dialyzer
 
 # Local cargo dirs
 .nix-cargo

--- a/platform_umbrella/mix.exs
+++ b/platform_umbrella/mix.exs
@@ -16,7 +16,9 @@ defmodule ControlServer.Umbrella.MixProject do
         flags: ~w[error_handling unmatched_returns unknown]a,
         plt_add_deps: :app_tree,
         plt_add_apps: [:mix, :ex_unit, :dialyzer],
-        plt_ignore_apps: [:bandit, :myxql]
+        plt_ignore_apps: [:bandit, :myxql],
+        plt_local_path: ".dialyzer",
+        plt_core_path: ".dialyzer"
       ]
     ]
   end


### PR DESCRIPTION
10:22 [without caching](https://github.com/batteries-included/batteries-included/actions/runs/9911201363/job/27383325918)
0:55 [with cache hit](https://github.com/batteries-included/batteries-included/actions/runs/9911325529/job/27383729781?pr=354)

It should still shave off a bunch of time even with only a partial cache hit. When we update elixir versions or dependency versions, we'll see a miss that will take a bit more time but almost certainly still better than 10 minutes.