### PR TITLE
fix(home-base): allow service to start

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/resources/istio/istio_ingress.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/resources/istio/istio_ingress.ex
@@ -434,10 +434,20 @@ defmodule CommonCore.Resources.IstioIngress do
     %{port: %{number: port.number, name: port.name, protocol: "TCP"}, hosts: hosts}
   end
 
-  defp build_server_for_traditional_service_port(hosts, port, false = _ssl_enabled?) do
+  defp build_server_for_traditional_service_port(hosts, %{protocol: protocol} = port, false = _ssl_enabled?)
+       when protocol in [:http, :http2] do
     %{
-      port: %{number: port.number, name: port.name, protocol: String.upcase(Atom.to_string(port.protocol))},
+      port: %{number: 80, name: port.name, protocol: normalize_protocol(port.protocol)},
       hosts: hosts
     }
   end
+
+  defp build_server_for_traditional_service_port(hosts, port, false = _ssl_enabled?) do
+    %{
+      port: %{number: port.number, name: port.name, protocol: normalize_protocol(port.protocol)},
+      hosts: hosts
+    }
+  end
+
+  defp normalize_protocol(proto), do: String.upcase(Atom.to_string(proto))
 end

--- a/platform_umbrella/apps/control_server_web/config/runtime.exs
+++ b/platform_umbrella/apps/control_server_web/config/runtime.exs
@@ -34,15 +34,15 @@ secret_key_base =
     """
 
 config :control_server, ControlServer.Repo,
-  ssl: true,
-  username: postgres_username,
-  password: postgres_password,
   database: postgres_database,
   hostname: postgres_host,
-  port: String.to_integer(System.get_env("POSTGRES_PORT") || "5432"),
+  log: false,
+  password: postgres_password,
   pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
+  port: String.to_integer(System.get_env("POSTGRES_PORT") || "5432"),
+  ssl: true,
   ssl_opts: [verify: :verify_none],
-  log: false
+  username: postgres_username
 
 config :control_server_web, ControlServerWeb.Endpoint,
   adapter: Bandit.PhoenixAdapter,

--- a/platform_umbrella/apps/home_base_web/config/runtime.exs
+++ b/platform_umbrella/apps/home_base_web/config/runtime.exs
@@ -1,7 +1,5 @@
 import Config
 
-web_host = System.get_env("WEB_HOST", "anton2")
-web_port = System.get_env("WEB_PORT", "8081")
 port = System.get_env("PORT", "4000")
 
 postgres_username =
@@ -36,19 +34,19 @@ secret_key_base =
     """
 
 config :home_base, HomeBase.Repo,
-  ssl: true,
-  username: postgres_username,
-  password: postgres_password,
   database: postgres_database,
   hostname: postgres_host,
+  log: false,
+  password: postgres_password,
+  pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
   port: String.to_integer(System.get_env("POSTGRES_PORT") || "5432"),
-  pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10")
+  ssl: true,
+  ssl_opts: [verify: :verify_none],
+  username: postgres_username
 
 config :home_base_web, HomeBaseWeb.Endpoint,
   http: [
-    port: String.to_integer(port),
-    # url: [host: web_host, port: String.to_integer(web_port)],
-    transport_options: [socket_opts: [:inet6]]
+    port: String.to_integer(port)
   ],
   check_origin: false,
   secret_key_base: secret_key_base,


### PR DESCRIPTION
I can create a traditional service with the home-base image and a pg database and this is sufficient to get it to start. There will be additional changes necessary to bootstrap / seed but this is sufficient to get it running.