### PR TITLE
Fixes modal form validation for containers, env values, and ports

### DIFF
--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/containers/container_modal.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/containers/container_modal.ex
@@ -58,7 +58,11 @@ defmodule ControlServerWeb.Containers.ContainerModal do
 
   @impl Phoenix.LiveComponent
   def handle_event("validate_container", %{"container" => params}, socket) do
-    changeset = Container.changeset(socket.assigns.container, params)
+    changeset =
+      socket.assigns.container
+      |> Container.changeset(params)
+      |> Map.put(:action, :validate)
+
     {:noreply, assign_changeset(socket, changeset)}
   end
 
@@ -69,7 +73,10 @@ defmodule ControlServerWeb.Containers.ContainerModal do
         %{assigns: %{container: container, idx: idx, container_field_name: cfn, update_func: update_func}} = socket
       ) do
     # Create a new changeset for the container
-    changeset = Container.changeset(container, params)
+    changeset =
+      container
+      |> Container.changeset(params)
+      |> Map.put(:action, :validate)
 
     if changeset.valid? do
       # Get the resulting container from the changeset

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/containers/env_value_modal.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/containers/env_value_modal.ex
@@ -72,7 +72,11 @@ defmodule ControlServerWeb.Containers.EnvValueModal do
 
   @impl Phoenix.LiveComponent
   def handle_event("validate_env_value", %{"env_value" => params}, socket) do
-    changeset = EnvValue.changeset(socket.assigns.env_value, params)
+    changeset =
+      socket.assigns.env_value
+      |> EnvValue.changeset(params)
+      |> Map.put(:action, :validate)
+
     {:noreply, assign_changeset(socket, changeset)}
   end
 
@@ -86,7 +90,10 @@ defmodule ControlServerWeb.Containers.EnvValueModal do
         %{"env_value" => params},
         %{assigns: %{env_value: env_value, idx: idx, update_func: update_func}} = socket
       ) do
-    changeset = EnvValue.changeset(env_value, params)
+    changeset =
+      env_value
+      |> EnvValue.changeset(params)
+      |> Map.put(:action, :validate)
 
     if changeset.valid? do
       new_env_value = Changeset.apply_changes(changeset)

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/knative/form_component.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/knative/form_component.ex
@@ -174,7 +174,6 @@ defmodule ControlServerWeb.Live.Knative.FormComponent do
     {idx, _} = Integer.parse(idx_string)
 
     env_values = Changeset.get_field(changeset, :env_values, [])
-
     env_value = Enum.fetch!(env_values, idx)
 
     {:noreply, socket |> assign_env_value(env_value) |> assign_env_value_idx(idx)}
@@ -183,9 +182,7 @@ defmodule ControlServerWeb.Live.Knative.FormComponent do
   def handle_event("del:env_value", %{"idx" => env_value_idx}, %{assigns: %{changeset: changeset}} = socket) do
     {idx, ""} = Integer.parse(env_value_idx)
 
-    env_values =
-      changeset |> Changeset.get_field(:env_values, []) |> List.delete_at(idx)
-
+    env_values = changeset |> Changeset.get_field(:env_values, []) |> List.delete_at(idx)
     new_changeset = Changeset.put_embed(changeset, :env_values, env_values)
 
     {:noreply, assign_changeset(socket, new_changeset)}

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/port_modal.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/port_modal.ex
@@ -49,7 +49,11 @@ defmodule ControlServerWeb.PortModal do
 
   @impl Phoenix.LiveComponent
   def handle_event("validate_port", %{"port" => params}, socket) do
-    changeset = Port.changeset(socket.assigns.port, params)
+    changeset =
+      socket.assigns.port
+      |> Port.changeset(params)
+      |> Map.put(:action, :validate)
+
     {:noreply, assign_changeset(socket, changeset)}
   end
 
@@ -58,7 +62,10 @@ defmodule ControlServerWeb.PortModal do
         %{"port" => params},
         %{assigns: %{port: port, idx: idx, update_func: update_func}} = socket
       ) do
-    changeset = Port.changeset(port, params)
+    changeset =
+      port
+      |> Port.changeset(params)
+      |> Map.put(:action, :validate)
 
     if changeset.valid? do
       new_port = Changeset.apply_changes(changeset)
@@ -84,13 +91,12 @@ defmodule ControlServerWeb.PortModal do
           <:title>Port</:title>
 
           <.flex column>
-            <.input label="Name" field={@form[:name]} autofocus placeholder="http" />
-            <.input label="Number " field={@form[:number]} autofocus placeholder="8080" />
+            <.input label="Name" field={@form[:name]} autofocus />
+            <.input label="Port" field={@form[:number]} />
             <.input
-              field={@form[:Protocol]}
+              field={@form[:protocol]}
               type="select"
               label="Protocol"
-              placeholder="HTTP2"
               options={Port.protocols()}
             />
           </.flex>

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/ports_panel.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/ports_panel.ex
@@ -24,7 +24,7 @@ defmodule ControlServerWeb.PortPanel do
     <.panel title="Ports" class={@class}>
       <.table rows={@ports}>
         <:col :let={p} label="Name"><%= p.name %></:col>
-        <:col :let={p} label="Number"><%= p.number %></:col>
+        <:col :let={p} label="Port"><%= p.number %></:col>
         <:col :let={p} label="Protocol"><%= p.protocol %></:col>
       </.table>
     </.panel>

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/traditional_services/form_component.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/traditional_services/form_component.ex
@@ -137,8 +137,44 @@ defmodule ControlServerWeb.Live.TraditionalServices.FormComponent do
     {:noreply, socket |> assign_env_value(new_env_var) |> assign_env_value_idx(nil)}
   end
 
+  def handle_event("edit:env_value", %{"idx" => idx_string}, %{assigns: %{changeset: changeset}} = socket) do
+    {idx, _} = Integer.parse(idx_string)
+
+    env_values = Changeset.get_field(changeset, :env_values, [])
+    env_value = Enum.fetch!(env_values, idx)
+
+    {:noreply, socket |> assign_env_value(env_value) |> assign_env_value_idx(idx)}
+  end
+
+  def handle_event("del:env_value", %{"idx" => env_value_idx}, %{assigns: %{changeset: changeset}} = socket) do
+    {idx, ""} = Integer.parse(env_value_idx)
+
+    env_values = changeset |> Changeset.get_field(:env_values, []) |> List.delete_at(idx)
+    new_changeset = Changeset.put_embed(changeset, :env_values, env_values)
+
+    {:noreply, assign_changeset(socket, new_changeset)}
+  end
+
   def handle_event("new_port", _, socket) do
     {:noreply, socket |> assign_port(%Port{}) |> assign_port_idx(nil)}
+  end
+
+  def handle_event("edit:port", %{"idx" => idx_string}, %{assigns: %{changeset: changeset}} = socket) do
+    {idx, _} = Integer.parse(idx_string)
+
+    ports = Changeset.get_field(changeset, :ports, [])
+    port = Enum.fetch!(ports, idx)
+
+    {:noreply, socket |> assign_port(port) |> assign_port_idx(idx)}
+  end
+
+  def handle_event("del:port", %{"idx" => idx_string}, %{assigns: %{changeset: changeset}} = socket) do
+    {idx, ""} = Integer.parse(idx_string)
+
+    ports = changeset |> Changeset.get_field(:ports, []) |> List.delete_at(idx)
+    new_changeset = Changeset.put_embed(changeset, :ports, ports)
+
+    {:noreply, assign_changeset(socket, new_changeset)}
   end
 
   def handle_event("new_container", %{"id" => "containers_panel-" <> cfn}, socket) do


### PR DESCRIPTION
Fixes #416 along with env values and ports in traditional services.