### PR TITLE
feat: add ability to specify backend ports

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/port.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/port.ex
@@ -1,0 +1,26 @@
+defmodule CommonCore.Port do
+  @moduledoc false
+  use CommonCore, :embedded_schema
+
+  @required_fields ~w(name port)a
+
+  @protocols [
+    tcp: :tcp,
+    udp: :udp,
+    sctp: :sctp
+  ]
+
+  batt_embedded_schema do
+    field :name, :string
+    field :port, :integer
+    field :protocol, Ecto.Enum, values: [:tcp, :udp, :sctp], default: :tcp
+  end
+
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> CommonCore.Ecto.Schema.schema_changeset(params)
+    |> downcase_fields([:name])
+  end
+
+  def protocols, do: @protocols
+end

--- a/platform_umbrella/apps/common_core/lib/common_core/tradtional_services/service.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/tradtional_services/service.ex
@@ -70,6 +70,7 @@ defmodule CommonCore.TraditionalServices.Service do
     embeds_many :containers, CommonCore.Containers.Container, on_replace: :delete
     embeds_many :init_containers, CommonCore.Containers.Container, on_replace: :delete
     embeds_many :env_values, CommonCore.Containers.EnvValue, on_replace: :delete
+    embeds_many :ports, CommonCore.Port, on_replace: :delete
 
     belongs_to :project, Project
 

--- a/platform_umbrella/apps/control_server/priv/repo/migrations/20240716045405_unify.exs
+++ b/platform_umbrella/apps/control_server/priv/repo/migrations/20240716045405_unify.exs
@@ -128,6 +128,7 @@ defmodule ControlServer.Repo.Migrations.Unify do
       add :containers, :map
       add :init_containers, :map
       add :env_values, :map
+      add :ports, :map
 
       add :kube_deployment_type, :string
       add :num_instances, :integer

--- a/platform_umbrella/apps/control_server/test/support/factory.ex
+++ b/platform_umbrella/apps/control_server/test/support/factory.ex
@@ -92,6 +92,14 @@ defmodule ControlServer.Factory do
     %CommonCore.Containers.EnvValue{name: sequence("env-value-"), value: "test", source_type: :value}
   end
 
+  def port_factory do
+    %CommonCore.Port{
+      name: sequence("port-"),
+      port: sequence(:port, [80, 443, 8080, 22, 8000]),
+      protocol: sequence(:protocol, [:tcp, :sctp, :udp])
+    }
+  end
+
   @spec knative_service_factory() :: CommonCore.Knative.Service.t()
   def knative_service_factory do
     %CommonCore.Knative.Service{

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/containers/env_value_modal.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/containers/env_value_modal.ex
@@ -65,8 +65,8 @@ defmodule ControlServerWeb.Containers.EnvValueModal do
   end
 
   @impl Phoenix.LiveComponent
-  def handle_event("cancel", _, socket) do
-    ControlServerWeb.Live.Knative.FormComponent.update_env_value(nil, nil)
+  def handle_event("cancel", _, %{assigns: %{update_func: update_func}} = socket) do
+    update_func.(nil, nil)
     {:noreply, socket}
   end
 

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/containers/hidden_forms.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/containers/hidden_forms.ex
@@ -35,4 +35,20 @@ defmodule ControlServerWeb.Containers.HiddenForms do
     </.inputs_for>
     """
   end
+
+  def ports_hidden_form(assigns) do
+    ~H"""
+    <.inputs_for :let={port} field={@field}>
+      <.single_port_hidden form={port} />
+    </.inputs_for>
+    """
+  end
+
+  def single_port_hidden(assigns) do
+    ~H"""
+    <.input type="hidden" field={@form[:name]} />
+    <.input type="hidden" field={@form[:port]} />
+    <.input type="hidden" field={@form[:protocol]} />
+    """
+  end
 end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/port_modal.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/port_modal.ex
@@ -1,0 +1,106 @@
+defmodule ControlServerWeb.PortModal do
+  @moduledoc false
+  use ControlServerWeb, :live_component
+
+  alias CommonCore.Port
+  alias Ecto.Changeset
+
+  @impl Phoenix.LiveComponent
+  def mount(socket) do
+    {:ok, socket}
+  end
+
+  @impl Phoenix.LiveComponent
+  def update(%{port: port, idx: idx, update_func: update_func, id: id} = _assigns, socket) do
+    {:ok,
+     socket
+     |> assign_id(id)
+     |> assign_idx(idx)
+     |> assign_port(port)
+     |> assign_changeset(Port.changeset(port, %{}))
+     |> assign_update_func(update_func)}
+  end
+
+  defp assign_id(socket, id) do
+    assign(socket, id: id)
+  end
+
+  defp assign_idx(socket, idx) do
+    assign(socket, idx: idx)
+  end
+
+  defp assign_update_func(socket, update_func) do
+    assign(socket, update_func: update_func)
+  end
+
+  defp assign_port(socket, port) do
+    assign(socket, port: port)
+  end
+
+  defp assign_changeset(socket, changeset) do
+    assign(socket, changeset: changeset, form: to_form(changeset))
+  end
+
+  @impl Phoenix.LiveComponent
+  def handle_event("cancel", _, %{assigns: %{update_func: update_func}} = socket) do
+    update_func.(nil, nil)
+    {:noreply, socket}
+  end
+
+  @impl Phoenix.LiveComponent
+  def handle_event("validate_port", %{"port" => params}, socket) do
+    changeset = Port.changeset(socket.assigns.port, params)
+    {:noreply, assign_changeset(socket, changeset)}
+  end
+
+  def handle_event(
+        "save_port",
+        %{"port" => params},
+        %{assigns: %{port: port, idx: idx, update_func: update_func}} = socket
+      ) do
+    changeset = Port.changeset(port, params)
+
+    if changeset.valid? do
+      new_port = Changeset.apply_changes(changeset)
+
+      update_func.(new_port, idx)
+    end
+
+    {:noreply, assign_changeset(socket, changeset)}
+  end
+
+  @impl Phoenix.LiveComponent
+  def render(assigns) do
+    ~H"""
+    <div>
+      <.form
+        for={@form}
+        id="port-form"
+        phx-change="validate_port"
+        phx-submit="save_port"
+        phx-target={@myself}
+      >
+        <.modal show size="lg" id={"#{@id}-modal"} on_cancel={JS.push("cancel", target: @myself)}>
+          <:title>Port</:title>
+
+          <.flex column>
+            <.input label="Name" field={@form[:name]} autofocus placeholder="http" />
+            <.input label="Port" field={@form[:port]} autofocus placeholder="8080" />
+            <.input
+              field={@form[:Protocol]}
+              type="select"
+              label="Protocol"
+              placeholder="tcp"
+              options={Port.protocols()}
+            />
+          </.flex>
+
+          <:actions cancel="Cancel">
+            <.button variant="primary" type="submit" phx-disable-with="Saving...">Save</.button>
+          </:actions>
+        </.modal>
+      </.form>
+    </div>
+    """
+  end
+end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/ports_panel.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/ports_panel.ex
@@ -1,0 +1,78 @@
+defmodule ControlServerWeb.PortPanel do
+  @moduledoc false
+  use ControlServerWeb, :html
+
+  # defp env_value_value(%{env_value: %{source_type: :value}} = assigns) do
+  #   ~H"""
+  #   <%= @env_value.value %>
+  #   """
+  # end
+  #
+  # defp env_value_value(%{env_value: %{source_type: _}} = assigns) do
+  #   ~H"""
+  #   <.truncate_tooltip value={"From #{@env_value.source_name}"} />
+  #   """
+  # end
+
+  attr :class, :any, default: nil
+  attr :editable, :boolean, default: false
+  attr :ports, :list, default: []
+  attr :target, :any, default: nil
+
+  def port_panel(%{editable: false} = assigns) do
+    ~H"""
+    <.panel title="Ports" class={@class}>
+      <.table rows={@ports}>
+        <:col :let={p} label="Name"><%= p.name %></:col>
+        <:col :let={p} label="Port"><%= p.port %></:col>
+        <:col :let={p} label="Protocol"><%= p.protocol %></:col>
+      </.table>
+    </.panel>
+    """
+  end
+
+  def port_panel(%{editable: true} = assigns) do
+    ~H"""
+    <.panel title="Ports" class={@class}>
+      <:menu>
+        <.button icon={:plus} phx-click="new_port" phx-target={@target}>
+          Add Port
+        </.button>
+      </:menu>
+
+      <.table rows={Enum.with_index(@ports)}>
+        <:col :let={{p, _idx}} label="Name"><%= p.name %></:col>
+        <:col :let={{p, _idx}} label="Port"><%= p.port %></:col>
+        <:col :let={{p, _idx}} label="Protocol"><%= p.protocol %></:col>
+        <:action :let={{p, idx}}>
+          <.button
+            variant="minimal"
+            icon={:x_mark}
+            id={"delete_port_" <> String.replace(p.name, " ", "")}
+            phx-click="del:port"
+            phx-value-idx={idx}
+            phx-target={@target}
+          />
+
+          <.tooltip target_id={"delete_port_" <> String.replace(p.name, " ", "")}>
+            Remove
+          </.tooltip>
+
+          <.button
+            variant="minimal"
+            icon={:pencil}
+            id={"edit_port_" <> String.replace(p.name, " ", "")}
+            phx-click="edit:port"
+            phx-value-idx={idx}
+            phx-target={@target}
+          />
+
+          <.tooltip target_id={"edit_port_" <> String.replace(p.name, " ", "")}>
+            Edit
+          </.tooltip>
+        </:action>
+      </.table>
+    </.panel>
+    """
+  end
+end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/backend/show.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/backend/show.ex
@@ -3,6 +3,7 @@ defmodule ControlServerWeb.Live.TraditionalServicesShow do
   use ControlServerWeb, {:live_view, layout: :sidebar}
 
   import ControlServerWeb.Containers.EnvValuePanel
+  import ControlServerWeb.PortPanel
   import KubeServices.SystemState.SummaryHosts
 
   alias CommonCore.TraditionalServices.Service
@@ -77,7 +78,8 @@ defmodule ControlServerWeb.Live.TraditionalServicesShow do
         <.a variant="bordered" href={service_url(@service)}>Running Service</.a>
       </.flex>
 
-      <.env_var_panel env_values={@service.env_values} class="lg:col-span-2" />
+      <.env_var_panel env_values={@service.env_values} class="lg:col-span-1" />
+      <.port_panel ports={@service.ports} class="lg:col-span-1" />
     </.grid>
     """
   end

--- a/platform_umbrella/apps/control_server_web/test/unit/live/traditional_services/traditional_services_new_live_test.exs
+++ b/platform_umbrella/apps/control_server_web/test/unit/live/traditional_services/traditional_services_new_live_test.exs
@@ -7,9 +7,10 @@ defmodule ControlServerWeb.TraditionalServicesNewLiveTest do
   describe "new" do
     test "can insert good params", %{conn: conn} do
       # There are only hidden inputs for these fields
-      params = :backend_service |> params_for() |> Map.drop(~w(containers init_containers env_values)a)
+      params = :backend_service |> params_for() |> Map.drop(~w(containers init_containers env_values ports)a)
       container = :containers_container |> params_for() |> Map.drop(~w(env_values)a)
       env_value = :containers_env_value |> params_for() |> Map.drop(~w(source_optional)a)
+      port = :port |> params_for() |> Map.drop(~w(protocol)a)
 
       conn
       |> start(~p|/traditional_services/new|)
@@ -19,6 +20,8 @@ defmodule ControlServerWeb.TraditionalServicesNewLiveTest do
       |> submit_form("#container-form", container: container)
       |> click("button", "Add Variable")
       |> submit_form("#env_value-form", env_value: env_value)
+      |> click("button", "Add Port")
+      |> submit_form("#port-form", port: port)
       |> submit_form("#backend-service-form", service: params)
       |> follow()
       |> assert_html(params.name)


### PR DESCRIPTION
part of #31 

This is just the UI and schema additions. Actually creating service resources will come in a quick follow up.