### PR TITLE
ci: share go test cache

### DIFF
--- a/.github/workflows/bix_go.yml
+++ b/.github/workflows/bix_go.yml
@@ -89,16 +89,16 @@ jobs:
         run: asdf reshim
 
       - name: Setup Go cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: |
             ${{ env.GOCACHE }}
             ${{ env.GOMODCACHE }}
           key:
-            ${{ runner.os }}-go-int-test-${{ hashFiles('**/go.sum',
+            ${{ runner.os }}-go-test-${{ hashFiles('**/go.sum',
             '.tool-versions') }}
           restore-keys: |
-            ${{ runner.os }}-go-int-test-
+            ${{ runner.os }}-go-test-
 
       - name: Run go integration test
         run: bin/bix go-test-int


### PR DESCRIPTION
I noticed that the test and int-test caches were the same size and can be shared to help conserve cache storage quota.