### PR TITLE
Changes to web project form

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/tradtional_services/service.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/tradtional_services/service.ex
@@ -56,6 +56,7 @@ defmodule CommonCore.TraditionalServices.Service do
   batt_schema "traditional_services" do
     slug_field :name
 
+    field :kube_internal, :boolean, default: false
     field :kube_deployment_type, Ecto.Enum, values: [:statefulset, :deployment], default: :deployment
     field :num_instances, :integer, default: 1
 

--- a/platform_umbrella/apps/control_server/priv/repo/migrations/20240716045405_unify.exs
+++ b/platform_umbrella/apps/control_server/priv/repo/migrations/20240716045405_unify.exs
@@ -130,6 +130,7 @@ defmodule ControlServer.Repo.Migrations.Unify do
       add :env_values, :map
       add :ports, :map
 
+      add :kube_internal, :boolean
       add :kube_deployment_type, :string
       add :num_instances, :integer
 

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/knative/form_subcomponents.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/knative/form_subcomponents.ex
@@ -16,6 +16,11 @@ defmodule ControlServerWeb.KnativeFormSubcomponents do
       <.flex column>
         <.input label="Name" field={@form[:name]} autofocus placeholder="Name" />
         <.input label="URL" name="url" value={potential_url(@form)} disabled />
+
+        <.input field={@form[:kube_internal]} type="radio">
+          <:option value="true">Internal</:option>
+          <:option value="false">External</:option>
+        </.input>
       </.flex>
     </div>
     """

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/traditional_services/form_subcomponents.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/traditional_services/form_subcomponents.ex
@@ -6,6 +6,7 @@ defmodule ControlServerWeb.TraditionalFormSubcomponents do
   alias CommonCore.Util.Memory
 
   attr :class, :any, default: nil
+  attr :with_divider, :boolean, default: true
   attr :form, Phoenix.HTML.Form, required: true
 
   def main_panel(assigns) do
@@ -32,12 +33,20 @@ defmodule ControlServerWeb.TraditionalFormSubcomponents do
         ]}
       />
 
-      <.flex class="justify-between w-full py-3 border-t border-gray-lighter dark:border-gray-darker" />
+      <.flex
+        :if={@with_divider}
+        class="justify-between w-full py-3 border-t border-gray-lighter dark:border-gray-darker"
+      />
 
       <.grid columns={[sm: 1, lg: 2]} class="items-center">
         <.h5>Number of instances</.h5>
         <.input field={@form[:num_instances]} type="range" min="1" max="5" step="1" />
       </.grid>
+
+      <.input field={@form[:kube_internal]} type="radio" class="mt-4">
+        <:option value="true">Internal</:option>
+        <:option value="false">External</:option>
+      </.input>
     </div>
     """
   end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/projects/show.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/projects/show.ex
@@ -193,7 +193,7 @@ defmodule ControlServerWeb.Projects.ShowLive do
         </.data_list>
       </.panel>
 
-      <div>
+      <div :if={@grafana_dashboard_url}>
         <.a :if={@grafana_dashboard_url} variant="bordered" href={@grafana_dashboard_url}>
           Grafana Dashboard
         </.a>


### PR DESCRIPTION
This changes the form for new web projects to make Knative vs. Traditional Service the primary focus. It also makes the database optional, and sets `DATABASE_URL` and `REDIS_URL` for the new service if those are enabled. Related to https://github.com/batteries-included/batteries-included/issues/388.

## Other Changes

- Add `kube_internal` flag to traditional services (needs to be implemented, see https://github.com/batteries-included/batteries-included/issues/445)
- Move internal/external radio buttons to knative/traditional service forms
- Hide project links section if there are no links

---

<img width="986" alt="Screenshot 2024-07-18 at 14 36 40" src="https://github.com/user-attachments/assets/3848609b-2e43-4264-9c6e-2a25f3ee3bcf">
