### PR TITLE
chore: remove sso/oauth from installation

### DIFF
--- a/platform_umbrella/apps/common_core/test/support/factory.ex
+++ b/platform_umbrella/apps/common_core/test/support/factory.ex
@@ -71,7 +71,6 @@ defmodule CommonCore.Factory do
       kube_provider: kube_provider,
       kube_provider_config: kube_provider_config,
       usage: usage,
-      initial_oauth_email: nil,
       control_jwk: control_jwk,
       user_id: user_id,
       default_size: sequence(:default_size, [:tiny, :small, :medium, :large, :xlarge, :huge])

--- a/platform_umbrella/apps/home_base/priv/repo/migrations/20221129015006_create_installations.exs
+++ b/platform_umbrella/apps/home_base/priv/repo/migrations/20221129015006_create_installations.exs
@@ -11,10 +11,6 @@ defmodule HomeBase.Repo.Migrations.CreateInstallations do
       add :kube_provider, :string
       add :kube_provider_config, :map
 
-      # Fields for SSO
-      add :sso_enabled, :boolean
-      add :initial_oauth_email, :string
-
       # Default size for the installation
       add :default_size, :string
 

--- a/platform_umbrella/apps/home_base_web/lib/home_base_web/live/installation/new_live.ex
+++ b/platform_umbrella/apps/home_base_web/lib/home_base_web/live/installation/new_live.ex
@@ -86,14 +86,6 @@ defmodule HomeBaseWeb.InstallationNewLive do
             label="Default Size"
             options={Installation.size_options()}
           />
-
-          <.input field={@form[:sso_enabled]} type="switch" label="Use Single Sign On" />
-
-          <.input
-            :if={normalize_value("checkbox", @form[:sso_enabled].value)}
-            field={@form[:initial_oauth_email]}
-            placeholder="Initial OAuth Email"
-          />
         </.panel>
       </.grid>
     </.form>

--- a/platform_umbrella/apps/home_base_web/lib/home_base_web/live/installation/show_live.ex
+++ b/platform_umbrella/apps/home_base_web/lib/home_base_web/live/installation/show_live.ex
@@ -113,14 +113,6 @@ defmodule HomeBaseWeb.InstallationShowLive do
           options={Installation.size_options()}
         />
 
-        <.input field={@form[:sso_enabled]} type="switch" label="Use Single Sign On" />
-
-        <.input
-          :if={normalize_value("checkbox", @form[:sso_enabled].value)}
-          field={@form[:initial_oauth_email]}
-          placeholder="Initial OAuth Email"
-        />
-
         <:actions>
           <.button variant="primary" type="submit">Save</.button>
         </:actions>


### PR DESCRIPTION
Summary:
For launch we'll require people to start the sso themselves. So clean up
the UI

Test Plan:
Tests changed
