### PR TITLE
fix: when token issuance for the correct region

### DIFF
--- a/bi/cmd/aws/get_token.go
+++ b/bi/cmd/aws/get_token.go
@@ -2,30 +2,57 @@ package aws
 
 import (
 	"encoding/json"
+	"log/slog"
 	"os"
 	"time"
 
 	eksutil "bi/pkg/cluster/eks/util"
+	"bi/pkg/installs"
+	"bi/pkg/log"
 
 	"github.com/spf13/cobra"
 )
 
 var getTokenCmd = &cobra.Command{
-	Use:   "get-token <cluster-name>",
+	Use:   "get-token [install-slug|install-spec-url|install-spec-file] cluster-name",
 	Short: "Get an auth token for the cluster",
-	Args:  cobra.ExactArgs(1),
+	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		clusterName := args[0]
+		installURL := args[0]
+		clusterName := args[1]
+
+		ctx := cmd.Context()
+		env, err := installs.NewEnv(ctx, installURL)
+		if err != nil {
+			return err
+		}
+
+		if err := log.CollectDebugLogs(env.DebugLogPath(cmd.CommandPath())); err != nil {
+			return err
+		}
 
 		ttl, err := cmd.Flags().GetDuration("ttl")
 		if err != nil {
 			return err
 		}
 
-		token, err := eksutil.GetToken(cmd.Context(), clusterName, ttl)
+		region, err := cmd.Flags().GetString("region")
 		if err != nil {
 			return err
 		}
+
+		slog.Debug("Attempting to get token",
+			slog.String("region", region),
+			slog.String("clusterName", clusterName),
+			slog.Duration("ttl", ttl))
+
+		token, err := eksutil.GetToken(cmd.Context(), region, clusterName, ttl)
+		if err != nil {
+			return err
+		}
+
+		maskedToken := token[:8] + "..." + token[len(token)-8:]
+		slog.Debug("Got token", slog.String("token", string(maskedToken)))
 
 		execCredential := map[string]any{
 			"kind":       "ExecCredential",
@@ -47,6 +74,7 @@ var getTokenCmd = &cobra.Command{
 
 func init() {
 	getTokenCmd.Flags().Duration("ttl", 15*time.Minute, "The duration for which the token should be valid")
+	getTokenCmd.Flags().String("region", "", "The AWS region for which the token should be valid")
 
 	awsCmd.AddCommand(getTokenCmd)
 }

--- a/bi/pkg/cluster/eks/util/token.go
+++ b/bi/pkg/cluster/eks/util/token.go
@@ -4,58 +4,39 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"net/http"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 )
 
 // GetToken returns a token that can be used to authenticate to an EKS cluster.
 // This is equivalent to running `aws eks get-token --cluster-name <clusterName>`
 // but without the need for the AWS CLI to be installed.
-func GetToken(ctx context.Context, clusterName string, ttl time.Duration) (string, error) {
-	cfg, err := config.LoadDefaultConfig(ctx)
+func GetToken(ctx context.Context, region, clusterName string, ttl time.Duration) (string, error) {
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
 	if err != nil {
 		return "", fmt.Errorf("failed to load AWS config: %w", err)
 	}
 
-	stsclient := sts.NewFromConfig(cfg)
-	presignclient := sts.NewPresignClient(stsclient)
+	client := sts.NewPresignClient(sts.NewFromConfig(cfg))
 
-	out, err := presignclient.PresignGetCallerIdentity(ctx, &sts.GetCallerIdentityInput{}, func(opt *sts.PresignOptions) {
-		opt.Presigner = &presignerV4{
-			client:      opt.Presigner,
-			clusterName: clusterName,
-			ttl:         ttl,
-		}
+	presignedURLRequest, err := client.PresignGetCallerIdentity(ctx, &sts.GetCallerIdentityInput{}, func(presignOptions *sts.PresignOptions) {
+		presignOptions.ClientOptions = append(presignOptions.ClientOptions, appendPresignHeaderValuesFunc(clusterName, ttl))
 	})
 	if err != nil {
-		return "", fmt.Errorf("failed to presign GetCallerIdentity: %w", err)
+		return "", fmt.Errorf("failed to presign caller identity: %w", err)
 	}
 
-	return fmt.Sprintf("k8s-aws-v1.%s", base64.RawStdEncoding.EncodeToString([]byte(out.URL))), nil
+	return fmt.Sprintf("k8s-aws-v1.%s", base64.RawURLEncoding.EncodeToString([]byte(presignedURLRequest.URL))), nil
 }
 
-var (
-	_ sts.HTTPPresignerV4 = (*presignerV4)(nil)
-)
-
-type presignerV4 struct {
-	client      sts.HTTPPresignerV4
-	clusterName string
-	ttl         time.Duration
-}
-
-func (p *presignerV4) PresignHTTP(
-	ctx context.Context, credentials aws.Credentials, r *http.Request,
-	payloadHash string, service string, region string, signingTime time.Time,
-	optFns ...func(*v4.SignerOptions),
-) (url string, signedHeader http.Header, err error) {
-	r.Header.Set("X-K8s-Aws-Id", p.clusterName)
-	r.Header.Set("X-Amz-Expires", fmt.Sprintf("%d", int(p.ttl.Seconds())))
-
-	return p.client.PresignHTTP(ctx, credentials, r, payloadHash, service, region, signingTime, optFns...)
+func appendPresignHeaderValuesFunc(clusterName string, ttl time.Duration) func(stsOptions *sts.Options) {
+	return func(stsOptions *sts.Options) {
+		stsOptions.APIOptions = append(stsOptions.APIOptions,
+			smithyhttp.SetHeaderValue("X-K8s-Aws-Id", clusterName),
+			smithyhttp.SetHeaderValue("X-Amz-Expires", fmt.Sprintf("%d", int(ttl.Seconds()))),
+		)
+	}
 }


### PR DESCRIPTION
When using aws sso, or any number of other aws setups its possible for the token to be issued for the wrong region.

Also pass in the install slug so we can get debug logging for `get-token` invocations.

This will be a breaking change for existing kubeconfigs.