### PR TITLE
feat(traditional): expose services publicly

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/state_summary/batteries.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/state_summary/batteries.ex
@@ -7,7 +7,7 @@ defmodule CommonCore.StateSummary.Batteries do
   alias CommonCore.StateSummary.Hosts
 
   @doc """
-  Generate a list of tuple mappings of battery type to host.
+  Generate a map of battery type to host.
 
   Filters out any types that don't have a host.
   """
@@ -20,7 +20,7 @@ defmodule CommonCore.StateSummary.Batteries do
   end
 
   @doc """
-  Generate a list of tuple mappings of battery type to host.
+  Generate a map of battery type to host.
 
   Includes battery types with nil host.
   """

--- a/platform_umbrella/apps/common_core/lib/common_core/state_summary/traditional_services.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/state_summary/traditional_services.ex
@@ -1,0 +1,28 @@
+defmodule CommonCore.StateSummary.TraditionalServices do
+  @moduledoc """
+    Utilities for manipulating and querying traditional service information from a state summary.
+  """
+  alias CommonCore.Port
+  alias CommonCore.StateSummary
+  alias CommonCore.StateSummary.Hosts
+  alias CommonCore.TraditionalServices.Service
+
+  def hosts_and_ports_by_name(%StateSummary{traditional_services: services} = state) do
+    Map.new(services, &host_and_ports_for_service(state, &1))
+  end
+
+  def external_hosts_and_ports_by_name(%StateSummary{traditional_services: services} = state) do
+    services
+    |> Enum.reject(&internal_or_portless/1)
+    |> Map.new(&host_and_ports_for_service(state, &1))
+  end
+
+  @spec host_and_ports_for_service(StateSummary.t(), Service.t()) :: {String.t(), list(Port.t())} | nil
+  defp host_and_ports_for_service(_state, %{ports: []} = _svc), do: nil
+  defp host_and_ports_for_service(state, %{ports: ports} = svc), do: {Hosts.traditional_host(state, svc), ports}
+
+  defp internal_or_portless(%{kube_internal: true}), do: true
+  defp internal_or_portless(%{ports: []}), do: true
+  defp internal_or_portless(%{ports: nil}), do: true
+  defp internal_or_portless(_), do: false
+end


### PR DESCRIPTION
closes #445 
part of: #31 

There's still a couple of follow ups to add SSL and oauth proxy support but those should be pretty straightforward at this point.

Test plan:
- [x] create external service with port(s) - it is accessible
- [x] create external service w/o port - isn't exposed
- [x] create internal service with ports - created and running w/ svc but no virtual svc
- [x] create internal service w/o port - created and running, no svc, no vs