### PR TITLE
feat: start applying actions when keycloak starts

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/actions/battery_core.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/actions/battery_core.ex
@@ -3,9 +3,44 @@ defmodule CommonCore.Actions.BatteryCore do
 
   use CommonCore.Actions.SSOClient, client_name: "battery_core"
 
+  alias CommonCore.Actions.FreshGeneratedAction
+  alias CommonCore.Batteries.SystemBattery
+  alias CommonCore.StateSummary
+  alias CommonCore.StateSummary.KeycloakSummary
+
   @impl ClientConfigurator
   def configure(_battery, _state, client) do
     opts = [baseUrl: nil, redirectUris: ["*"], webOrigins: []]
     {struct!(client, opts), Keyword.keys(opts)}
+  end
+
+  @spec materialize(SystemBattery.t(), StateSummary.t()) :: list(FreshGeneratedAction.t() | nil)
+  def materialize(%SystemBattery{} = _system_battery, %StateSummary{} = state_summary) do
+    [ensure_core_realm(state_summary)]
+  end
+
+  defp ensure_core_realm(%StateSummary{keycloak_state: key_state} = _state_summary) do
+    realm_name = CommonCore.Defaults.Keycloak.realm_name()
+    # No action needed if the realm already exists
+    if KeycloakSummary.realm_member?(key_state, realm_name) do
+      nil
+    else
+      %FreshGeneratedAction{
+        action: :create,
+        type: :realm,
+        realm: nil,
+        # Keycloak RealmRepresentation
+        value: %{
+          # The realm name is an identifier for the realm and cannot be changed.
+          realm: realm_name,
+          # The display name for the realm.
+          displayName: "Batteries Included",
+          # Allows users to click the remember me checkbox.
+          rememberMe: true,
+          social: false,
+          enabled: true
+        }
+      }
+    end
   end
 end

--- a/platform_umbrella/apps/common_core/lib/common_core/actions/fresh_action.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/actions/fresh_action.ex
@@ -10,7 +10,7 @@ defmodule CommonCore.Actions.FreshGeneratedAction do
   These are transitory and will be re-created at will.
   """
   typedstruct do
-    # create, delete
+    # create, delete, ping
     field :action, atom()
 
     # Realm, client, user

--- a/platform_umbrella/apps/common_core/lib/common_core/actions/sso.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/actions/sso.ex
@@ -5,36 +5,10 @@ defmodule CommonCore.Actions.SSO do
   alias CommonCore.Actions.FreshGeneratedAction
   alias CommonCore.Batteries.SystemBattery
   alias CommonCore.StateSummary
-  alias CommonCore.StateSummary.KeycloakSummary
 
   @spec materialize(SystemBattery.t(), StateSummary.t()) :: list(FreshGeneratedAction.t() | nil)
-  def materialize(%SystemBattery{} = _system_battery, %StateSummary{} = state_summary) do
-    [ping(), ensure_core_realm(state_summary)]
-  end
-
-  defp ensure_core_realm(%StateSummary{keycloak_state: key_state} = _state_summary) do
-    realm_name = CommonCore.Defaults.Keycloak.realm_name()
-    # No action needed if the realm already exists
-    if KeycloakSummary.realm_member?(key_state, realm_name) do
-      nil
-    else
-      %FreshGeneratedAction{
-        action: :create,
-        type: :realm,
-        realm: nil,
-        # Keycloak RealmRepresentation
-        value: %{
-          # The realm name is an identifier for the realm and cannot be changed.
-          realm: realm_name,
-          # The display name for the realm.
-          displayName: "Batteries Included",
-          # Allows users to click the remember me checkbox.
-          rememberMe: true,
-          social: false,
-          enabled: true
-        }
-      }
-    end
+  def materialize(%SystemBattery{} = _system_battery, %StateSummary{} = _state_summary) do
+    [ping()]
   end
 
   defp ping, do: %FreshGeneratedAction{action: :ping, type: :realm, value: %{}}

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/net_sec.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/net_sec.ex
@@ -67,7 +67,7 @@ defmodule ControlServerWeb.Live.NetSecHome do
     assign(socket, page_title: socket.assigns.catalog_group.name)
   end
 
-  defp sso_panel(assigns) do
+  defp keycloak_panel(assigns) do
     ~H"""
     <.panel title="Realms">
       <:menu>
@@ -143,8 +143,8 @@ defmodule ControlServerWeb.Live.NetSecHome do
     <.grid :if={@batteries && @batteries != []} columns={%{sm: 1, lg: 2}} class="w-full">
       <%= for battery <- @batteries do %>
         <%= case battery.type do %>
-          <% :sso -> %>
-            <.sso_panel realms={@keycloak_realms} keycloak_url={@keycloak_url} />
+          <% :keycloak -> %>
+            <.keycloak_panel realms={@keycloak_realms} keycloak_url={@keycloak_url} />
           <% :metallb -> %>
             <.metallb_panel ip_address_pools={@ip_address_pools} />
           <% :trivy_operator -> %>

--- a/platform_umbrella/apps/kube_services/lib/kube_services/batteries/keycloak.ex
+++ b/platform_umbrella/apps/kube_services/lib/kube_services/batteries/keycloak.ex
@@ -15,7 +15,11 @@ defmodule KubeServices.Batteries.Keycloak do
       # Start the AdminClient
       AdminClientSupervisor,
       # After we know the admin client is up and running, start the user manager
-      KubeServices.Keycloak.UserManager
+      KubeServices.Keycloak.UserManager,
+      KubeServices.SnapshotApply.KeycloakApply,
+      # A genserver the watches for failed Keycloak applys.
+      # Starting a new attempt with increasing delays.
+      {KubeServices.SnapshotApply.FailedKeycloakLauncher, max_delay: 91_237}
     ]
 
     Supervisor.init(children, strategy: :one_for_all)

--- a/platform_umbrella/apps/kube_services/lib/kube_services/batteries/sso.ex
+++ b/platform_umbrella/apps/kube_services/lib/kube_services/batteries/sso.ex
@@ -8,11 +8,7 @@ defmodule KubeServices.Batteries.SSO do
     _battery = Keyword.fetch!(opts, :battery)
 
     children = [
-      KubeServices.SnapshotApply.KeycloakApply,
-      KubeServices.Keycloak.OIDCSupervisor,
-      # A genserver the watches for failed Keycloak applys.
-      # Starting a new attempt with increasing delays.
-      {KubeServices.SnapshotApply.FailedKeycloakLauncher, max_delay: 91_237}
+      KubeServices.Keycloak.OIDCSupervisor
     ]
 
     Supervisor.init(children, strategy: :one_for_one)

--- a/platform_umbrella/apps/kube_services/lib/kube_services/snapshot_apply/worker.ex
+++ b/platform_umbrella/apps/kube_services/lib/kube_services/snapshot_apply/worker.ex
@@ -14,10 +14,10 @@ defmodule KubeServices.SnapshotApply.Worker do
   require Logger
 
   @me __MODULE__
-  @state_opts [:sso_enabled, :running]
+  @state_opts [:keycloak_enabled, :running]
 
   typedstruct module: State do
-    field :sso_enabled, boolean(), default: false
+    field :keycloak_enabled, boolean(), default: false
     field :running, boolean(), default: true
     field :init_delay, non_neg_integer(), default: 5_000
     field :delay, non_neg_integer(), default: 300_000
@@ -27,7 +27,7 @@ defmodule KubeServices.SnapshotApply.Worker do
     {state_opts, opts} =
       opts
       |> Keyword.put_new(:name, @me)
-      |> Keyword.put_new(:sso_enabled, Batteries.battery_enabled?(:sso))
+      |> Keyword.put_new(:keycloak_enabled, Batteries.battery_enabled?(:keycloak))
       |> Keyword.split(@state_opts)
 
     GenServer.start_link(__MODULE__, state_opts, opts)
@@ -60,10 +60,6 @@ defmodule KubeServices.SnapshotApply.Worker do
     _e, _r -> false
   end
 
-  def set_sso_enabled(target \\ @me, running) do
-    GenServer.call(target, {:set_sso_enabled, running})
-  end
-
   @doc """
   Handle the background message sent through `Process.send_after()` for periodic
   """
@@ -83,10 +79,6 @@ defmodule KubeServices.SnapshotApply.Worker do
 
   def handle_call({:set_running, running}, _from, %State{running: was_running} = state) do
     {:reply, was_running, %State{state | running: running}}
-  end
-
-  def handle_call({:set_sso_enabled, running}, _from, %State{sso_enabled: was_running} = state) do
-    {:reply, was_running, %State{state | sso_enabled: running}}
   end
 
   def handle_cast({:perform, umbrella_snapshot}, %State{} = state) do
@@ -135,8 +127,8 @@ defmodule KubeServices.SnapshotApply.Worker do
 
   # Prepare
   defp kube_prepare(us, _state), do: KubeApply.prepare(us)
-  defp keycloak_prepare(_us, %State{sso_enabled: false}), do: {:ok, nil}
-  defp keycloak_prepare(us, %State{sso_enabled: true}), do: KeycloakApply.prepare(us)
+  defp keycloak_prepare(_us, %State{keycloak_enabled: false}), do: {:ok, nil}
+  defp keycloak_prepare(us, %State{keycloak_enabled: true}), do: KeycloakApply.prepare(us)
 
   # Generate
   defp summary(_state), do: Summarizer.new()


### PR DESCRIPTION
Summary:
This PR starts most of the things that SSO was starting but when
keycloak starts. That allows users to start keycloak. Then add a user
to the needed realm and then continue on.

Test Plan:
Deployed it locally.
![image](https://github.com/user-attachments/assets/a64f4096-c262-48f1-a5de-90f2b39a45bc)

