### PR TITLE
chore: try to limit aws lb controller flapping

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/resources/aws_loadbalancer_controller.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/resources/aws_loadbalancer_controller.ex
@@ -9,6 +9,7 @@ defmodule CommonCore.Resources.AwsLoadBalancerController do
   import CommonCore.StateSummary.Namespaces
 
   alias CommonCore.Resources.Builder, as: B
+  alias CommonCore.Resources.FilterResource, as: F
   alias CommonCore.StateSummary.Core
 
   resource(:crd_ingress_) do
@@ -62,6 +63,7 @@ defmodule CommonCore.Resources.AwsLoadBalancerController do
 
   resource(:deployment_aws_load_balancer_controller, battery, state) do
     namespace = base_namespace(state)
+    cluster_name = Core.config_field(state, :cluster_name)
 
     template =
       %{}
@@ -98,7 +100,7 @@ defmodule CommonCore.Resources.AwsLoadBalancerController do
           },
           "containers" => [
             %{
-              "args" => ["--cluster-name=#{Core.config_field(state, :cluster_name)}", "--ingress-class=alb"],
+              "args" => ["--cluster-name=#{cluster_name}", "--ingress-class=alb"],
               "image" => battery.config.image,
               "imagePullPolicy" => "IfNotPresent",
               "livenessProbe" => %{
@@ -153,6 +155,7 @@ defmodule CommonCore.Resources.AwsLoadBalancerController do
     |> B.name(@app_name)
     |> B.namespace(namespace)
     |> B.spec(spec)
+    |> F.require_non_nil(cluster_name)
   end
 
   resource(:ingress_class_alb) do

--- a/platform_umbrella/apps/common_core/lib/common_core/resources/ferretdb.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/resources/ferretdb.ex
@@ -37,7 +37,7 @@ defmodule CommonCore.Resources.FerretDB do
     |> B.namespace(namespace)
     |> B.spec(spec)
     |> F.require_battery(state, :victoria_metrics)
-    |> F.require(state.ferret_services != [])
+    |> F.require_non_empty(state.ferret_services)
   end
 
   def service_account(%FerretService{} = ferret_service, _battery, %StateSummary{} = state) do

--- a/platform_umbrella/apps/common_core/lib/common_core/resources/resource_generator/filter_resource.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/resources/resource_generator/filter_resource.ex
@@ -50,4 +50,8 @@ defmodule CommonCore.Resources.FilterResource do
   def require(resource, boolean)
   def require(resource, true), do: resource
   def require(_, _falsey), do: nil
+
+  @spec require_non_nil(map(), term()) :: map() | nil
+  def require_non_nil(_resource, nil), do: nil
+  def require_non_nil(resource, _), do: resource
 end


### PR DESCRIPTION
Looking at #374, I checked to see if there was anything in the resources that would be inherently flappy. I didn't see anything and this shouldn't change anything but it's a bit of a belt-and-suspenders.