### PR TITLE
Add FerretDB section to database projects

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/ferretdb/ferret_service.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/ferretdb/ferret_service.ex
@@ -43,7 +43,7 @@ defmodule CommonCore.FerretDB.FerretService do
 
   batt_schema "ferret_services" do
     slug_field :name
-    field :instances, :integer
+    field :instances, :integer, default: 1
     field :cpu_requested, :integer
     field :cpu_limits, :integer
     field :memory_requested, :integer

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/ferretdb/form_component.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/ferretdb/form_component.ex
@@ -2,8 +2,9 @@ defmodule ControlServerWeb.FerretDBFormComponent do
   @moduledoc false
   use ControlServerWeb, :live_component
 
+  import ControlServerWeb.FerretDBFormSubcomponents
+
   alias CommonCore.FerretDB.FerretService
-  alias CommonCore.Util.Memory
   alias ControlServer.FerretDB
   alias ControlServer.Postgres
   alias Ecto.Changeset
@@ -28,43 +29,13 @@ defmodule ControlServerWeb.FerretDBFormComponent do
 
         <.grid columns={[sm: 1, lg: 2]}>
           <.panel class="col-span-2">
-            <.grid columns={[sm: 1, lg: 2]}>
-              <.input field={@form[:name]} label="Name" disabled={@action == :edit} />
-              <.input
-                field={@form[:postgres_cluster_id]}
-                label="Postgres Cluster"
-                type="select"
-                placeholder="Choose a postgres cluster"
-                options={Enum.map(@pg_clusters, &{&1.name, &1.id})}
-              />
-              <.input
-                field={@form[:virtual_size]}
-                type="select"
-                label="Size"
-                placeholder="Choose a size"
-                options={FerretService.preset_options_for_select()}
-              />
+            <.size_form form={@form} pg_clusters={@pg_clusters} />
 
-              <.grid columns={[sm: 1, lg: 2]} class="items-center">
-                <.h5>Number of instances</.h5>
-                <.input field={@form[:instances]} type="range" min="1" max="3" step="1" />
-              </.grid>
-            </.grid>
-            <.data_list
-              :if={@form[:virtual_size].value != "custom"}
-              variant="horizontal-bolded"
-              class="mt-3 mb-5"
-              data={[
-                {"Memory limits:", Memory.humanize(@form[:memory_limits].value)},
-                {"CPU limits:", @form[:cpu_limits].value}
-              ]}
-            />
+            <.flex class="justify-between w-full py-3 border-t border-gray-lighter dark:border-gray-darker" />
 
-            <.grid :if={@form[:virtual_size].value == "custom"} columns={[sm: 1, md: 2, xl: 4]}>
-              <.input field={@form[:cpu_requested]} label="Cpu requested" />
-              <.input field={@form[:cpu_limits]} label="Cpu limits" />
-              <.input field={@form[:memory_requested]} label="Memory requested" />
-              <.input field={@form[:memory_limits]} label="Memory limits" />
+            <.grid columns={[sm: 1, lg: 2]} class="items-center">
+              <.h5>Number of instances</.h5>
+              <.input field={@form[:instances]} type="range" min="1" max="3" step="1" />
             </.grid>
           </.panel>
 

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/ferretdb/form_subcomponents.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/ferretdb/form_subcomponents.ex
@@ -1,0 +1,54 @@
+defmodule ControlServerWeb.FerretDBFormSubcomponents do
+  @moduledoc false
+  use ControlServerWeb, :html
+
+  alias CommonCore.FerretDB.FerretService
+  alias CommonCore.Util.Memory
+
+  attr :class, :any, default: nil
+  attr :action, :atom, default: nil
+  attr :form, Phoenix.HTML.Form, required: true
+  attr :pg_clusters, :list
+
+  def size_form(assigns) do
+    ~H"""
+    <div class={["contents", @class]}>
+      <.grid columns={[sm: 1, lg: 2]}>
+        <.input field={@form[:name]} label="Name" />
+        <.input
+          :if={assigns[:pg_clusters]}
+          field={@form[:postgres_cluster_id]}
+          label="Postgres Cluster"
+          type="select"
+          placeholder="Choose a postgres cluster"
+          options={Enum.map(@pg_clusters, &{&1.name, &1.id})}
+        />
+        <.input
+          field={@form[:virtual_size]}
+          type="select"
+          label="Size"
+          placeholder="Choose a size"
+          options={FerretService.preset_options_for_select()}
+        />
+      </.grid>
+
+      <.data_list
+        :if={@form[:virtual_size].value != "custom"}
+        variant="horizontal-bolded"
+        class="mt-3 mb-5"
+        data={[
+          {"Memory limits:", Memory.humanize(@form[:memory_limits].value)},
+          {"CPU limits:", @form[:cpu_limits].value}
+        ]}
+      />
+
+      <.grid :if={@form[:virtual_size].value == "custom"} columns={[sm: 1, md: 2, xl: 4]}>
+        <.input field={@form[:cpu_requested]} label="Cpu requested" />
+        <.input field={@form[:cpu_limits]} label="Cpu limits" />
+        <.input field={@form[:memory_requested]} label="Memory requested" />
+        <.input field={@form[:memory_limits]} label="Memory limits" />
+      </.grid>
+    </div>
+    """
+  end
+end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/batteries_form.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/batteries_form.ex
@@ -243,6 +243,7 @@ defmodule ControlServerWeb.Projects.BatteriesForm do
           "postgres" -> [:cloudnative_pg]
           "postgres_ids" -> [:cloudnative_pg]
           "redis" -> [:redis]
+          "ferret" -> [:ferretdb]
           "jupyter" -> [:notebooks]
           "knative" -> [:knative]
           "traditional" -> [:traditional_services]

--- a/platform_umbrella/apps/kube_services/lib/kube_services/smart_builder.ex
+++ b/platform_umbrella/apps/kube_services/lib/kube_services/smart_builder.ex
@@ -1,5 +1,6 @@
 defmodule KubeServices.SmartBuilder do
   @moduledoc false
+  alias CommonCore.FerretDB.FerretService
   alias CommonCore.Notebooks.JupyterLabNotebook
   alias CommonCore.Postgres.Cluster, as: PGCluster
   alias CommonCore.Postgres.PGDatabase
@@ -37,6 +38,12 @@ defmodule KubeServices.SmartBuilder do
     %RedisCluster{
       num_redis_instances: 1,
       num_sentinel_instances: num_sentinel_instances,
+      virtual_size: Atom.to_string(SummaryBatteries.default_size())
+    }
+  end
+
+  def new_ferretdb do
+    %FerretService{
       virtual_size: Atom.to_string(SummaryBatteries.default_size())
     }
   end


### PR DESCRIPTION
Related to https://github.com/batteries-included/batteries-included/issues/388. This allows FerretDB instances to be created as part of a database-only project. It will automatically use the project's Postgres database, and the switch will be disabled if there is no Postgres database.

<img width="934" alt="Screenshot 2024-07-16 at 17 45 11" src="https://github.com/user-attachments/assets/56bc4825-f578-4a3c-9b4c-11d30d218f3c">