### PR TITLE
fix: use latest image for bootstrap scripts

### DIFF
--- a/bootstrap/damian.install.json
+++ b/bootstrap/damian.install.json
@@ -1,12 +1,12 @@
 {
-  "id": "batt_0190b3fb44367d1f91b69d6ac3780fbc",
+  "id": "batt_0190bc7e5ca07950b7556b6e76e1d9f9",
   "usage": "development",
   "default_size": "small",
   "control_jwk": {
     "crv": "Ed25519",
-    "d": "2nGiFvIZEGB6_RuToPeixUjclecOiC2qOHbPR_VthpA",
+    "d": "mswqPWdyrUuZMMr8e8XkfStNTVWDRIa92ZF9f70HAMM",
     "kty": "OKP",
-    "x": "yhi8osQpNkJiWFExbqJI6syoy3Unma5Yhjzgou_3clI"
+    "x": "b9cZTWsR0naDvcmfPeII_W2HTlSsES9sdJRLyEuuh0g"
   },
   "inserted_at": null,
   "updated_at": null,
@@ -16,5 +16,5 @@
   "sso_enabled": false,
   "initial_oauth_email": null,
   "user_id": null,
-  "team_id": "batt_0190b3fb44117ee8a86cb54e512d403e"
+  "team_id": "batt_0190bc7e5c7e746ab4600abf1aacb09b"
 }

--- a/bootstrap/damian.spec.json
+++ b/bootstrap/damian.spec.json
@@ -9,26 +9,26 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_0190b3fb445172c786cc09909d97d511",
+        "id": "batt_0190bc7e5cb27430a7a7e7bf07ae2c42",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
-          "image": "public.ecr.aws/batteries-included/control-server:0.13.1-78b30183-dirty",
+          "image": "public.ecr.aws/batteries-included/control-server:latest",
           "cluster_type": "aws",
+          "bootstrap_image": "public.ecr.aws/batteries-included/kube-bootstrap:latest",
           "core_namespace": "battery-core",
+          "server_in_cluster": true,
           "base_namespace": "battery-base",
           "data_namespace": "battery-data",
           "ai_namespace": "battery-ai",
-          "bootstrap_image": "public.ecr.aws/batteries-included/kube-bootstrap:0.13.1-78b30183-dirty",
           "default_size": "small",
           "cluster_name": "damian",
-          "server_in_cluster": true,
-          "install_id": "batt_0190b3fb44367d1f91b69d6ac3780fbc",
+          "install_id": "batt_0190bc7e5ca07950b7556b6e76e1d9f9",
           "control_jwk": {
             "crv": "Ed25519",
-            "d": "2nGiFvIZEGB6_RuToPeixUjclecOiC2qOHbPR_VthpA",
+            "d": "mswqPWdyrUuZMMr8e8XkfStNTVWDRIa92ZF9f70HAMM",
             "kty": "OKP",
-            "x": "yhi8osQpNkJiWFExbqJI6syoy3Unma5Yhjzgou_3clI"
+            "x": "b9cZTWsR0naDvcmfPeII_W2HTlSsES9sdJRLyEuuh0g"
           },
           "image_override": null,
           "bootstrap_image_override": null
@@ -38,7 +38,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0190b3fb44517b4fb05163dfb80cc685",
+        "id": "batt_0190bc7e5cb27530aa59275d023ab064",
         "type": "karpenter",
         "config": {
           "type": "karpenter",
@@ -53,7 +53,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0190b3fb445175fca3735cc41e89fea0",
+        "id": "batt_0190bc7e5cb271afb06a3d656488f5dd",
         "type": "cert_manager",
         "config": {
           "type": "cert_manager",
@@ -63,9 +63,9 @@
           "controller_image": "quay.io/jetstack/cert-manager-controller:v1.14.7",
           "ctl_image": "quay.io/jetstack/cert-manager-ctl:v1.14.7",
           "webhook_image": "quay.io/jetstack/cert-manager-webhook:v1.14.7",
-          "controller_image_override": null,
           "acmesolver_image_override": null,
           "cainjector_image_override": null,
+          "controller_image_override": null,
           "ctl_image_override": null,
           "webhook_image_override": null
         },
@@ -74,7 +74,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0190b3fb44517bfba071257a4c9334db",
+        "id": "batt_0190bc7e5cb27204a0ad79feef463b1e",
         "type": "battery_ca",
         "config": {
           "type": "battery_ca"
@@ -84,7 +84,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0190b3fb44517f078b77c5807e471a47",
+        "id": "batt_0190bc7e5cb27ed2be84697e7816902a",
         "type": "aws_load_balancer_controller",
         "config": {
           "type": "aws_load_balancer_controller",
@@ -99,7 +99,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0190b3fb44517f50ad180757240625e8",
+        "id": "batt_0190bc7e5cb27aa3afc34b7ecf1ccc65",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
@@ -111,7 +111,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0190b3fb4451748abc4904c9bfd19601",
+        "id": "batt_0190bc7e5cb2755eb5684f37eb65c98d",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -125,7 +125,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0190b3fb44517c7c8ef241763b589f05",
+        "id": "batt_0190bc7e5cb275eeace2b07b6687fce6",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -137,7 +137,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0190b3fb44527965b6dd6c588799f5ba",
+        "id": "batt_0190bc7e5cb2727087c1105d6f6cadf8",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -159,20 +159,20 @@
           "name": "control",
           "owner": "battery-control-user"
         },
-        "storage_class": null,
         "cpu_requested": 500,
         "cpu_limits": 2000,
         "memory_requested": 1073741824,
         "memory_limits": 4294967296,
         "num_instances": 1,
         "virtual_size": "small",
+        "storage_class": null,
         "inserted_at": null,
         "updated_at": null,
         "users": [
           {
             "position": null,
             "username": "battery-control-user",
-            "password": "ZOQCGQDYUUX44H2LP2U3L4S4",
+            "password": "TIW2JS76YM3BZBV4DPZP6NW7",
             "roles": [
               "createdb",
               "login"
@@ -200,7 +200,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "K74VCTLBNIWU6NKBDHFEKKB3F22J3NGD7CDLQY6DQI5W6CCCSZPA===="
+          "battery/hash": "HT737A62K7LK5QDVZIPBWHBVZRPXBONZ5RUBFWG5UOD643VPCAKA===="
         },
         "labels": {
           "app": "battery-core",
@@ -210,7 +210,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0190b3fb445172c786cc09909d97d511",
+          "battery/owner": "batt_0190bc7e5cb27430a7a7e7bf07ae2c42",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -233,7 +233,7 @@
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "AQJ2EMGQCRAHACI6EQB5DAXQUYWZPRHNFHARD7FX7LQ2OEARLYJQ===="
+          "battery/hash": "YFLKEUYZD2TCR4MDYHV2XZC46VP7TDZO32YEOSCQOGODYHLQQ7YA===="
         },
         "labels": {
           "app": "battery-core",
@@ -243,7 +243,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0190b3fb445172c786cc09909d97d511",
+          "battery/owner": "batt_0190bc7e5cb27430a7a7e7bf07ae2c42",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -267,7 +267,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_0190b3fb445172c786cc09909d97d511",
+              "battery/owner": "batt_0190bc7e5cb27430a7a7e7bf07ae2c42",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -280,7 +280,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "HK5D5KGSCUCJ6JJGGMUG5DQHTHFC57FMESPGYRKYMIALHUQ2LMEM5HMIUQ3OITW4"
+                    "value": "53ILWCLYRQ2BWWMCJOLSTIBS2UDL7MWUA66CGW7DQMCK4AIBKGOGJKSKX2GCASSZ"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -291,7 +291,7 @@
                     "value": "/var/run/secrets/summary/summary.json"
                   }
                 ],
-                "image": "public.ecr.aws/batteries-included/kube-bootstrap:0.13.1-78b30183-dirty",
+                "image": "public.ecr.aws/batteries-included/kube-bootstrap:latest",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "bootstrap",
                 "volumeMounts": [
@@ -328,7 +328,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "VBLMKTPORT53LDHYJGEEPSADK6NU4BSSY5E6M5SJ63OONANSFLIA===="
+          "battery/hash": "KUL2HL6EPEITSCRJJ5PHLAQBS634MXICAR5EN3FI33JCXXIKWQ5Q===="
         },
         "labels": {
           "app": "battery-core",
@@ -338,7 +338,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0190b3fb445172c786cc09909d97d511",
+          "battery/owner": "batt_0190bc7e5cb27430a7a7e7bf07ae2c42",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -350,7 +350,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "PXCCAIFKLK2KJBRQRWT5TIROC4AXMKKGANGZKJQXUGKIWJSWGMFQ===="
+          "battery/hash": "XZB2RAQODN5UXWITQNKYX32KT3HPXFU5YBROJPD7RC26CK2W7ERQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -360,7 +360,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0190b3fb445172c786cc09909d97d511",
+          "battery/owner": "batt_0190bc7e5cb27430a7a7e7bf07ae2c42",
           "version": "latest"
         },
         "name": "bootstrap",
@@ -373,7 +373,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "J4G42DGOX5QD35HWZ7LRIQTSEDWWSBXFZTSOVN6G5D7MFK74TZSA====",
+          "battery/hash": "ARTUZJB27EGSJHLH4JJQUNIKQ3666UCXNDRVYIZI7YPIVTY5IKQA====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -384,7 +384,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0190b3fb445172c786cc09909d97d511",
+          "battery/owner": "batt_0190bc7e5cb27430a7a7e7bf07ae2c42",
           "version": "latest"
         },
         "name": "gp2"
@@ -399,7 +399,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "3C5WBXDOGM6BU6EXPQOCJ6C5UT6YRU63T7QKFT6SVWBSISPDXDGA====",
+          "battery/hash": "FIQ22WJAH7UG5E4ZMGKNUTDKJAPJ5I72R4E22ON36DZ2P63EGN2Q====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -410,7 +410,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0190b3fb445172c786cc09909d97d511",
+          "battery/owner": "batt_0190bc7e5cb27430a7a7e7bf07ae2c42",
           "version": "latest"
         },
         "name": "gp2-90032408"
@@ -430,7 +430,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "LABOQKMXZDGJRAN74SR7NUGAHRF5NK7TBPQVX7CRT4CUQXEBRRPA====",
+          "battery/hash": "3NWKMH6WPQHYBAFSFSVX4A5X7GKKLLMWOVNXJ77DR3Q6ETVESLEQ====",
           "storageclass.kubernetes.io/is-default-class": "true"
         },
         "labels": {
@@ -441,7 +441,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0190b3fb445172c786cc09909d97d511",
+          "battery/owner": "batt_0190bc7e5cb27430a7a7e7bf07ae2c42",
           "version": "latest"
         },
         "name": "gp3-105457460"

--- a/bootstrap/dev.install.json
+++ b/bootstrap/dev.install.json
@@ -1,12 +1,12 @@
 {
-  "id": "batt_0190b3fb4417769dbd57951a8c03628f",
+  "id": "batt_0190bc7e5c7e78079bbbd0490e65a9bb",
   "usage": "internal_dev",
   "default_size": "tiny",
   "control_jwk": {
     "crv": "Ed25519",
-    "d": "qWO3ofIAE2bZDh8lIOMwkFadoSMLPYCeECKbxIDtFpQ",
+    "d": "Hb9vJmYNslAqjNyRxV2rmUhhIuHNE9u8q6iu-inhmXs",
     "kty": "OKP",
-    "x": "4IhUNInZFlMn3l-VUc6HIOJjDQo_O8TiSs8WJS2LC64"
+    "x": "0ZRHC25IdGSDOw2uWoRHZHBIBtYNw-5QzfqhXWFbVQk"
   },
   "inserted_at": null,
   "updated_at": null,
@@ -16,5 +16,5 @@
   "sso_enabled": false,
   "initial_oauth_email": null,
   "user_id": null,
-  "team_id": "batt_0190b3fb44117ee8a86cb54e512d403e"
+  "team_id": "batt_0190bc7e5c7e746ab4600abf1aacb09b"
 }

--- a/bootstrap/dev.spec.json
+++ b/bootstrap/dev.spec.json
@@ -9,7 +9,7 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_0190b3fb44397a36a9f0f38ab00cca13",
+        "id": "batt_0190bc7e5ca37d32a7f41077301ce799",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -23,7 +23,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0190b3fb443b7014b44a0196ea1a0299",
+        "id": "batt_0190bc7e5ca377aa91b15d6a0ca7efd2",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -35,26 +35,26 @@
         "updated_at": null
       },
       {
-        "id": "batt_0190b3fb443c752794a9609cf86d0ace",
+        "id": "batt_0190bc7e5ca37517972048626312b084",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
-          "image": "public.ecr.aws/batteries-included/control-server:0.13.1-78b30183-dirty",
+          "image": "public.ecr.aws/batteries-included/control-server:latest",
           "cluster_type": "kind",
+          "bootstrap_image": "public.ecr.aws/batteries-included/kube-bootstrap:latest",
           "core_namespace": "battery-core",
+          "server_in_cluster": false,
           "base_namespace": "battery-base",
           "data_namespace": "battery-data",
           "ai_namespace": "battery-ai",
-          "bootstrap_image": "public.ecr.aws/batteries-included/kube-bootstrap:0.13.1-78b30183-dirty",
           "default_size": "tiny",
           "cluster_name": "dev",
-          "server_in_cluster": false,
-          "install_id": "batt_0190b3fb4417769dbd57951a8c03628f",
+          "install_id": "batt_0190bc7e5c7e78079bbbd0490e65a9bb",
           "control_jwk": {
             "crv": "Ed25519",
-            "d": "qWO3ofIAE2bZDh8lIOMwkFadoSMLPYCeECKbxIDtFpQ",
+            "d": "Hb9vJmYNslAqjNyRxV2rmUhhIuHNE9u8q6iu-inhmXs",
             "kty": "OKP",
-            "x": "4IhUNInZFlMn3l-VUc6HIOJjDQo_O8TiSs8WJS2LC64"
+            "x": "0ZRHC25IdGSDOw2uWoRHZHBIBtYNw-5QzfqhXWFbVQk"
           },
           "image_override": null,
           "bootstrap_image_override": null
@@ -64,15 +64,15 @@
         "updated_at": null
       },
       {
-        "id": "batt_0190b3fb443d73b4ae253ddc99d84141",
+        "id": "batt_0190bc7e5ca37724aa944d889ca862b8",
         "type": "metallb",
         "config": {
           "type": "metallb",
           "controller_image": "quay.io/metallb/controller:v0.13.12",
+          "controller_image_override": null,
           "speaker_image": "quay.io/metallb/speaker:v0.13.12",
           "frrouting_image": "quay.io/frrouting/frr:8.5.4",
           "speaker_image_override": null,
-          "controller_image_override": null,
           "frrouting_image_override": null
         },
         "group": "net_sec",
@@ -80,7 +80,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0190b3fb443d7deaaed8d0c562113c68",
+        "id": "batt_0190bc7e5ca370bea882cc478c259361",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
@@ -92,7 +92,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0190b3fb443e724d9031f68c61411248",
+        "id": "batt_0190bc7e5ca37b0aaf1ac90e78e470d3",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -114,13 +114,13 @@
           "name": "control",
           "owner": "battery-control-user"
         },
-        "storage_class": null,
         "cpu_requested": 500,
         "cpu_limits": 500,
         "memory_requested": 536870912,
         "memory_limits": 536870912,
         "num_instances": 1,
         "virtual_size": "tiny",
+        "storage_class": null,
         "inserted_at": null,
         "updated_at": null,
         "users": [
@@ -139,7 +139,7 @@
           {
             "position": null,
             "username": "battery-control-user",
-            "password": "ZV4MYFUV4XAXO7YRRX63DIZE",
+            "password": "HBOZNVAQSQPBNDQCWS67EAK7",
             "roles": [
               "createdb",
               "login"
@@ -167,7 +167,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "ZRDQ3VZ3CDPJMIKH5DBBELGECLLLXTAWZ3RG2YMYKOWIBQGAWLGA===="
+          "battery/hash": "KF3DBIBX4UJHMGUBBFN475G5UYZI4S623FCVGNXXIIXOZXBRS22A===="
         },
         "labels": {
           "app": "battery-core",
@@ -177,7 +177,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0190b3fb443c752794a9609cf86d0ace",
+          "battery/owner": "batt_0190bc7e5ca37517972048626312b084",
           "istio-injection": "enabled",
           "version": "latest"
         },

--- a/bootstrap/elliott.install.json
+++ b/bootstrap/elliott.install.json
@@ -1,12 +1,12 @@
 {
-  "id": "batt_0190b3fb44367497879a251edfef1a07",
+  "id": "batt_0190bc7e5ca0796f9e931df0bedcc811",
   "usage": "development",
   "default_size": "small",
   "control_jwk": {
     "crv": "Ed25519",
-    "d": "YFGGT-A_KDhc8c7zuE1ocQDDYU7Fhm9iZ3bQ1-qxpx8",
+    "d": "EOHIEl6nxdSXA9aXhYvCEDHAS8ytlifI7MzYofB1-_4",
     "kty": "OKP",
-    "x": "ySqcp9EbbfsrmN7kt3Xxru6sLmXoVFLGhBdEHk766tw"
+    "x": "cFvZ-QmrBn_rYnJYGknq5xRasl3RzQ9X9pzpNN6ow6Y"
   },
   "inserted_at": null,
   "updated_at": null,
@@ -16,5 +16,5 @@
   "sso_enabled": false,
   "initial_oauth_email": null,
   "user_id": null,
-  "team_id": "batt_0190b3fb44117ee8a86cb54e512d403e"
+  "team_id": "batt_0190bc7e5c7e746ab4600abf1aacb09b"
 }

--- a/bootstrap/elliott.spec.json
+++ b/bootstrap/elliott.spec.json
@@ -9,26 +9,26 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_0190b3fb444e749188104242bfe41f85",
+        "id": "batt_0190bc7e5cb177be905435a2e140e368",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
-          "image": "public.ecr.aws/batteries-included/control-server:0.13.1-78b30183-dirty",
+          "image": "public.ecr.aws/batteries-included/control-server:latest",
           "cluster_type": "aws",
+          "bootstrap_image": "public.ecr.aws/batteries-included/kube-bootstrap:latest",
           "core_namespace": "battery-core",
+          "server_in_cluster": true,
           "base_namespace": "battery-base",
           "data_namespace": "battery-data",
           "ai_namespace": "battery-ai",
-          "bootstrap_image": "public.ecr.aws/batteries-included/kube-bootstrap:0.13.1-78b30183-dirty",
           "default_size": "small",
           "cluster_name": "elliott",
-          "server_in_cluster": true,
-          "install_id": "batt_0190b3fb44367497879a251edfef1a07",
+          "install_id": "batt_0190bc7e5ca0796f9e931df0bedcc811",
           "control_jwk": {
             "crv": "Ed25519",
-            "d": "YFGGT-A_KDhc8c7zuE1ocQDDYU7Fhm9iZ3bQ1-qxpx8",
+            "d": "EOHIEl6nxdSXA9aXhYvCEDHAS8ytlifI7MzYofB1-_4",
             "kty": "OKP",
-            "x": "ySqcp9EbbfsrmN7kt3Xxru6sLmXoVFLGhBdEHk766tw"
+            "x": "cFvZ-QmrBn_rYnJYGknq5xRasl3RzQ9X9pzpNN6ow6Y"
           },
           "image_override": null,
           "bootstrap_image_override": null
@@ -38,7 +38,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0190b3fb444e705cb2aa5a8dcdfd0294",
+        "id": "batt_0190bc7e5cb17334b5dd483d907e59a5",
         "type": "karpenter",
         "config": {
           "type": "karpenter",
@@ -53,7 +53,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0190b3fb444f7afc925b0c0df8f607d7",
+        "id": "batt_0190bc7e5cb173c6a47a45681a97d80a",
         "type": "cert_manager",
         "config": {
           "type": "cert_manager",
@@ -63,9 +63,9 @@
           "controller_image": "quay.io/jetstack/cert-manager-controller:v1.14.7",
           "ctl_image": "quay.io/jetstack/cert-manager-ctl:v1.14.7",
           "webhook_image": "quay.io/jetstack/cert-manager-webhook:v1.14.7",
-          "controller_image_override": null,
           "acmesolver_image_override": null,
           "cainjector_image_override": null,
+          "controller_image_override": null,
           "ctl_image_override": null,
           "webhook_image_override": null
         },
@@ -74,7 +74,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0190b3fb444f7115ad62cf655f0fe89f",
+        "id": "batt_0190bc7e5cb1766d902812fcd19f066c",
         "type": "battery_ca",
         "config": {
           "type": "battery_ca"
@@ -84,7 +84,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0190b3fb44507c34af9d0d3e62420508",
+        "id": "batt_0190bc7e5cb1776ba0cf98a4b76da887",
         "type": "aws_load_balancer_controller",
         "config": {
           "type": "aws_load_balancer_controller",
@@ -99,7 +99,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0190b3fb44517d3f82ca40bab40f2e57",
+        "id": "batt_0190bc7e5cb17a1c8b0e544d858c7c3d",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
@@ -111,7 +111,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0190b3fb44517001ab738d68350a0b48",
+        "id": "batt_0190bc7e5cb27f4dafc8146d9340ff99",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -125,7 +125,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0190b3fb44517c8d8b1d94a8d74a0d92",
+        "id": "batt_0190bc7e5cb27505a81b73394d78deb7",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -137,7 +137,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0190b3fb44517ab4b4db5d9af9155169",
+        "id": "batt_0190bc7e5cb27d26b531515ff6c591b4",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -159,20 +159,20 @@
           "name": "control",
           "owner": "battery-control-user"
         },
-        "storage_class": null,
         "cpu_requested": 500,
         "cpu_limits": 2000,
         "memory_requested": 1073741824,
         "memory_limits": 4294967296,
         "num_instances": 1,
         "virtual_size": "small",
+        "storage_class": null,
         "inserted_at": null,
         "updated_at": null,
         "users": [
           {
             "position": null,
             "username": "battery-control-user",
-            "password": "TGNV77B3HD7RW3U4FV6H7IJV",
+            "password": "CFW266LK6EZIMX7DIYWYGH3Y",
             "roles": [
               "createdb",
               "login"
@@ -200,7 +200,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "JEWTHAOUIURMISKUJORW3I32SKL4IPZKLISEYBAKUZE5ARQMOJQA===="
+          "battery/hash": "D2XMMXDM4QSQE562QKVGOFUWOKNNH7BVMD5IRW5LNOP7PYBTYQ6Q===="
         },
         "labels": {
           "app": "battery-core",
@@ -210,7 +210,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0190b3fb444e749188104242bfe41f85",
+          "battery/owner": "batt_0190bc7e5cb177be905435a2e140e368",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -233,7 +233,7 @@
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "C7ZRZSZKH672VPBKVP4DA26BL5MIMKSDNKOFZ27IR63XV2KDWH3Q===="
+          "battery/hash": "IJ2MUJEJ6SZCN6F4L656BPPFOLOODLEKXQJWEAAEYG36AQDKRDWQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -243,7 +243,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0190b3fb444e749188104242bfe41f85",
+          "battery/owner": "batt_0190bc7e5cb177be905435a2e140e368",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -267,7 +267,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_0190b3fb444e749188104242bfe41f85",
+              "battery/owner": "batt_0190bc7e5cb177be905435a2e140e368",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -280,7 +280,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "L4BYO4AUMECYWUBTGQNSUCQRMWPAYTGDGBEIJBRICGI55C7MHELK3FZCNXF7SFKL"
+                    "value": "ZPHVGZDXQZAQ5L5R5DSGGWN74RP3ESTGXGYOXG3MO2X7IFT4JHPRX22M4E7EQUD3"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -291,7 +291,7 @@
                     "value": "/var/run/secrets/summary/summary.json"
                   }
                 ],
-                "image": "public.ecr.aws/batteries-included/kube-bootstrap:0.13.1-78b30183-dirty",
+                "image": "public.ecr.aws/batteries-included/kube-bootstrap:latest",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "bootstrap",
                 "volumeMounts": [
@@ -328,7 +328,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "GAKP5X7SACECNI5LMGDCE6YG75A6PV7E4YRFJIALQEEPCN23AMFQ===="
+          "battery/hash": "UU7QCFTVT3SWCNTRHIEJUSXZYFYDCL5BCX4BRVM2NDT7HEP77F5A===="
         },
         "labels": {
           "app": "battery-core",
@@ -338,7 +338,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0190b3fb444e749188104242bfe41f85",
+          "battery/owner": "batt_0190bc7e5cb177be905435a2e140e368",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -350,7 +350,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "BGKJXQREO5EZK4W5DTX6YPLJAUR5FNO3L2LBCH4OZLZK4CMGGCLQ===="
+          "battery/hash": "K2PGKRZIOHC5B47ACJZPJFCOP6ELYBGVOPD7STMXELUC3ORMD5CQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -360,7 +360,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0190b3fb444e749188104242bfe41f85",
+          "battery/owner": "batt_0190bc7e5cb177be905435a2e140e368",
           "version": "latest"
         },
         "name": "bootstrap",
@@ -373,7 +373,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "7F4SQNDLNGGAQV3HN5Y4DF6DCJQGMHRH5D3SP45GEXCXE7POPV4A====",
+          "battery/hash": "PNJG2NSN5KJCZ56HGJTTPUONLLZV25AWQTBK4Q4HJLD3766Y7ZTA====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -384,7 +384,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0190b3fb444e749188104242bfe41f85",
+          "battery/owner": "batt_0190bc7e5cb177be905435a2e140e368",
           "version": "latest"
         },
         "name": "gp2"
@@ -399,7 +399,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "EYLVDSB2NLQMTZMTHZPTPLAVIWQL3IQX2UBXMXSYYP6SWFWHDICQ====",
+          "battery/hash": "EJHJM52CMEZF4D5NYNLSSUWMOA3VWM2M376RVTJNY7TJ3QHXPLDQ====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -410,7 +410,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0190b3fb444e749188104242bfe41f85",
+          "battery/owner": "batt_0190bc7e5cb177be905435a2e140e368",
           "version": "latest"
         },
         "name": "gp2-90032408"
@@ -430,7 +430,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "HZCV6ZH43SFRQ4W6CFQNAK7M6NVHHO37Y3HWYF2OWRMS4W2SAOOQ====",
+          "battery/hash": "IGTWWVUZF6YM72HBGLKPAQNMC245X25QKNMT2AWGXXHYPDWBSE3A====",
           "storageclass.kubernetes.io/is-default-class": "true"
         },
         "labels": {
@@ -441,7 +441,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0190b3fb444e749188104242bfe41f85",
+          "battery/owner": "batt_0190bc7e5cb177be905435a2e140e368",
           "version": "latest"
         },
         "name": "gp3-105457460"

--- a/bootstrap/integration-test.install.json
+++ b/bootstrap/integration-test.install.json
@@ -1,12 +1,12 @@
 {
-  "id": "batt_0190b3fb44367d51b5a60216c9ce8173",
+  "id": "batt_0190bc7e5ca17315ac4ef929fbc0717f",
   "usage": "internal_int_test",
   "default_size": "tiny",
   "control_jwk": {
     "crv": "Ed25519",
-    "d": "TefIorxaN242zBzp9-w6hn9ZT0MOhf0oHaxRO9kKHes",
+    "d": "tVGVAPeldMWUOBcualbhgvHyAU5fRxWNEDbYzIxHzuk",
     "kty": "OKP",
-    "x": "DNxc_ZZBjWRFzA0vdSPv10WH-QVh9oBpGAj0toKOmUs"
+    "x": "EcprUz43t1_-9lGTBuoYYEJXyVqgPthfuiS1L7nC5l0"
   },
   "inserted_at": null,
   "updated_at": null,
@@ -16,5 +16,5 @@
   "sso_enabled": false,
   "initial_oauth_email": null,
   "user_id": null,
-  "team_id": "batt_0190b3fb44117ee8a86cb54e512d403e"
+  "team_id": "batt_0190bc7e5c7e746ab4600abf1aacb09b"
 }

--- a/bootstrap/integration-test.spec.json
+++ b/bootstrap/integration-test.spec.json
@@ -9,26 +9,26 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_0190b3fb44527b158a093fff16641496",
+        "id": "batt_0190bc7e5cb377f1976e5c12123a3906",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
-          "image": "public.ecr.aws/batteries-included/control-server:0.13.1-78b30183-dirty",
+          "image": "public.ecr.aws/batteries-included/control-server:latest",
           "cluster_type": "kind",
+          "bootstrap_image": "public.ecr.aws/batteries-included/kube-bootstrap:latest",
           "core_namespace": "battery-core",
+          "server_in_cluster": false,
           "base_namespace": "battery-base",
           "data_namespace": "battery-data",
           "ai_namespace": "battery-ai",
-          "bootstrap_image": "public.ecr.aws/batteries-included/kube-bootstrap:0.13.1-78b30183-dirty",
           "default_size": "tiny",
           "cluster_name": "integration-test",
-          "server_in_cluster": false,
-          "install_id": "batt_0190b3fb44367d51b5a60216c9ce8173",
+          "install_id": "batt_0190bc7e5ca17315ac4ef929fbc0717f",
           "control_jwk": {
             "crv": "Ed25519",
-            "d": "TefIorxaN242zBzp9-w6hn9ZT0MOhf0oHaxRO9kKHes",
+            "d": "tVGVAPeldMWUOBcualbhgvHyAU5fRxWNEDbYzIxHzuk",
             "kty": "OKP",
-            "x": "DNxc_ZZBjWRFzA0vdSPv10WH-QVh9oBpGAj0toKOmUs"
+            "x": "EcprUz43t1_-9lGTBuoYYEJXyVqgPthfuiS1L7nC5l0"
           },
           "image_override": null,
           "bootstrap_image_override": null
@@ -48,13 +48,13 @@
           "name": "control",
           "owner": "battery-control-user"
         },
-        "storage_class": null,
         "cpu_requested": 500,
         "cpu_limits": 500,
         "memory_requested": 536870912,
         "memory_limits": 536870912,
         "num_instances": 1,
         "virtual_size": "tiny",
+        "storage_class": null,
         "inserted_at": null,
         "updated_at": null,
         "users": [
@@ -73,7 +73,7 @@
           {
             "position": null,
             "username": "battery-control-user",
-            "password": "PND2DYBIXN4TFW7HMX4FOSO3",
+            "password": "JIP3XPQAIPCVNCXWNFOYS67Y",
             "roles": [
               "createdb",
               "login"
@@ -101,7 +101,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "4H3IHPNWHTPFZF7RRCGFS4VFPJLKAHVNDOK5Z5D3JAF3EQDCVDFA===="
+          "battery/hash": "DDWDGQSOJCBAYXQKO2QRHYAD4LHMJWTLRUN2S44VMQUYFWHMTRQQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -111,7 +111,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0190b3fb44527b158a093fff16641496",
+          "battery/owner": "batt_0190bc7e5cb377f1976e5c12123a3906",
           "istio-injection": "enabled",
           "version": "latest"
         },

--- a/bootstrap/jason.install.json
+++ b/bootstrap/jason.install.json
@@ -1,12 +1,12 @@
 {
-  "id": "batt_0190b3fb443675e5b4b95ab1c86a4433",
+  "id": "batt_0190bc7e5ca079fb92af5f3fcf2d539b",
   "usage": "development",
   "default_size": "small",
   "control_jwk": {
     "crv": "Ed25519",
-    "d": "ZQHaEmSHVQU8yUOYXZ5fGuD5_v6OahWRvnqVsheDtKU",
+    "d": "4kL2R7UPENfuQI3DUoNPDWPSpfmHQSUGnymn3yMgqfg",
     "kty": "OKP",
-    "x": "TdgYQvgQpPdRB4aYJZ2_XvzeLfVg4nu1hNH245tHAfg"
+    "x": "pka0opykKPRSAFJDF2HtjopN1hSZ6_xzlptarsY1H1M"
   },
   "inserted_at": null,
   "updated_at": null,
@@ -16,5 +16,5 @@
   "sso_enabled": false,
   "initial_oauth_email": null,
   "user_id": null,
-  "team_id": "batt_0190b3fb44117ee8a86cb54e512d403e"
+  "team_id": "batt_0190bc7e5c7e746ab4600abf1aacb09b"
 }

--- a/bootstrap/jason.spec.json
+++ b/bootstrap/jason.spec.json
@@ -9,26 +9,26 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_0190b3fb44517905a2aca156a034f19d",
+        "id": "batt_0190bc7e5cb272ef93e56514f3920c63",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
-          "image": "public.ecr.aws/batteries-included/control-server:0.13.1-78b30183-dirty",
+          "image": "public.ecr.aws/batteries-included/control-server:latest",
           "cluster_type": "aws",
+          "bootstrap_image": "public.ecr.aws/batteries-included/kube-bootstrap:latest",
           "core_namespace": "battery-core",
+          "server_in_cluster": true,
           "base_namespace": "battery-base",
           "data_namespace": "battery-data",
           "ai_namespace": "battery-ai",
-          "bootstrap_image": "public.ecr.aws/batteries-included/kube-bootstrap:0.13.1-78b30183-dirty",
           "default_size": "small",
           "cluster_name": "jason",
-          "server_in_cluster": true,
-          "install_id": "batt_0190b3fb443675e5b4b95ab1c86a4433",
+          "install_id": "batt_0190bc7e5ca079fb92af5f3fcf2d539b",
           "control_jwk": {
             "crv": "Ed25519",
-            "d": "ZQHaEmSHVQU8yUOYXZ5fGuD5_v6OahWRvnqVsheDtKU",
+            "d": "4kL2R7UPENfuQI3DUoNPDWPSpfmHQSUGnymn3yMgqfg",
             "kty": "OKP",
-            "x": "TdgYQvgQpPdRB4aYJZ2_XvzeLfVg4nu1hNH245tHAfg"
+            "x": "pka0opykKPRSAFJDF2HtjopN1hSZ6_xzlptarsY1H1M"
           },
           "image_override": null,
           "bootstrap_image_override": null
@@ -38,7 +38,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0190b3fb44517a15a9dcfaccf64c7cf5",
+        "id": "batt_0190bc7e5cb27028b971449f8684e577",
         "type": "karpenter",
         "config": {
           "type": "karpenter",
@@ -53,7 +53,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0190b3fb445179ca807e5885c431e7e6",
+        "id": "batt_0190bc7e5cb274bc8c93e0686a068e39",
         "type": "cert_manager",
         "config": {
           "type": "cert_manager",
@@ -63,9 +63,9 @@
           "controller_image": "quay.io/jetstack/cert-manager-controller:v1.14.7",
           "ctl_image": "quay.io/jetstack/cert-manager-ctl:v1.14.7",
           "webhook_image": "quay.io/jetstack/cert-manager-webhook:v1.14.7",
-          "controller_image_override": null,
           "acmesolver_image_override": null,
           "cainjector_image_override": null,
+          "controller_image_override": null,
           "ctl_image_override": null,
           "webhook_image_override": null
         },
@@ -74,7 +74,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0190b3fb4451712c91f934dfb32e796f",
+        "id": "batt_0190bc7e5cb276cebbafd0ae0ed6cd77",
         "type": "battery_ca",
         "config": {
           "type": "battery_ca"
@@ -84,7 +84,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0190b3fb445170269d43407ccaeb8e53",
+        "id": "batt_0190bc7e5cb2724aa4946c6eff3e09c3",
         "type": "aws_load_balancer_controller",
         "config": {
           "type": "aws_load_balancer_controller",
@@ -99,7 +99,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0190b3fb44517d6184f852041e3550cd",
+        "id": "batt_0190bc7e5cb27190958447760dbc96f0",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
@@ -111,7 +111,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0190b3fb44517b3eaacb60682ba51bd5",
+        "id": "batt_0190bc7e5cb27b3fbf04702c5e837ce0",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -125,7 +125,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0190b3fb445177669715e83e70466032",
+        "id": "batt_0190bc7e5cb273ee888f2971bae834bd",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -137,7 +137,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0190b3fb4451723991d8ddd1f1a88d0b",
+        "id": "batt_0190bc7e5cb27fe697ea0e96676c510e",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -159,20 +159,20 @@
           "name": "control",
           "owner": "battery-control-user"
         },
-        "storage_class": null,
         "cpu_requested": 500,
         "cpu_limits": 2000,
         "memory_requested": 1073741824,
         "memory_limits": 4294967296,
         "num_instances": 1,
         "virtual_size": "small",
+        "storage_class": null,
         "inserted_at": null,
         "updated_at": null,
         "users": [
           {
             "position": null,
             "username": "battery-control-user",
-            "password": "LCTTVOF3RUVXGPUXNMEW7NI4",
+            "password": "6AAM7MIJHIQIVYZJYTI2P4CA",
             "roles": [
               "createdb",
               "login"
@@ -200,7 +200,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "RSDQBXFAG5DL4I6IEHOWISDHERA4M4LUC26M53AQEMO6UM65SLAQ===="
+          "battery/hash": "A2VQIFYLD5XZEJ45JKUIDT5SUMIOO52M7JQ2MDC26WWGY6DZFHRA===="
         },
         "labels": {
           "app": "battery-core",
@@ -210,7 +210,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0190b3fb44517905a2aca156a034f19d",
+          "battery/owner": "batt_0190bc7e5cb272ef93e56514f3920c63",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -233,7 +233,7 @@
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "IUKKO5WCU7EFJDLFBSSLSSLE5UPRZEQVMT4UOWQYQZ2N2XWYFBNQ===="
+          "battery/hash": "SGHQ3VTRQOZPDYMCJTDHHKF3VJV7OAKZ72XTRETRW7EM7IZP6BHQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -243,7 +243,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0190b3fb44517905a2aca156a034f19d",
+          "battery/owner": "batt_0190bc7e5cb272ef93e56514f3920c63",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -267,7 +267,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_0190b3fb44517905a2aca156a034f19d",
+              "battery/owner": "batt_0190bc7e5cb272ef93e56514f3920c63",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -280,7 +280,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "UCRQ23QAJZOIU43YR53BOLES4UAMQWXGNATMVGVA4RR3BJSS6OCAHO2A4MESN3TB"
+                    "value": "4ENPR6FNTVDP5GE4FCHRAINXZ7RB4SHX4XNFTMTATDGVCBWEXUWOVEMBPHCITKX6"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -291,7 +291,7 @@
                     "value": "/var/run/secrets/summary/summary.json"
                   }
                 ],
-                "image": "public.ecr.aws/batteries-included/kube-bootstrap:0.13.1-78b30183-dirty",
+                "image": "public.ecr.aws/batteries-included/kube-bootstrap:latest",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "bootstrap",
                 "volumeMounts": [
@@ -328,7 +328,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "BSIJHUUM33KWFIQSLRF3QFL7T55Z2IH4EUZNUHIXOSZFTVWAR5JQ===="
+          "battery/hash": "EPYP7VP5QLSETTPZQWSXCNVTFXYGO6E5QNXYGUZ2FWZKPHUD3M3Q===="
         },
         "labels": {
           "app": "battery-core",
@@ -338,7 +338,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0190b3fb44517905a2aca156a034f19d",
+          "battery/owner": "batt_0190bc7e5cb272ef93e56514f3920c63",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -350,7 +350,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "2JECNONZRCVQVUO4MFGNSABTTDFMTUTYKSFKRVMLQMZAZD4TYOIQ===="
+          "battery/hash": "2IJFGHQFNXEB7ZS7ZJFUSK7ION5RC3WWZWWKV6PSYPZBTCU4O5QA===="
         },
         "labels": {
           "app": "battery-core",
@@ -360,7 +360,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0190b3fb44517905a2aca156a034f19d",
+          "battery/owner": "batt_0190bc7e5cb272ef93e56514f3920c63",
           "version": "latest"
         },
         "name": "bootstrap",
@@ -373,7 +373,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "U4SNKVPWIVJKQFLUU7FH3J5KSB6E74UDUCB2WB2BT4VSLPXXJAVA====",
+          "battery/hash": "IWF52DZU27P3UFXKLGPIC6IDGKBGQLLX6WR52B6KBKOQZLYGJ6CA====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -384,7 +384,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0190b3fb44517905a2aca156a034f19d",
+          "battery/owner": "batt_0190bc7e5cb272ef93e56514f3920c63",
           "version": "latest"
         },
         "name": "gp2"
@@ -399,7 +399,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "KK7UXMOTLAAXWNFUOKBR7FXJHL5QUSN7VMZXUN6TJTHDPFGCMGAQ====",
+          "battery/hash": "WOSRBEMSUQNV4RHDPW34DMFXQV267RQYUW6PVH6UQUCQNZ354MGQ====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -410,7 +410,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0190b3fb44517905a2aca156a034f19d",
+          "battery/owner": "batt_0190bc7e5cb272ef93e56514f3920c63",
           "version": "latest"
         },
         "name": "gp2-90032408"
@@ -430,7 +430,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "34R75HJB2SYE4RJBBS4H3IFOMNXC5M42A3D5SR4JHXB67ZLLX2VQ====",
+          "battery/hash": "AK7RQLSBKHQBDXTPFUGKCPBDZZISJFIETM6KI2BVGBKKJCEQSALA====",
           "storageclass.kubernetes.io/is-default-class": "true"
         },
         "labels": {
@@ -441,7 +441,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0190b3fb44517905a2aca156a034f19d",
+          "battery/owner": "batt_0190bc7e5cb272ef93e56514f3920c63",
           "version": "latest"
         },
         "name": "gp3-105457460"

--- a/bootstrap/local.install.json
+++ b/bootstrap/local.install.json
@@ -1,12 +1,12 @@
 {
-  "id": "batt_0190b3fb443673408a4775f31b03107a",
+  "id": "batt_0190bc7e5ca07fcb92be8d2d43c307e3",
   "usage": "development",
   "default_size": "tiny",
   "control_jwk": {
     "crv": "Ed25519",
-    "d": "NWlj8Anh_bl6EelNW7PC07RGUh7U3eOrxk__e0KQsNs",
+    "d": "XhWl6_6eci1ds9W_YLZCyox4fBk1Sl0Uz7F57d3GErc",
     "kty": "OKP",
-    "x": "jZuJcePIAx5uh8ZhXkL9Lun2K-E1SQAfQS8UZv_Q9mo"
+    "x": "om1_cIDBp8FUFXmgm142ghRaqf4Mo2Hy8HJm5WB4NXc"
   },
   "inserted_at": null,
   "updated_at": null,
@@ -16,5 +16,5 @@
   "sso_enabled": false,
   "initial_oauth_email": null,
   "user_id": null,
-  "team_id": "batt_0190b3fb44117ee8a86cb54e512d403e"
+  "team_id": "batt_0190bc7e5c7e746ab4600abf1aacb09b"
 }

--- a/bootstrap/local.spec.json
+++ b/bootstrap/local.spec.json
@@ -9,7 +9,7 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_0190b3fb444e7854b19c43771437d23f",
+        "id": "batt_0190bc7e5cb07e9c862ab9cc36e16a13",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -23,7 +23,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0190b3fb444e714da0eb5130ee68984d",
+        "id": "batt_0190bc7e5cb0750993ed3c029789d6d2",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -35,26 +35,26 @@
         "updated_at": null
       },
       {
-        "id": "batt_0190b3fb444e77a2862d5db934cbdb35",
+        "id": "batt_0190bc7e5cb07b2f815183534f4f9ac2",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
-          "image": "public.ecr.aws/batteries-included/control-server:0.13.1-78b30183-dirty",
+          "image": "public.ecr.aws/batteries-included/control-server:latest",
           "cluster_type": "kind",
+          "bootstrap_image": "public.ecr.aws/batteries-included/kube-bootstrap:latest",
           "core_namespace": "battery-core",
+          "server_in_cluster": true,
           "base_namespace": "battery-base",
           "data_namespace": "battery-data",
           "ai_namespace": "battery-ai",
-          "bootstrap_image": "public.ecr.aws/batteries-included/kube-bootstrap:0.13.1-78b30183-dirty",
           "default_size": "tiny",
           "cluster_name": "local",
-          "server_in_cluster": true,
-          "install_id": "batt_0190b3fb443673408a4775f31b03107a",
+          "install_id": "batt_0190bc7e5ca07fcb92be8d2d43c307e3",
           "control_jwk": {
             "crv": "Ed25519",
-            "d": "NWlj8Anh_bl6EelNW7PC07RGUh7U3eOrxk__e0KQsNs",
+            "d": "XhWl6_6eci1ds9W_YLZCyox4fBk1Sl0Uz7F57d3GErc",
             "kty": "OKP",
-            "x": "jZuJcePIAx5uh8ZhXkL9Lun2K-E1SQAfQS8UZv_Q9mo"
+            "x": "om1_cIDBp8FUFXmgm142ghRaqf4Mo2Hy8HJm5WB4NXc"
           },
           "image_override": null,
           "bootstrap_image_override": null
@@ -64,15 +64,15 @@
         "updated_at": null
       },
       {
-        "id": "batt_0190b3fb444e7dd7b86f2389da28b953",
+        "id": "batt_0190bc7e5cb07be38dbad86331cd0a3f",
         "type": "metallb",
         "config": {
           "type": "metallb",
           "controller_image": "quay.io/metallb/controller:v0.13.12",
+          "controller_image_override": null,
           "speaker_image": "quay.io/metallb/speaker:v0.13.12",
           "frrouting_image": "quay.io/frrouting/frr:8.5.4",
           "speaker_image_override": null,
-          "controller_image_override": null,
           "frrouting_image_override": null
         },
         "group": "net_sec",
@@ -80,7 +80,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0190b3fb444e7b9b905496b5b426f7e7",
+        "id": "batt_0190bc7e5cb07e9ebfc748a20c6fcaef",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
@@ -92,7 +92,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0190b3fb444e712b9e6153802d79a1dc",
+        "id": "batt_0190bc7e5cb07a75838bf0ae8b426c28",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -114,20 +114,20 @@
           "name": "control",
           "owner": "battery-control-user"
         },
-        "storage_class": null,
         "cpu_requested": 500,
         "cpu_limits": 500,
         "memory_requested": 536870912,
         "memory_limits": 536870912,
         "num_instances": 1,
         "virtual_size": "tiny",
+        "storage_class": null,
         "inserted_at": null,
         "updated_at": null,
         "users": [
           {
             "position": null,
             "username": "battery-control-user",
-            "password": "YOZEISIKPMHU46LJWNEHMPJ5",
+            "password": "MPTTPCDCA3TI5DCYQA54CE56",
             "roles": [
               "createdb",
               "login"
@@ -155,7 +155,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "G4LFUFIVPHG7WCTH7QT2H22P2TCJTYEYF5G2SIKNIPX6PG3SVFMA===="
+          "battery/hash": "7M46MIC5PTZLZOQVNECJZGVZFREV66D23THRU2BZREIKDGJ4FTCA===="
         },
         "labels": {
           "app": "battery-core",
@@ -165,7 +165,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0190b3fb444e77a2862d5db934cbdb35",
+          "battery/owner": "batt_0190bc7e5cb07b2f815183534f4f9ac2",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -188,7 +188,7 @@
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "OJNOYBX2MLQ35OFRAKZ4QLOATY6BWYFB4UIY5MD7OIRJHELU3SAQ===="
+          "battery/hash": "EW7JXBJPDEXSWHC2UJJAAV6EIHAHW77I2O464C4O6B27H5JRYLTQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -198,7 +198,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0190b3fb444e77a2862d5db934cbdb35",
+          "battery/owner": "batt_0190bc7e5cb07b2f815183534f4f9ac2",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -222,7 +222,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_0190b3fb444e77a2862d5db934cbdb35",
+              "battery/owner": "batt_0190bc7e5cb07b2f815183534f4f9ac2",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -235,7 +235,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "EPEX3TU2CIKJZVNEVCQWBAJKVW6DX5PBTNBDNPLDO5SNIUCGM32NVE6GJR62RYRV"
+                    "value": "WAQOC3WUF2TEWRMLNBRLVQRMUHW646SLPDZKEMIPZ72SZDDKKK55BU4KKLM4UG6N"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -246,7 +246,7 @@
                     "value": "/var/run/secrets/summary/summary.json"
                   }
                 ],
-                "image": "public.ecr.aws/batteries-included/kube-bootstrap:0.13.1-78b30183-dirty",
+                "image": "public.ecr.aws/batteries-included/kube-bootstrap:latest",
                 "imagePullPolicy": "IfNotPresent",
                 "name": "bootstrap",
                 "volumeMounts": [
@@ -283,7 +283,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "NH3SS2A3NORPQBXHTPCOKJFAGN47BBZLKEVNHK7SAJD7PH57QT4Q===="
+          "battery/hash": "2V3FNQXDVSNAKHFVAO5E3RB3W35EOGN4H63TEMAB5BI42XKG5VWA===="
         },
         "labels": {
           "app": "battery-core",
@@ -293,7 +293,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0190b3fb444e77a2862d5db934cbdb35",
+          "battery/owner": "batt_0190bc7e5cb07b2f815183534f4f9ac2",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -305,7 +305,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "JMMBHDF53CJ5Z72L57PF7IE67JHNWDXXGK4JUSDORIXPISOFBVQA===="
+          "battery/hash": "7CQE4UOH7J2YVBRHDFNH2CM7GMARQABRETN5CSXH7QDFDPQXOZZQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -315,7 +315,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0190b3fb444e77a2862d5db934cbdb35",
+          "battery/owner": "batt_0190bc7e5cb07b2f815183534f4f9ac2",
           "version": "latest"
         },
         "name": "bootstrap",

--- a/bootstrap/team.json
+++ b/bootstrap/team.json
@@ -1,5 +1,5 @@
 {
-  "id": "batt_0190b3fb44117ee8a86cb54e512d403e",
+  "id": "batt_0190bc7e5c7e746ab4600abf1aacb09b",
   "name": "Batteries Included Team",
   "inserted_at": null,
   "updated_at": null,


### PR DESCRIPTION
Summary:
Latest is what we are testing. somehow a -dirty got in there

Test Plan:
Booting an aws cluster for demo now.
