### PR TITLE
chore: update elixir version in asdf

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 erlang 27.0
-elixir 1.17.1-otp-27
+elixir 1.17.2-otp-27
 nodejs 22.4.0
 golang 1.22.5
 shfmt 3.8.0


### PR DESCRIPTION
Summary:
Docker was already building with 1.17.2 we should test and develop with
the same.

Test Plan:
`asdf install`

Github CI other than docker uses the new version
