### PR TITLE
feature: project description should be markdown

### DIFF
--- a/platform_umbrella/apps/common_ui/lib/common_ui/components/form.ex
+++ b/platform_umbrella/apps/common_ui/lib/common_ui/components/form.ex
@@ -3,6 +3,7 @@ defmodule CommonUI.Components.Form do
   use CommonUI, :component
 
   import CommonUI.Components.FlashGroup
+  import CommonUI.Components.Markdown
   import CommonUI.Components.Panel
   import CommonUI.Components.Typography
   import CommonUI.Gettext, warn: false
@@ -47,8 +48,8 @@ defmodule CommonUI.Components.Form do
         </div>
 
         <div>
-          <.panel :if={@description} title="Info">
-            <p><%= @description %></p>
+          <.panel :if={@description} title="Description">
+            <.markdown content={@description} />
           </.panel>
         </div>
       </div>

--- a/platform_umbrella/apps/common_ui/lib/common_ui/components/input.ex
+++ b/platform_umbrella/apps/common_ui/lib/common_ui/components/input.ex
@@ -40,6 +40,10 @@ defmodule CommonUI.Components.Input do
   attr :tick_target, :any, default: nil
   attr :show_value, :boolean, default: true
 
+  # Used for textarea
+  attr :rows, :any, default: nil
+  attr :cols, :any, default: nil
+
   # Used for radio buttons
   slot :option do
     attr :value, :string, required: true
@@ -364,6 +368,8 @@ defmodule CommonUI.Components.Input do
           input_class(@errors),
           @class
         ]}
+        rows={@rows}
+        cols={@cols}
         {@rest}
       ><%= normalize_value("textarea", @value) %></textarea>
 

--- a/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/form_test/test_stepped_form.heyya_snap
+++ b/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/form_test/test_stepped_form.heyya_snap
@@ -57,7 +57,7 @@
   <div class="gap-4 lg:gap-6 flex items-center justify-between flex-wrap w-full px-6 pt-5">
   
     <h3 class="text-xl font-medium text-gray-darker dark:text-white ">
-  Info
+  Description
 </h3>
 
     
@@ -66,7 +66,11 @@
 
   <div class="relative flex-1 px-6 py-5 ">
     
-        <p>Some description</p>
+        <section class="prose lg:prose-xl">
+  <p>
+  Some description
+</p>
+</section>
       
   </div>
 </div>

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/project_form.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/project_form.ex
@@ -5,8 +5,19 @@ defmodule ControlServerWeb.Projects.ProjectForm do
   alias CommonCore.Projects.Project
   alias ControlServer.Projects
 
+  @default_description """
+  # Project Info
+
+  Here you can describe your project. This is a great place to provide context for your project and help others understand what you're working on.
+
+  ## Operational Runbook
+  - Start incident response documentation
+  - Alert on-call rotations
+  - Start shared commincation
+  """
+
   def mount(socket) do
-    changeset = Projects.change_project(%Project{})
+    changeset = Projects.change_project(%Project{description: @default_description})
 
     {:ok,
      socket
@@ -52,7 +63,9 @@ defmodule ControlServerWeb.Projects.ProjectForm do
         class={@class}
         variant="stepped"
         title="Tell More About Your Project"
-        description="A place for introductory information about this stage of project creation"
+        description={
+          @form[:description].value || "Add a description to help others understand your project."
+        }
         phx-target={@myself}
         phx-change="validate"
         phx-submit="save"
@@ -75,6 +88,7 @@ defmodule ControlServerWeb.Projects.ProjectForm do
           label="Project Description"
           placeholder="Enter a project description (optional)"
           maxlength={1000}
+          rows="15"
         />
 
         <:actions>

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/projects/edit.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/projects/edit.ex
@@ -47,7 +47,7 @@ defmodule ControlServerWeb.Projects.EditLive do
 
     <.panel>
       <.simple_form for={@form} id="edit-project-form" phx-change="validate" phx-submit="save">
-        <.grid variant="col-2">
+        <.flex column>
           <.input field={@form[:name]} label="Project Name" placeholder="Enter project name" />
 
           <.input
@@ -56,8 +56,9 @@ defmodule ControlServerWeb.Projects.EditLive do
             label="Project Description"
             placeholder="Enter a project description (optional)"
             maxlength={1000}
+            rows="15"
           />
-        </.grid>
+        </.flex>
       </.simple_form>
     </.panel>
     """

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/projects/show.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/projects/show.ex
@@ -3,6 +3,7 @@ defmodule ControlServerWeb.Projects.ShowLive do
   use ControlServerWeb, {:live_view, layout: :sidebar}
 
   import CommonCore.Resources.FieldAccessors, only: [labeled_owner: 1]
+  import CommonUI.Components.Markdown
   import ControlServerWeb.BackendServicesTable
   import ControlServerWeb.FerretServicesTable
   import ControlServerWeb.KnativeServicesTable
@@ -184,7 +185,7 @@ defmodule ControlServerWeb.Projects.ShowLive do
             <.relative_display time={@project.inserted_at} />
           </:item>
           <:item :if={@project.description} title="Description">
-            <%= @project.description %>
+            <.markdown content={@project.description} />
           </:item>
         </.data_list>
       </.panel>


### PR DESCRIPTION
Summary:
- Add an example description
- make simple_forms description markdown
- make show project use markdown for desription

Test Plan:
- Tests updated
