### PR TITLE
ci: cache docker builds

### DIFF
--- a/.github/workflows/bix_docker.yml
+++ b/.github/workflows/bix_docker.yml
@@ -46,6 +46,12 @@ jobs:
       - name: Reshim ASDF
         shell: bash
         run: asdf reshim
+      - name: Configure builder
+        run: >-
+          docker buildx create --name container --driver docker-container
+          --driver-opt default-load=true
+      - name: Expose GitHub Runtime
+        uses: crazy-max/ghaction-github-runtime@v3
       - name: Build control-server image
         run: bin/bix build-image control-server
       - name: Build home-base image

--- a/bin/bix
+++ b/bin/bix
@@ -380,26 +380,40 @@ do_build_image() {
     version="${BASE_VERSION}-$(version_tag)"
     log "${GREEN}Building${NOFORMAT} container image ${image_name} with  version ${version}"
 
+    declare -a cache_args
+    if [ "${GITHUB_ACTIONS:-""}" = "true" ]; then
+        cache_args+=(--cache-from
+            "type=gha,url=$ACTIONS_CACHE_URL,token=$ACTIONS_RUNTIME_TOKEN,scope=$image_name"
+            --cache-to
+            "type=gha,mode=max,url=$ACTIONS_CACHE_URL,token=$ACTIONS_RUNTIME_TOKEN,scope=$image_name"
+            --builder=container)
+    fi
+
     case "${image_name}" in
     control-server)
-        docker build . -f docker/platform.dockerfile \
+        docker buildx build . -f docker/platform.dockerfile \
             -t "control-server:${version}" \
-            --build-arg RELEASE=control_server
+            --build-arg RELEASE=control_server \
+            "${cache_args[@]}"
         ;;
     home-base)
-        docker build . -f docker/platform.dockerfile \
+        docker buildx build . -f docker/platform.dockerfile \
             -t "home-base:${version}" \
-            --build-arg RELEASE=home_base
+            --build-arg RELEASE=home_base \
+            "${cache_args[@]}"
         ;;
 
     kube-bootstrap)
-        docker build . -f docker/platform.dockerfile \
+        docker buildx build . -f docker/platform.dockerfile \
             -t "kube-bootstrap:${version}" \
-            --build-arg RELEASE=kube_bootstrap
+            --build-arg RELEASE=kube_bootstrap \
+            "${cache_args[@]}"
         ;;
+
     pastebin)
-        docker build . -f docker/pastebin.dockerfile \
-            -t "pastebin:${version}"
+        docker buildx build . -f docker/pastebin.dockerfile \
+            -t "pastebin:${version}" \
+            "${cache_args[@]}"
         ;;
     *)
         die "Unknown image name: ${image_name} not in expected list control-server, home-base, kube-bootstrap, pastebin"


### PR DESCRIPTION
Previously was [8-12 minutes](https://github.com/batteries-included/batteries-included/actions?query=workflow%3A%22%22BIX+Docker%22%22++)
Now [under 4](https://github.com/batteries-included/batteries-included/actions/runs/9912750660/job/27388254019?pr=356)

In the worst case - when base image is updated - it adds a couple of minutes to prepare and create cache. Under most circumstances, though, it should save quite a bit of time. 