### PR TITLE
fix: allow longer time for status unknown

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/et/install_status.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/et/install_status.ex
@@ -19,7 +19,7 @@ defmodule CommonCore.ET.InstallStatus do
   end
 
   def new_unknown! do
-    exp = DateTime.utc_now() |> DateTime.add(1, :hour) |> DateTime.to_unix()
+    exp = DateTime.utc_now() |> DateTime.add(8, :hour) |> DateTime.to_unix()
     new!(status: :unknown, exp: exp)
   end
 


### PR DESCRIPTION
Summary:
When the first unknown status expires we go into error. One hour is too
fast right now since AWS installs sometimes take 30+ mins to start.

Test Plan:
Demos can happen without me swearing
