### PR TITLE
feat: add google analytics to the static pages

### DIFF
--- a/static/src/config.yaml
+++ b/static/src/config.yaml
@@ -63,7 +63,7 @@ apps:
 analytics:
   vendors:
     googleAnalytics:
-      id: null # or "G-XXXXXXXXXX"
+      id: 'G-Q2NSHQYFR7'
 
 ui:
   tokens:


### PR DESCRIPTION
Summary:
- Add the measurement id
- That should trigger script inclusion

This fixes: #129

Test Plan:
CI
