### PR TITLE
Add pagination for all remaining resources

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/audit/edit_version.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/audit/edit_version.ex
@@ -5,6 +5,19 @@ defmodule CommonCore.Audit.EditVersion do
 
   import Ecto.Changeset
 
+  @derive [
+    {Jason.Encoder, except: [:__meta__]},
+    {
+      Flop.Schema,
+      filterable: [],
+      sortable: [:entity_id, :entity_schema, :action, :rollback, :recorded_at],
+      default_order: %{
+        order_by: [:recorded_at],
+        order_directions: [:desc]
+      }
+    }
+  ]
+
   # We can't use the standard CommonCore schema
   # because EditVersions are inserted via a backround
   # tranasacion. That transaction relies on the :binary_id
@@ -12,8 +25,6 @@ defmodule CommonCore.Audit.EditVersion do
   # to the database adapter for generation)
   @primary_key {:id, :binary_id, autogenerate: true}
   @timestamps_opts [type: :utc_datetime_usec]
-
-  @derive {Jason.Encoder, except: [:__meta__]}
 
   @optional_fields ~w(rollback)a
   @required_fields ~w(patch entity_id entity_schema action recorded_at)a

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/system_battery.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/system_battery.ex
@@ -38,6 +38,17 @@ defmodule CommonCore.Batteries.SystemBattery do
   alias CommonCore.Batteries.VMOperatorConfig
   alias CommonCore.Ecto.PolymorphicType
 
+  @derive {
+    Flop.Schema,
+    filterable: [],
+    sortable: [:type, :group, :inserted_at, :updated_at],
+    default_limit: 5,
+    default_order: %{
+      order_by: [:updated_at],
+      order_directions: [:desc]
+    }
+  }
+
   @possible_types [
     aws_load_balancer_controller: AwsLoadBalancerControllerConfig,
     traditional_services: TraditionalServicesConfig,

--- a/platform_umbrella/apps/common_core/lib/common_core/ferretdb/ferret_service.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/ferretdb/ferret_service.ex
@@ -6,6 +6,11 @@ defmodule CommonCore.FerretDB.FerretService do
   alias CommonCore.Projects.Project
   alias CommonCore.Util.Memory
 
+  @derive {
+    Flop.Schema,
+    filterable: [:name], sortable: [:id, :name, :instances]
+  }
+
   @required_fields ~w(instances postgres_cluster_id)a
 
   @presets [

--- a/platform_umbrella/apps/common_core/lib/common_core/knative/service.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/knative/service.ex
@@ -5,6 +5,11 @@ defmodule CommonCore.Knative.Service do
 
   alias CommonCore.Projects.Project
 
+  @derive {
+    Flop.Schema,
+    filterable: [:name], sortable: [:id, :name, :rollout_duration]
+  }
+
   @required_fields ~w(name)a
 
   batt_schema "knative_services" do

--- a/platform_umbrella/apps/common_core/lib/common_core/metal_lb/ip_address_pool.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/metal_lb/ip_address_pool.ex
@@ -3,6 +3,11 @@ defmodule CommonCore.MetalLB.IPAddressPool do
 
   use CommonCore, :schema
 
+  @derive {
+    Flop.Schema,
+    filterable: [:name], sortable: [:id, :name, :subnet]
+  }
+
   @required_fields [:name, :subnet]
 
   batt_schema "ip_address_pools" do

--- a/platform_umbrella/apps/common_core/lib/common_core/notebooks/jupyter_lab_notebook.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/notebooks/jupyter_lab_notebook.ex
@@ -7,6 +7,11 @@ defmodule CommonCore.Notebooks.JupyterLabNotebook do
   alias CommonCore.Projects.Project
   alias CommonCore.Util.Memory
 
+  @derive {
+    Flop.Schema,
+    filterable: [:name], sortable: [:id, :name, :storage_size, :memory_limits]
+  }
+
   @presets [
     %{
       name: "tiny",

--- a/platform_umbrella/apps/common_core/lib/common_core/postgres/cluster.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/postgres/cluster.ex
@@ -6,6 +6,11 @@ defmodule CommonCore.Postgres.Cluster do
   alias CommonCore.Projects.Project
   alias CommonCore.Util.Memory
 
+  @derive {
+    Flop.Schema,
+    filterable: [:name], sortable: [:id, :name, :type, :num_instances, :users, :storage_size]
+  }
+
   @presets [
     %{
       name: "tiny",

--- a/platform_umbrella/apps/common_core/lib/common_core/projects/project.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/projects/project.ex
@@ -3,12 +3,12 @@ defmodule CommonCore.Projects.Project do
 
   use CommonCore, :schema
 
-  @required_fields ~w(name)a
-
   @derive {
     Flop.Schema,
     filterable: [:name], sortable: [:id, :name]
   }
+
+  @required_fields ~w(name)a
 
   batt_schema "projects" do
     field :name, :string

--- a/platform_umbrella/apps/common_core/lib/common_core/redis/failover_cluster.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/redis/failover_cluster.ex
@@ -6,6 +6,11 @@ defmodule CommonCore.Redis.FailoverCluster do
   alias CommonCore.Projects.Project
   alias CommonCore.Util.Memory
 
+  @derive {
+    Flop.Schema,
+    filterable: [:name], sortable: [:id, :name, :num_redis_instances, :num_sentinel_instances, :memory_limits]
+  }
+
   @presets [
     %{
       name: "tiny",

--- a/platform_umbrella/apps/common_core/lib/common_core/traditional_services/service.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/traditional_services/service.ex
@@ -6,6 +6,11 @@ defmodule CommonCore.TraditionalServices.Service do
   alias CommonCore.Projects.Project
   alias CommonCore.Util.Memory
 
+  @derive {
+    Flop.Schema,
+    filterable: [:name], sortable: [:id, :name, :num_instances]
+  }
+
   @service_size_preset [
     %{
       name: "tiny",

--- a/platform_umbrella/apps/common_ui/lib/common_ui/components/table.ex
+++ b/platform_umbrella/apps/common_ui/lib/common_ui/components/table.ex
@@ -101,7 +101,7 @@ defmodule CommonUI.Components.Table do
           class={tbody_class()}
           phx-update={match?(%Phoenix.LiveView.LiveStream{}, @rows) && "stream"}
         >
-          <tr :for={row <- @rows} id={@row_id && @row_id.(row)} class={tbody_tr_class()}>
+          <tr :for={row <- @rows} id={@row_id && @row_id.(row)} class={@row_click && tbody_tr_class()}>
             <td :for={col <- @col} class={tbody_td_class()} phx-click={@row_click && @row_click.(row)}>
               <%= render_slot(col, @row_item.(row)) %>
             </td>

--- a/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/table_test/test_default_table_component.heyya_snap
+++ b/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/table_test/test_default_table_component.heyya_snap
@@ -8,7 +8,7 @@
     </thead>
 
     <tbody id="foobar-body" class="relative text-sm leading-6 text-gray-darkest dark:text-gray-lighter before:content-[&#39;@&#39;] before:block before:leading-3 before:indent-[-99999px]">
-      <tr class="cursor-pointer hover:bg-gray-lightest dark:hover:bg-gray-darkest-tint">
+      <tr class="">
         <td class="px-2 py-4 align-top first:rounded-l-lg last:rounded-r-lg first:font-semibold">
           100
         </td><td class="px-2 py-4 align-top first:rounded-l-lg last:rounded-r-lg first:font-semibold">
@@ -16,7 +16,7 @@
         </td>
 
         
-      </tr><tr class="cursor-pointer hover:bg-gray-lightest dark:hover:bg-gray-darkest-tint">
+      </tr><tr class="">
         <td class="px-2 py-4 align-top first:rounded-l-lg last:rounded-r-lg first:font-semibold">
           102
         </td><td class="px-2 py-4 align-top first:rounded-l-lg last:rounded-r-lg first:font-semibold">
@@ -24,7 +24,7 @@
         </td>
 
         
-      </tr><tr class="cursor-pointer hover:bg-gray-lightest dark:hover:bg-gray-darkest-tint">
+      </tr><tr class="">
         <td class="px-2 py-4 align-top first:rounded-l-lg last:rounded-r-lg first:font-semibold">
           420
         </td><td class="px-2 py-4 align-top first:rounded-l-lg last:rounded-r-lg first:font-semibold">

--- a/platform_umbrella/apps/control_server/lib/control_server/audit.ex
+++ b/platform_umbrella/apps/control_server/lib/control_server/audit.ex
@@ -11,6 +11,10 @@ defmodule ControlServer.Audit do
     |> Repo.all()
   end
 
+  def list_edit_versions(params) do
+    Repo.Flop.validate_and_run(EditVersion, params, for: EditVersion)
+  end
+
   def history(%{id: id, __struct__: struct} = _entity, opts \\ []) do
     limit = Keyword.get(opts, :limit, 10)
 

--- a/platform_umbrella/apps/control_server/lib/control_server/batteries.ex
+++ b/platform_umbrella/apps/control_server/lib/control_server/batteries.ex
@@ -20,12 +20,11 @@ defmodule ControlServer.Batteries do
     Repo.all(SystemBattery)
   end
 
-  @spec list_system_batteries_slim() :: [SystemBattery.t()]
-  def list_system_batteries_slim do
+  @spec list_system_batteries(map()) :: {atom(), {[SystemBattery.t()], Flop.Meta.t()}}
+  def list_system_batteries(params) do
     from(sb in SystemBattery)
     |> select([:id, :group, :type, :inserted_at, :updated_at])
-    |> order_by(desc: :updated_at)
-    |> Repo.all()
+    |> Repo.Flop.validate_and_run(params, for: SystemBattery)
   end
 
   def list_system_batteries_for_group(group, repo \\ Repo) do

--- a/platform_umbrella/apps/control_server/lib/control_server/content_addressable.ex
+++ b/platform_umbrella/apps/control_server/lib/control_server/content_addressable.ex
@@ -9,6 +9,10 @@ defmodule ControlServer.ContentAddressable do
     Repo.all(Document)
   end
 
+  def list_documents(params) do
+    Repo.Flop.validate_and_run(Document, params, for: Document)
+  end
+
   def count_documents do
     Repo.aggregate(Document, :count)
   end
@@ -39,14 +43,6 @@ defmodule ControlServer.ContentAddressable do
           newest: max(car.inserted_at),
           record_count: count(car.id)
         }
-    )
-  end
-
-  def paginated_documents(opts \\ %{}) do
-    Repo.Flop.validate_and_run(
-      from(car in Document),
-      opts,
-      for: Document
     )
   end
 end

--- a/platform_umbrella/apps/control_server/lib/control_server/deleted/delete_archivist.ex
+++ b/platform_umbrella/apps/control_server/lib/control_server/deleted/delete_archivist.ex
@@ -17,17 +17,8 @@ defmodule ControlServer.Deleted.DeleteArchivist do
     |> repo.transaction()
   end
 
-  @doc """
-  Returns the list of DeletedResources.
-
-  ## Examples
-
-      iex> list_deleted_resource()
-      [%DeletedResource{}, ...]
-
-  """
-  def list_deleted_resources(limit \\ 25) do
-    Repo.all(DeletedResource, order_by: [desc: :updated_at], limit: limit)
+  def list_deleted_resources(params) do
+    Repo.Flop.validate_and_run(DeletedResource, params, for: DeletedResource)
   end
 
   @doc """

--- a/platform_umbrella/apps/control_server/lib/control_server/deleted/deleted_resource.ex
+++ b/platform_umbrella/apps/control_server/lib/control_server/deleted/deleted_resource.ex
@@ -3,6 +3,16 @@ defmodule ControlServer.Deleted.DeletedResource do
 
   use CommonCore, :schema
 
+  @derive {
+    Flop.Schema,
+    filterable: [:name],
+    sortable: [:name, :namespace, :kind, :updated_at],
+    default_order: %{
+      order_by: [:updated_at],
+      order_directions: [:desc]
+    }
+  }
+
   @required_fields ~w(kind name namespace hash document_id been_undeleted)a
 
   batt_schema "deleted_resources" do

--- a/platform_umbrella/apps/control_server/lib/control_server/ferretdb.ex
+++ b/platform_umbrella/apps/control_server/lib/control_server/ferretdb.ex
@@ -19,6 +19,10 @@ defmodule ControlServer.FerretDB do
     Repo.all(FerretService)
   end
 
+  def list_ferret_services(params) do
+    Repo.Flop.validate_and_run(FerretService, params, for: FerretService)
+  end
+
   @doc """
   Gets a single ferret_service.
 

--- a/platform_umbrella/apps/control_server/lib/control_server/knative.ex
+++ b/platform_umbrella/apps/control_server/lib/control_server/knative.ex
@@ -19,6 +19,10 @@ defmodule ControlServer.Knative do
     Repo.all(Service)
   end
 
+  def list_services(params) do
+    Repo.Flop.validate_and_run(Service, params, for: Service)
+  end
+
   @doc """
   Gets a single service.
 

--- a/platform_umbrella/apps/control_server/lib/control_server/metal_lb.ex
+++ b/platform_umbrella/apps/control_server/lib/control_server/metal_lb.ex
@@ -18,6 +18,10 @@ defmodule ControlServer.MetalLB do
     Repo.all(IPAddressPool)
   end
 
+  def list_ip_address_pools(params) do
+    Repo.Flop.validate_and_run(IPAddressPool, params, for: IPAddressPool)
+  end
+
   @doc """
   Gets a single ip_address_pool.
 

--- a/platform_umbrella/apps/control_server/lib/control_server/notebooks.ex
+++ b/platform_umbrella/apps/control_server/lib/control_server/notebooks.ex
@@ -19,6 +19,10 @@ defmodule ControlServer.Notebooks do
     Repo.all(JupyterLabNotebook)
   end
 
+  def list_jupyter_lab_notebooks(params) do
+    Repo.Flop.validate_and_run(JupyterLabNotebook, params, for: JupyterLabNotebook)
+  end
+
   @doc """
   Gets a single jupyter_lab_notebook.
 

--- a/platform_umbrella/apps/control_server/lib/control_server/postgres.ex
+++ b/platform_umbrella/apps/control_server/lib/control_server/postgres.ex
@@ -20,6 +20,10 @@ defmodule ControlServer.Postgres do
     Repo.all(Cluster)
   end
 
+  def list_clusters(params) do
+    Repo.Flop.validate_and_run(Cluster, params, for: Cluster)
+  end
+
   def internal_clusters do
     Repo.all(from c in Cluster, where: c.type == :internal)
   end

--- a/platform_umbrella/apps/control_server/lib/control_server/redis.ex
+++ b/platform_umbrella/apps/control_server/lib/control_server/redis.ex
@@ -19,6 +19,10 @@ defmodule ControlServer.Redis do
     Repo.all(FailoverCluster)
   end
 
+  def list_failover_clusters(params) do
+    Repo.Flop.validate_and_run(FailoverCluster, params, for: FailoverCluster)
+  end
+
   @doc """
   Gets a single failover_cluster.
 

--- a/platform_umbrella/apps/control_server/lib/control_server/snapshot_apply/umbrella.ex
+++ b/platform_umbrella/apps/control_server/lib/control_server/snapshot_apply/umbrella.ex
@@ -18,13 +18,10 @@ defmodule ControlServer.SnapshotApply.Umbrella do
     Repo.all(UmbrellaSnapshot)
   end
 
-  def paginated_umbrella_snapshots(opts \\ %{}) do
+  def list_umbrella_snapshots(params) do
     from(ks in UmbrellaSnapshot)
     |> preload([:kube_snapshot, :keycloak_snapshot])
-    |> Repo.Flop.validate_and_run(
-      opts,
-      for: UmbrellaSnapshot
-    )
+    |> Repo.Flop.validate_and_run(params, for: UmbrellaSnapshot)
   end
 
   def latest_umbrella_snapshots(limit \\ 10) do

--- a/platform_umbrella/apps/control_server/lib/control_server/snapshot_apply/umbrella_snapshot.ex
+++ b/platform_umbrella/apps/control_server/lib/control_server/snapshot_apply/umbrella_snapshot.ex
@@ -6,7 +6,7 @@ defmodule ControlServer.SnapshotApply.UmbrellaSnapshot do
   @derive {
     Flop.Schema,
     filterable: [],
-    sortable: [:inserted_at, :id],
+    sortable: [:id, :inserted_at],
     default_order: %{
       order_by: [:inserted_at, :id],
       order_directions: [:desc, :desc]

--- a/platform_umbrella/apps/control_server/lib/control_server/traditional_services.ex
+++ b/platform_umbrella/apps/control_server/lib/control_server/traditional_services.ex
@@ -19,6 +19,10 @@ defmodule ControlServer.TraditionalServices do
     Repo.all(Service)
   end
 
+  def list_traditional_services(params) do
+    Repo.Flop.validate_and_run(Service, params, for: Service)
+  end
+
   @doc """
   Gets a single service.
 

--- a/platform_umbrella/apps/control_server/test/control_server/batteries_test.exs
+++ b/platform_umbrella/apps/control_server/test/control_server/batteries_test.exs
@@ -11,9 +11,18 @@ defmodule ControlServer.BatteriesTest do
 
     @invalid_attrs %{config: nil, group: nil, type: nil}
 
-    test "list_system_batteries/0 returns all system_batteries" do
+    test "list_system_batteries/0 returns all system batteries" do
       system_battery = system_battery_fixture()
       assert Batteries.list_system_batteries() == [system_battery]
+    end
+
+    test "list_system_batteries/1 returns paginated system batteries" do
+      _system_battery1 = system_battery_fixture()
+      system_battery2 = system_battery_fixture(%{type: :ferretdb})
+
+      assert {:ok, {[system_battery], _}} = Batteries.list_system_batteries(%{limit: 1})
+      assert system_battery.id == system_battery2.id
+      refute system_battery.config
     end
 
     test "get_system_battery!/1 returns the system_battery with given id" do

--- a/platform_umbrella/apps/control_server/test/control_server/ferretdb_test.exs
+++ b/platform_umbrella/apps/control_server/test/control_server/ferretdb_test.exs
@@ -10,9 +10,17 @@ defmodule ControlServer.FerretDBTest do
 
     @invalid_attrs %{instances: nil, cpu_requested: nil, cpu_limits: nil, memory_requested: nil, memory_limits: nil}
 
-    test "list_ferret_services/0 returns all ferret_services" do
+    test "list_ferret_services/0 returns all ferret services" do
       ferret_service = ferret_service_fixture()
       assert FerretDB.list_ferret_services() == [ferret_service]
+    end
+
+    test "list_ferret_services/1 returns paginated ferret services" do
+      ferret_service1 = ferret_service_fixture()
+      _ferret_service2 = ferret_service_fixture()
+
+      assert {:ok, {[ferret_service], _}} = FerretDB.list_ferret_services(%{limit: 1})
+      assert ferret_service.id == ferret_service1.id
     end
 
     test "get_ferret_service!/1 returns the ferret_service with given id" do

--- a/platform_umbrella/apps/control_server/test/control_server/knative_test.exs
+++ b/platform_umbrella/apps/control_server/test/control_server/knative_test.exs
@@ -19,6 +19,14 @@ defmodule ControlServer.KnativeTest do
       assert Knative.list_services() == [service]
     end
 
+    test "list_services/1 returns paginated services" do
+      service1 = service_fixture()
+      _service2 = service_fixture()
+
+      assert {:ok, {[service], _}} = Knative.list_services(%{limit: 1})
+      assert service.id == service1.id
+    end
+
     test "get_service!/1 returns the service with given id" do
       service = service_fixture()
       assert Knative.get_service!(service.id) == service

--- a/platform_umbrella/apps/control_server/test/control_server/metal_lb_test.exs
+++ b/platform_umbrella/apps/control_server/test/control_server/metal_lb_test.exs
@@ -9,9 +9,17 @@ defmodule ControlServer.MetalLBTest do
 
     @invalid_attrs %{name: nil, subnet: nil}
 
-    test "list_ip_address_pools/0 returns all ip_address_pools" do
+    test "list_ip_address_pools/0 returns all ip address pools" do
       ip_address_pool = ip_address_pool_fixture()
       assert MetalLB.list_ip_address_pools() == [ip_address_pool]
+    end
+
+    test "list_ip_address_pools/1 returns paginated ip address pools" do
+      ip_address_pool1 = ip_address_pool_fixture()
+      _ip_address_pool2 = ip_address_pool_fixture()
+
+      assert {:ok, {[ip_address_pool], _}} = MetalLB.list_ip_address_pools(%{limit: 1})
+      assert ip_address_pool.id == ip_address_pool1.id
     end
 
     test "get_ip_address_pool!/1 returns the ip_address_pool with given id" do

--- a/platform_umbrella/apps/control_server/test/control_server/notebooks_test.exs
+++ b/platform_umbrella/apps/control_server/test/control_server/notebooks_test.exs
@@ -18,9 +18,17 @@ defmodule ControlServer.NotebooksTest do
       Map.put(jupyter_lab_notebook, :virtual_size, nil)
     end
 
-    test "list_jupyter_lab_notebooks/0 returns all jupyter_lab_notebooks" do
+    test "list_jupyter_lab_notebooks/0 returns all jupyter lab notebooks" do
       jupyter_lab_notebook = jupyter_lab_notebook_fixture()
       assert Notebooks.list_jupyter_lab_notebooks() == [jupyter_lab_notebook]
+    end
+
+    test "list_jupyter_lab_notebooks/1 returns paginated jupyter lab notebooks" do
+      jupyter_lab_notebook1 = jupyter_lab_notebook_fixture()
+      _jupyter_lab_notebook2 = jupyter_lab_notebook_fixture()
+
+      assert {:ok, {[jupyter_lab_notebook], _}} = Notebooks.list_jupyter_lab_notebooks(%{limit: 1})
+      assert jupyter_lab_notebook.id == jupyter_lab_notebook1.id
     end
 
     test "get_jupyter_lab_notebook!/1 returns the jupyter_lab_notebook with given id" do

--- a/platform_umbrella/apps/control_server/test/control_server/postgres_test.exs
+++ b/platform_umbrella/apps/control_server/test/control_server/postgres_test.exs
@@ -41,6 +41,14 @@ defmodule ControlServer.PostgresTest do
       assert Postgres.list_clusters() == [cluster]
     end
 
+    test "list_clusters/1 returns paginated clusters" do
+      cluster1 = cluster_fixture()
+      _cluster2 = cluster_fixture(%{name: "another-name"})
+
+      assert {:ok, {[cluster], _}} = Postgres.list_clusters(%{limit: 1})
+      assert cluster.id == cluster1.id
+    end
+
     test "get_cluster!/1 returns the cluster with given id" do
       cluster = cluster_fixture()
       assert Postgres.get_cluster!(cluster.id) == cluster

--- a/platform_umbrella/apps/control_server/test/control_server/redis_test.exs
+++ b/platform_umbrella/apps/control_server/test/control_server/redis_test.exs
@@ -13,9 +13,17 @@ defmodule ControlServer.RedisTest do
       num_sentinel_instances: nil
     }
 
-    test "list_failover_clusters/0 returns all failover_clusters" do
+    test "list_failover_clusters/0 returns all failover clusters" do
       failover_cluster = failover_cluster_fixture()
       assert Redis.list_failover_clusters() == [failover_cluster]
+    end
+
+    test "list_failover_clusters/1 returns paginated failover clusters" do
+      failover_cluster1 = failover_cluster_fixture()
+      _failover_cluster2 = failover_cluster_fixture()
+
+      assert {:ok, {[failover_cluster], _}} = Redis.list_failover_clusters(%{limit: 1})
+      assert failover_cluster.id == failover_cluster1.id
     end
 
     test "get_failover_cluster!/1 returns the failover_cluster with given id" do

--- a/platform_umbrella/apps/control_server/test/control_server/snapshot_apply/umbrella_test.exs
+++ b/platform_umbrella/apps/control_server/test/control_server/snapshot_apply/umbrella_test.exs
@@ -8,9 +8,17 @@ defmodule ControlServer.SnapshotApply.UmbrellaTest do
 
     alias ControlServer.SnapshotApply.UmbrellaSnapshot
 
-    test "list_umbrella_snapshots/0 returns all umbrella_snapshots" do
+    test "list_umbrella_snapshots/0 returns all umbrella snapshots" do
       umbrella_snapshot = umbrella_snapshot_fixture()
       assert Umbrella.list_umbrella_snapshots() == [umbrella_snapshot]
+    end
+
+    test "list_umbrella_snapshots/1 returns paginated umbrella snapshots" do
+      _umbrella_snapshot1 = umbrella_snapshot_fixture()
+      umbrella_snapshot2 = umbrella_snapshot_fixture()
+
+      assert {:ok, {[umbrella_snapshot], _}} = Umbrella.list_umbrella_snapshots(%{limit: 1})
+      assert umbrella_snapshot.id == umbrella_snapshot2.id
     end
 
     test "get_umbrella_snapshot!/1 returns the umbrella_snapshot with given id" do

--- a/platform_umbrella/apps/control_server/test/control_server/traditional_services/traditional_services_test.exs
+++ b/platform_umbrella/apps/control_server/test/control_server/traditional_services/traditional_services_test.exs
@@ -10,7 +10,7 @@ defmodule ControlServer.TraditionalServicesTest do
 
     @invalid_attrs %{name: nil, containers: nil, init_containers: nil, env_values: nil}
 
-    test "list_traditional_services/0 returns all traditional_services" do
+    test "list_traditional_services/0 returns all traditional services" do
       service = service_fixture()
       assert 1 == length(TraditionalServices.list_traditional_services())
       [found] = TraditionalServices.list_traditional_services()
@@ -19,6 +19,14 @@ defmodule ControlServer.TraditionalServicesTest do
       assert found.containers == service.containers
       assert found.init_containers == service.init_containers
       assert found.env_values == service.env_values
+    end
+
+    test "list_traditional_services/1 returns paginated traditional services" do
+      service1 = service_fixture()
+      _service2 = service_fixture()
+
+      assert {:ok, {[service], _}} = TraditionalServices.list_traditional_services(%{limit: 1})
+      assert service.id == service1.id
     end
 
     test "get_service!/1 returns the service with given id" do

--- a/platform_umbrella/apps/control_server/test/support/fixtures/knative_fixtures.ex
+++ b/platform_umbrella/apps/control_server/test/support/fixtures/knative_fixtures.ex
@@ -11,7 +11,6 @@ defmodule ControlServer.KnativeFixtures do
     {:ok, service} =
       attrs
       |> Enum.into(%{
-        name: "some-name",
         image: "batteries_included/test-image"
       })
       |> ControlServer.Knative.create_service()

--- a/platform_umbrella/apps/control_server/test/support/fixtures/metal_lb_fixtures.ex
+++ b/platform_umbrella/apps/control_server/test/support/fixtures/metal_lb_fixtures.ex
@@ -11,7 +11,6 @@ defmodule ControlServer.MetalLBFixtures do
     {:ok, ip_address_pool} =
       attrs
       |> Enum.into(%{
-        name: "some-name",
         subnet: "some subnet"
       })
       |> ControlServer.MetalLB.create_ip_address_pool()

--- a/platform_umbrella/apps/control_server/test/support/fixtures/redis_fixtures.ex
+++ b/platform_umbrella/apps/control_server/test/support/fixtures/redis_fixtures.ex
@@ -11,7 +11,6 @@ defmodule ControlServer.RedisFixtures do
     {:ok, failover_cluster} =
       attrs
       |> Enum.into(%{
-        name: "some-name",
         type: :standard,
         virtual_size: nil,
         memory_limits: 100,

--- a/platform_umbrella/apps/control_server/test/support/fixtures/traditional_services_fixtures.ex
+++ b/platform_umbrella/apps/control_server/test/support/fixtures/traditional_services_fixtures.ex
@@ -14,8 +14,7 @@ defmodule ControlServer.TraditionalServicesFixtures do
         containers: [],
         env_values: [],
         init_containers: [],
-        virtural_size: "medium",
-        name: "some-name"
+        virtural_size: "medium"
       })
       |> ControlServer.TraditionalServices.create_service()
 

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/audit/edit_versions_table.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/audit/edit_versions_table.ex
@@ -2,12 +2,8 @@ defmodule ControlServerWeb.Audit.EditVersionsTable do
   @moduledoc false
   use ControlServerWeb, :html
 
-  defp show_url(edit_version) do
-    ~p"/edit_versions/#{edit_version.id}"
-  end
-
-  attr :edit_versions, :list, required: true
-  attr :id, :string, default: "edit_versions-table"
+  attr :meta, :map, default: nil
+  attr :rows, :list, required: true
 
   attr :abridged, :boolean,
     default: false,
@@ -17,23 +13,33 @@ defmodule ControlServerWeb.Audit.EditVersionsTable do
 
   def edit_versions_table(assigns) do
     ~H"""
-    <.table id={@id} rows={@edit_versions} {@rest} row_click={&JS.navigate(show_url(&1))}>
-      <:col :let={edit_version} :if={!@abridged} label="Entity ID">
+    <.table
+      id="edit-versions-table"
+      variant={@meta && "paginated"}
+      rows={@rows}
+      meta={@meta}
+      path={~p"/edit_versions"}
+      row_click={&JS.navigate(show_url(&1))}
+      {@rest}
+    >
+      <:col :let={edit_version} :if={!@abridged} field={:entity_id} label="Entity ID">
         <%= edit_version.entity_id %>
       </:col>
-      <:col :let={edit_version} :if={!@abridged} label="Entity Type">
+      <:col :let={edit_version} :if={!@abridged} field={:entity_schema} label="Entity Type">
         <%= edit_version.entity_schema %>
       </:col>
-      <:col :let={edit_version} label="Action">
+      <:col :let={edit_version} field={:action} label="Action">
         <%= edit_version.action %>
       </:col>
-      <:col :let={edit_version} label="Was Rollback?">
+      <:col :let={edit_version} field={:rollback} label="Was Rollback?">
         <%= edit_version.rollback %>
       </:col>
-      <:col :let={edit_version} label="Recorded Time">
+      <:col :let={edit_version} field={:recorded_at} label="Recorded Time">
         <.relative_display time={edit_version.recorded_at} />
       </:col>
     </.table>
     """
   end
+
+  defp show_url(edit_version), do: ~p"/edit_versions/#{edit_version.id}"
 end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/batteries/running_batteries.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/batteries/running_batteries.ex
@@ -89,17 +89,23 @@ defmodule ControlServerWeb.RunningBatteriesPanel do
           </.tab_bar>
         </:menu>
 
-        <.table id="running-batteries-table" rows={@filtered_batteries || []}>
-          <:col :let={battery} label="Battery name">
+        <.table
+          id="running-batteries-table"
+          variant="paginated"
+          rows={@filtered_batteries || []}
+          meta={@meta}
+          path={~p"/"}
+        >
+          <:col :let={battery} field={:type} label="Battery name">
             <%= Naming.humanize(battery.type) %>
           </:col>
-          <:col :let={battery} label="Type">
+          <:col :let={battery} field={:group} label="Type">
             <%= battery.group %>
           </:col>
-          <:col :let={battery} label="Installed">
+          <:col :let={battery} field={:inserted_at} label="Installed">
             <.relative_display time={battery.inserted_at} />
           </:col>
-          <:col :let={battery} label="Last Updated">
+          <:col :let={battery} field={:updated_at} label="Last Updated">
             <.relative_display time={battery.updated_at} />
           </:col>
         </.table>

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/content_addressable/documents_table.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/content_addressable/documents_table.ex
@@ -1,16 +1,16 @@
-defmodule ControlServerWeb.ContentAddressable.ResourceTable do
+defmodule ControlServerWeb.ContentAddressable.DocumentsTable do
   @moduledoc false
   use ControlServerWeb, :html
 
-  attr :resources, :list, required: true
+  attr :rows, :list, default: []
   attr :meta, :map, default: nil
 
   def documents_table(%{} = assigns) do
     ~H"""
     <.table
-      id="resources-table"
+      id="documents-table"
       variant={@meta && "paginated"}
-      rows={@resources || []}
+      rows={@rows}
       meta={@meta}
       path={~p"/content_addressable"}
     >

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/ferretdb/ferret_services_table.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/ferretdb/ferret_services_table.ex
@@ -3,14 +3,24 @@ defmodule ControlServerWeb.FerretServicesTable do
   use ControlServerWeb, :html
 
   attr :rows, :list, default: []
+  attr :meta, :map, default: nil
   attr :abridged, :boolean, default: false
 
   def ferret_services_table(assigns) do
     ~H"""
-    <.table id="ferret_services" rows={@rows} row_click={&JS.navigate(show_url(&1))}>
-      <:col :let={service} :if={!@abridged} label="ID"><%= service.id %></:col>
-      <:col :let={service} label="Name"><%= service.name %></:col>
-      <:col :let={service} :if={!@abridged} label="Instances"><%= service.instances %></:col>
+    <.table
+      id="ferret_services"
+      variant={@meta && "paginated"}
+      rows={@rows}
+      meta={@meta}
+      path={~p"/ferretdb"}
+      row_click={&JS.navigate(show_url(&1))}
+    >
+      <:col :let={service} :if={!@abridged} field={:id} label="ID"><%= service.id %></:col>
+      <:col :let={service} field={:name} label="Name"><%= service.name %></:col>
+      <:col :let={service} :if={!@abridged} field={:instances} label="Instances">
+        <%= service.instances %>
+      </:col>
       <:action :let={service}>
         <.flex class="justify-items-center align-middle">
           <.button

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/ip_pools/ip_address_pools_table.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/ip_pools/ip_address_pools_table.ex
@@ -3,14 +3,21 @@ defmodule ControlServerWeb.IPAddressPoolsTable do
   use ControlServerWeb, :html
 
   attr :rows, :list, default: []
+  attr :meta, :map, default: nil
   attr :abridged, :boolean, default: false, doc: "the abridged property control display of the id column and formatting"
 
   def ip_address_pools_table(assigns) do
     ~H"""
-    <.table id="ip-address-pools-table" rows={@rows}>
-      <:col :let={pool} :if={!@abridged} label="ID"><%= pool.id %></:col>
-      <:col :let={pool} label="Name"><%= pool.name %></:col>
-      <:col :let={pool} label="Subnet"><%= pool.subnet %></:col>
+    <.table
+      id="ip-address-pools-table"
+      variant={@meta && "paginated"}
+      rows={@rows}
+      meta={@meta}
+      path={~p"/ip_address_pools"}
+    >
+      <:col :let={pool} :if={!@abridged} field={:id} label="ID"><%= pool.id %></:col>
+      <:col :let={pool} field={:name} label="Name"><%= pool.name %></:col>
+      <:col :let={pool} field={:subnet} label="Subnet"><%= pool.subnet %></:col>
 
       <:action :let={pool}>
         <.flex>

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/istio/virtual_services_table.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/istio/virtual_services_table.ex
@@ -11,7 +11,7 @@ defmodule ControlServerWeb.Istio.VirtualServicesTable do
   def virtual_services_table(assigns) do
     ~H"""
     <.table id="virtual-services-table" rows={@rows} row_click={&JS.navigate(show_url(&1))}>
-      <:col :let={virtual_service} :if={!@abridged} label="ID"><%= virtual_service.id %></:col>
+      <:col :let={virtual_service} :if={!@abridged} label="ID"><%= uid(virtual_service) %></:col>
       <:col :let={virtual_service} label="Name"><%= name(virtual_service) %></:col>
       <:col :let={virtual_service} label="Namespace"><%= namespace(virtual_service) %></:col>
       <:col :let={virtual_service} :if={!@abridged} label="Hosts">

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/knative/knative_services_table.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/knative/knative_services_table.ex
@@ -7,14 +7,22 @@ defmodule ControlServerWeb.KnativeServicesTable do
   alias CommonCore.Knative.Service
 
   attr :rows, :list, required: true
+  attr :meta, :map, default: nil
   attr :abridged, :boolean, default: false, doc: "the abridged property control display of the id column and formatting"
 
   def knative_services_table(assigns) do
     ~H"""
-    <.table id="knative-display-table" rows={@rows} row_click={&JS.navigate(show_url(&1))}>
-      <:col :let={service} :if={!@abridged} label="ID"><%= service.id %></:col>
-      <:col :let={service} label="Name"><%= service.name %></:col>
-      <:col :let={service} :if={!@abridged} label="Rollout Duration">
+    <.table
+      id="knative-display-table"
+      variant={@meta && "paginated"}
+      rows={@rows}
+      meta={@meta}
+      path={~p"/knative/services"}
+      row_click={&JS.navigate(show_url(&1))}
+    >
+      <:col :let={service} :if={!@abridged} field={:id} label="ID"><%= service.id %></:col>
+      <:col :let={service} field={:name} label="Name"><%= service.name %></:col>
+      <:col :let={service} :if={!@abridged} field={:rollout_duration} label="Rollout Duration">
         <%= service.rollout_duration %>
       </:col>
       <:action :let={service}>

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/notebooks/notebooks_table.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/notebooks/notebooks_table.ex
@@ -7,15 +7,26 @@ defmodule ControlServerWeb.NotebooksTable do
   alias CommonCore.Util.Memory
 
   attr :rows, :list, default: []
+  attr :meta, :map, default: nil
   attr :abridged, :boolean, default: false, doc: "the abridged property control display of the id column and formatting"
 
   def notebooks_table(assigns) do
     ~H"""
-    <.table id="notebook-display-table" rows={@rows} row_click={&JS.navigate(show_url(&1))}>
-      <:col :let={notebook} :if={!@abridged} label="ID"><%= notebook.id %></:col>
-      <:col :let={notebook} label="Name"><%= notebook.name %></:col>
-      <:col :let={notebook} :if={!@abridged} label="Storage Size">
+    <.table
+      id="notebook-display-table"
+      variant={@meta && "paginated"}
+      rows={@rows}
+      meta={@meta}
+      path={~p"/notebooks"}
+      row_click={&JS.navigate(show_url(&1))}
+    >
+      <:col :let={notebook} :if={!@abridged} field={:id} label="ID"><%= notebook.id %></:col>
+      <:col :let={notebook} field={:name} label="Name"><%= notebook.name %></:col>
+      <:col :let={notebook} :if={!@abridged} field={:storage_size} label="Storage Size">
         <%= Memory.humanize(notebook.storage_size) %>
+      </:col>
+      <:col :let={notebook} :if={!@abridged} field={:memory_limits} label="Memory Limits">
+        <%= Memory.humanize(notebook.memory_limits) %>
       </:col>
       <:action :let={notebook}>
         <.flex class="justify-items-center">

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/postgres/postgres_cluster_table.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/postgres/postgres_cluster_table.ex
@@ -7,17 +7,29 @@ defmodule ControlServerWeb.PostgresClusterTable do
 
   attr :id, :string, default: "postgres-cluster-table"
   attr :rows, :list, required: true
+  attr :meta, :map, default: nil
   attr :abridged, :boolean, default: false, doc: "the abridged property control display of the id column and formatting"
 
   def postgres_clusters_table(assigns) do
     ~H"""
-    <.table id={@id} rows={@rows} row_click={&JS.navigate(show_url(&1))}>
-      <:col :let={pg} :if={!@abridged} label="ID"><%= pg.id %></:col>
-      <:col :let={pg} label="Name"><%= pg.name %></:col>
-      <:col :let={pg} :if={!@abridged} label="Type"><%= pg.type %></:col>
-      <:col :let={pg} :if={!@abridged} label="Instances"><%= pg.num_instances %></:col>
-      <:col :let={pg} :if={!@abridged} label="User Count"><%= length(pg.users) %></:col>
-      <:col :let={pg} :if={!@abridged} label="Storage Size">
+    <.table
+      variant={@meta && "paginated"}
+      id={@id}
+      rows={@rows}
+      meta={@meta}
+      path={~p"/postgres"}
+      row_click={&JS.navigate(show_url(&1))}
+    >
+      <:col :let={pg} :if={!@abridged} field={:id} label="ID"><%= pg.id %></:col>
+      <:col :let={pg} field={:name} label="Name"><%= pg.name %></:col>
+      <:col :let={pg} :if={!@abridged} field={:type} label="Type"><%= pg.type %></:col>
+      <:col :let={pg} :if={!@abridged} field={:num_instances} label="Instances">
+        <%= pg.num_instances %>
+      </:col>
+      <:col :let={pg} :if={!@abridged} field={:users} label="User Count">
+        <%= length(pg.users) %>
+      </:col>
+      <:col :let={pg} :if={!@abridged} field={:storage_size} label="Storage Size">
         <%= Memory.humanize(pg.storage_size) %>
       </:col>
       <:action :let={pg}>

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/redis/redis_table.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/redis/redis_table.ex
@@ -6,18 +6,28 @@ defmodule ControlServerWeb.RedisTable do
   alias CommonCore.Util.Memory
 
   attr :rows, :list, default: []
+  attr :meta, :map, default: nil
   attr :abridged, :boolean, default: false, doc: "the abridged property control display of the id column and formatting"
 
   def redis_table(assigns) do
     ~H"""
-    <.table id="redis-display-table" rows={@rows} row_click={&JS.navigate(show_url(&1))}>
-      <:col :let={redis} :if={!@abridged} label="ID"><%= redis.id %></:col>
-      <:col :let={redis} label="Name"><%= redis.name %></:col>
-      <:col :let={redis} :if={!@abridged} label="Instances"><%= redis.num_redis_instances %></:col>
-      <:col :let={redis} :if={!@abridged} label="Sentinel Instances">
+    <.table
+      id="redis-display-table"
+      variant={@meta && "paginated"}
+      rows={@rows}
+      meta={@meta}
+      path={~p"/redis"}
+      row_click={&JS.navigate(show_url(&1))}
+    >
+      <:col :let={redis} :if={!@abridged} field={:id} label="ID"><%= redis.id %></:col>
+      <:col :let={redis} field={:name} label="Name"><%= redis.name %></:col>
+      <:col :let={redis} :if={!@abridged} field={:num_redis_instances} label="Instances">
+        <%= redis.num_redis_instances %>
+      </:col>
+      <:col :let={redis} :if={!@abridged} field={:num_sentinel_instances} label="Sentinel Instances">
         <%= redis.num_sentinel_instances %>
       </:col>
-      <:col :let={redis} :if={!@abridged} label="Memory Limits">
+      <:col :let={redis} :if={!@abridged} field={:memory_limits} label="Memory Limits">
         <%= Memory.humanize(redis.memory_limits) %>
       </:col>
       <:action :let={redis}>

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/traditional_services/traditional_services_table.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/traditional_services/traditional_services_table.ex
@@ -8,14 +8,24 @@ defmodule ControlServerWeb.TraditionalServicesTable do
   alias CommonCore.TraditionalServices.Service
 
   attr :rows, :list, required: true
+  attr :meta, :map, default: nil
   attr :abridged, :boolean, default: false, doc: "the abridged property control display of the id column and formatting"
 
   def traditional_services_table(assigns) do
     ~H"""
-    <.table id="traditional-display-table" rows={@rows} row_click={&JS.navigate(show_url(&1))}>
-      <:col :let={service} :if={!@abridged} label="ID"><%= service.id %></:col>
-      <:col :let={service} label="Name"><%= service.name %></:col>
-      <:col :let={service} :if={!@abridged} label="Instances"><%= service.num_instances %></:col>
+    <.table
+      id="traditional-display-table"
+      variant={@meta && "paginated"}
+      rows={@rows}
+      meta={@meta}
+      path={~p"/traditional_services"}
+      row_click={&JS.navigate(show_url(&1))}
+    >
+      <:col :let={service} :if={!@abridged} field={:id} label="ID"><%= service.id %></:col>
+      <:col :let={service} field={:name} label="Name"><%= service.name %></:col>
+      <:col :let={service} :if={!@abridged} field={:num_instances} label="Instances">
+        <%= service.num_instances %>
+      </:col>
       <:action :let={service}>
         <.flex class="justify-items-center">
           <.button

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/audit/edit_versions_list.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/audit/edit_versions_list.ex
@@ -4,25 +4,30 @@ defmodule ControlServerWeb.Live.EditVersionsList do
 
   import ControlServerWeb.Audit.EditVersionsTable
 
+  alias ControlServer.Audit
+
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
-    {:ok, socket |> assign_edit_versions() |> assign_page_title()}
+    {:ok, assign(socket, :page_title, "Edit Versions")}
   end
 
-  defp assign_page_title(socket) do
-    assign(socket, :page_title, "Edit Versions")
-  end
-
-  def assign_edit_versions(socket) do
-    assign(socket, :edit_versions, ControlServer.Audit.list_edit_versions())
+  @impl Phoenix.LiveView
+  def handle_params(params, _session, socket) do
+    with {:ok, {edit_versions, meta}} <- Audit.list_edit_versions(params) do
+      {:noreply,
+       socket
+       |> assign(:meta, meta)
+       |> assign(:edit_versions, edit_versions)}
+    end
   end
 
   @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
     <.page_header title={@page_title} back_link={~p"/magic"} />
+
     <.panel title="All Versions">
-      <.edit_versions_table edit_versions={@edit_versions} />
+      <.edit_versions_table rows={@edit_versions} meta={@meta} />
     </.panel>
     """
   end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/content_addressable/index.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/content_addressable/index.ex
@@ -2,9 +2,33 @@ defmodule ControlServerWeb.Live.ContentAddressableIndex do
   @moduledoc false
   use ControlServerWeb, {:live_view, layout: :sidebar}
 
-  import ControlServerWeb.ContentAddressable.ResourceTable
+  import ControlServerWeb.ContentAddressable.DocumentsTable
 
   alias ControlServer.ContentAddressable
+
+  @impl Phoenix.LiveView
+  def mount(_params, _session, socket) do
+    {:ok, assign_stats(socket)}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_params(params, _session, socket) do
+    with {:ok, {resources, meta}} <- ContentAddressable.list_documents(params) do
+      {:noreply,
+       socket
+       |> assign(:meta, meta)
+       |> assign(:resources, resources)}
+    end
+  end
+
+  defp assign_stats(socket) do
+    %{oldest: oldest, record_count: cnt, newest: newest} = ContentAddressable.get_stats()
+
+    socket
+    |> assign(:count, cnt)
+    |> assign(:oldest, oldest)
+    |> assign(:newest, newest)
+  end
 
   @impl Phoenix.LiveView
   def render(assigns) do
@@ -21,32 +45,8 @@ defmodule ControlServerWeb.Live.ContentAddressableIndex do
     </.page_header>
 
     <.panel title="Resources">
-      <.documents_table resources={@resources} meta={@meta} />
+      <.documents_table rows={@resources} meta={@meta} />
     </.panel>
     """
-  end
-
-  @impl Phoenix.LiveView
-  def mount(_params, _session, socket) do
-    {:ok, assign_stats(socket)}
-  end
-
-  @impl Phoenix.LiveView
-  def handle_params(params, _session, socket) do
-    with {:ok, {resources, meta}} <- ContentAddressable.paginated_documents(params) do
-      {:noreply,
-       socket
-       |> assign(:meta, meta)
-       |> assign(:resources, resources)}
-    end
-  end
-
-  defp assign_stats(socket) do
-    %{oldest: oldest, record_count: cnt, newest: newest} = ContentAddressable.get_stats()
-
-    socket
-    |> assign(:count, cnt)
-    |> assign(:oldest, oldest)
-    |> assign(:newest, newest)
   end
 end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/ferrretdb/show.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/ferrretdb/show.ex
@@ -149,7 +149,7 @@ defmodule ControlServerWeb.Live.FerretServiceShow do
     ~H"""
     <.page_header title="Edit History" back_link={show_url(@ferret_service)} />
     <.panel title="Edit History">
-      <.edit_versions_table edit_versions={@edit_versions} abridged />
+      <.edit_versions_table rows={@edit_versions} abridged />
     </.panel>
     """
   end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/group_batteries/edit.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/group_batteries/edit.ex
@@ -1,4 +1,4 @@
-defmodule ControlServerWeb.GroupBatteries.EditLive do
+defmodule ControlServerWeb.Live.GroupBatteriesEdit do
   @moduledoc false
   use ControlServerWeb, {:live_view, layout: :sidebar}
 

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/group_batteries/index.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/group_batteries/index.ex
@@ -1,4 +1,4 @@
-defmodule ControlServerWeb.GroupBatteries.IndexLive do
+defmodule ControlServerWeb.Live.GroupBatteriesIndex do
   @moduledoc false
   use ControlServerWeb, {:live_view, layout: :sidebar}
 

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/group_batteries/new.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/group_batteries/new.ex
@@ -1,4 +1,4 @@
-defmodule ControlServerWeb.GroupBatteries.NewLive do
+defmodule ControlServerWeb.Live.GroupBatteriesNew do
   @moduledoc false
   use ControlServerWeb, {:live_view, layout: :sidebar}
 

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/home.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/home.ex
@@ -18,8 +18,18 @@ defmodule ControlServerWeb.Live.Home do
      |> assign_current_page()
      |> assign_page_title()
      |> assign_latest_snapshot()
-     |> assign_batteries()
      |> assign_pods()}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_params(params, _session, socket) do
+    with {:ok, {batteries, meta}} <- Batteries.list_system_batteries(params) do
+      {:noreply,
+       socket
+       |> assign(:batteries, batteries)
+       |> assign(:batteries_meta, meta)
+       |> assign(:batteries_count, meta.total_count)}
+    end
   end
 
   defp assign_catalog_group(socket) do
@@ -38,14 +48,6 @@ defmodule ControlServerWeb.Live.Home do
     snapshots = Umbrella.latest_umbrella_snapshots(1)
 
     assign(socket, :latest_snapshot, Enum.at(snapshots, 0))
-  end
-
-  defp assign_batteries(socket) do
-    batteries = Batteries.list_system_batteries_slim()
-
-    socket
-    |> assign(:batteries, batteries)
-    |> assign(:batteries_count, Enum.count(batteries))
   end
 
   def assign_pods(socket) do
@@ -126,6 +128,7 @@ defmodule ControlServerWeb.Live.Home do
         id="running_bat_home_hero"
         class="lg:col-span-12"
         batteries={@batteries}
+        meta={@batteries_meta}
       />
     </.grid>
     """

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/istio/virtual_services.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/istio/virtual_services.ex
@@ -32,7 +32,7 @@ defmodule ControlServerWeb.Live.IstioVirtualServicesIndex do
     <.page_header title={@page_title} back_link={~p"/net_sec"} />
 
     <.panel title="Virtual Services">
-      <.virtual_services_table abridged rows={@virtual_services} />
+      <.virtual_services_table rows={@virtual_services} />
     </.panel>
     """
   end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/k8/deployment/show.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/k8/deployment/show.ex
@@ -1,4 +1,4 @@
-defmodule ControlServerWeb.DeploymentLive.Show do
+defmodule ControlServerWeb.Live.DeploymentShow do
   @moduledoc false
   use ControlServerWeb, {:live_view, layout: :sidebar}
 

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/k8/pod/show.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/k8/pod/show.ex
@@ -1,4 +1,4 @@
-defmodule ControlServerWeb.PodLive.Show do
+defmodule ControlServerWeb.Live.PodShow do
   @moduledoc false
   use ControlServerWeb, {:live_view, layout: :sidebar}
 

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/k8/service/show.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/k8/service/show.ex
@@ -1,4 +1,4 @@
-defmodule ControlServerWeb.ServiceLive.Show do
+defmodule ControlServerWeb.Live.ServiceShow do
   @moduledoc false
   use ControlServerWeb, {:live_view, layout: :sidebar}
 

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/k8/stateful_set/show.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/k8/stateful_set/show.ex
@@ -1,4 +1,4 @@
-defmodule ControlServerWeb.StatefulSetLive.Show do
+defmodule ControlServerWeb.Live.StatefulSetShow do
   @moduledoc false
   use ControlServerWeb, {:live_view, layout: :sidebar}
 

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/knative/index.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/knative/index.ex
@@ -1,37 +1,35 @@
-defmodule ControlServerWeb.Live.KnativeServicesIndex do
+defmodule ControlServerWeb.Live.KnativeIndex do
   @moduledoc false
   use ControlServerWeb, {:live_view, layout: :sidebar}
 
-  import ControlServer.Knative
   import ControlServerWeb.KnativeServicesTable
+
+  alias ControlServer.Knative
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
     {:ok,
      socket
-     |> assign_services()
-     |> assign_current_page()
-     |> assign(:current_page, :devtools)}
+     |> assign(:current_page, :devtools)
+     |> assign(:page_title, "Knative Services")}
   end
 
   @impl Phoenix.LiveView
-  def handle_params(params, _url, socket) do
-    {:noreply, apply_action(socket, socket.assigns.live_action, params)}
+  def handle_params(params, _session, socket) do
+    with {:ok, {services, meta}} <- Knative.list_services(params) do
+      {:noreply,
+       socket
+       |> assign(:meta, meta)
+       |> assign(:services, services)
+       |> assign(:form, to_form(meta))}
+    end
   end
 
-  defp apply_action(socket, :index, _params) do
-    assign(socket, :page_title, "Knative Services")
+  @impl Phoenix.LiveView
+  def handle_event("search", params, socket) do
+    params = Map.delete(params, "_target")
+    {:noreply, push_patch(socket, to: ~p"/knative/services?#{params}")}
   end
-
-  defp assign_services(socket) do
-    assign(socket, :services, list_services())
-  end
-
-  defp assign_current_page(socket) do
-    assign(socket, :current_page, :devtools)
-  end
-
-  defp new_url, do: ~p"/knative/services/new"
 
   @impl Phoenix.LiveView
   def render(assigns) do
@@ -43,8 +41,19 @@ defmodule ControlServerWeb.Live.KnativeServicesIndex do
     </.page_header>
 
     <.panel title="All Services">
-      <.knative_services_table rows={@services} />
+      <:menu>
+        <.table_search
+          meta={@meta}
+          fields={[name: [op: :ilike]]}
+          placeholder="Filter by name"
+          on_change="search"
+        />
+      </:menu>
+
+      <.knative_services_table rows={@services} meta={@meta} />
     </.panel>
     """
   end
+
+  defp new_url, do: ~p"/knative/services/new"
 end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/knative/show.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/knative/show.ex
@@ -256,7 +256,7 @@ defmodule ControlServerWeb.Live.KnativeShow do
     <.header service={@service} timeline_installed={@timeline_installed} />
 
     <.panel title="Edit History">
-      <.edit_versions_table edit_versions={@edit_versions} abridged />
+      <.edit_versions_table rows={@edit_versions} abridged />
     </.panel>
     """
   end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/postgres/show.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/postgres/show.ex
@@ -276,7 +276,7 @@ defmodule ControlServerWeb.Live.PostgresShow do
     ~H"""
     <.page_header title="Edit History" back_link={show_url(@cluster)} />
     <.panel title="Edit History">
-      <.edit_versions_table edit_versions={@edit_versions} abridged />
+      <.edit_versions_table rows={@edit_versions} abridged />
     </.panel>
     """
   end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/projects/edit.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/projects/edit.ex
@@ -1,9 +1,10 @@
-defmodule ControlServerWeb.Projects.EditLive do
+defmodule ControlServerWeb.Live.ProjectsEdit do
   @moduledoc false
   use ControlServerWeb, {:live_view, layout: :sidebar}
 
   alias ControlServer.Projects
 
+  @impl Phoenix.LiveView
   def mount(%{"id" => id}, _session, socket) do
     project = Projects.get_project!(id)
     changeset = Projects.change_project(project)
@@ -15,6 +16,7 @@ defmodule ControlServerWeb.Projects.EditLive do
      |> assign(:project, project)}
   end
 
+  @impl Phoenix.LiveView
   def handle_event("validate", %{"project" => params}, socket) do
     changeset =
       socket.assigns.project
@@ -24,6 +26,7 @@ defmodule ControlServerWeb.Projects.EditLive do
     {:noreply, assign(socket, :form, to_form(changeset))}
   end
 
+  @impl Phoenix.LiveView
   def handle_event("save", %{"project" => params}, socket) do
     case Projects.update_project(socket.assigns.project, params) do
       {:ok, project} ->
@@ -37,6 +40,7 @@ defmodule ControlServerWeb.Projects.EditLive do
     end
   end
 
+  @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
     <.page_header title={@page_title} back_link={~p"/projects/#{@project.id}"}>

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/projects/index.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/projects/index.ex
@@ -1,4 +1,4 @@
-defmodule ControlServerWeb.Projects.IndexLive do
+defmodule ControlServerWeb.Live.ProjectsIndex do
   @moduledoc false
   use ControlServerWeb, {:live_view, layout: :sidebar}
 
@@ -6,10 +6,12 @@ defmodule ControlServerWeb.Projects.IndexLive do
 
   alias ControlServer.Projects
 
+  @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
     {:ok, assign(socket, :page_title, "Projects")}
   end
 
+  @impl Phoenix.LiveView
   def handle_params(params, _session, socket) do
     with {:ok, {projects, meta}} <- Projects.list_projects(params) do
       {:noreply,
@@ -20,12 +22,13 @@ defmodule ControlServerWeb.Projects.IndexLive do
     end
   end
 
+  @impl Phoenix.LiveView
   def handle_event("search", params, socket) do
     params = Map.delete(params, "_target")
-
     {:noreply, push_patch(socket, to: ~p"/projects?#{params}")}
   end
 
+  @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
     <.page_header title={@page_title} back_link={~p"/"}>

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/projects/new.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/projects/new.ex
@@ -1,4 +1,4 @@
-defmodule ControlServerWeb.Projects.NewLive do
+defmodule ControlServerWeb.Live.ProjectsNew do
   @moduledoc false
   use ControlServerWeb, {:live_view, layout: :sidebar}
 
@@ -26,6 +26,7 @@ defmodule ControlServerWeb.Projects.NewLive do
 
   require Logger
 
+  @impl Phoenix.LiveView
   def mount(params, _session, socket) do
     # Allow the back button to be dynamic and go back steps
     return_to = Map.get(params, "return_to", ~p"/projects")
@@ -44,6 +45,7 @@ defmodule ControlServerWeb.Projects.NewLive do
 
   # Moves back to the previous step, or navigates to the `return_to` URL query if on the first
   # step. This allows the back button to be dynamic and either move steps or do a live navigation.
+  @impl Phoenix.LiveView
   def handle_event("back", params, socket) do
     prev_index = Enum.find_index(socket.assigns.steps, &(&1 == socket.assigns.current_step)) - 1
     prev_step = Enum.at(socket.assigns.steps, prev_index)
@@ -57,6 +59,7 @@ defmodule ControlServerWeb.Projects.NewLive do
 
   # Updates the project steps when the type changes in the new project subform.
   # It also resets the form data so we don't create resources from a previously-selected type.
+  @impl Phoenix.LiveView
   def handle_info({:project_type, project_type}, socket) do
     {:noreply,
      socket
@@ -66,6 +69,7 @@ defmodule ControlServerWeb.Projects.NewLive do
 
   # Moves to the next step when sub-forms are submitted. This will store the sub-form data in the
   # assigns until the end of the new project flow, when all the resources will be created at once.
+  @impl Phoenix.LiveView
   def handle_info({:next, {step, step_data}}, socket) do
     form_data = Map.put(socket.assigns.form_data, step, step_data)
     next_index = Enum.find_index(socket.assigns.steps, &(&1 == step)) + 1
@@ -87,6 +91,7 @@ defmodule ControlServerWeb.Projects.NewLive do
     end
   end
 
+  @impl Phoenix.LiveView
   def handle_info({:async_installer, {:install_complete, _}}, socket) do
     # Pause for a moment to make sure the sexy loader is shown
     Process.sleep(1000)
@@ -118,6 +123,7 @@ defmodule ControlServerWeb.Projects.NewLive do
     end
   end
 
+  @impl Phoenix.LiveView
   def handle_info({:async_installer, _}, socket), do: {:noreply, socket}
 
   defp install_batteries(data) do
@@ -262,6 +268,7 @@ defmodule ControlServerWeb.Projects.NewLive do
     end
   end
 
+  @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
     <div class="flex flex-col h-full gap-8">

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/projects/show.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/projects/show.ex
@@ -1,4 +1,4 @@
-defmodule ControlServerWeb.Projects.ShowLive do
+defmodule ControlServerWeb.Live.ProjectsShow do
   @moduledoc false
   use ControlServerWeb, {:live_view, layout: :sidebar}
 
@@ -18,10 +18,12 @@ defmodule ControlServerWeb.Projects.ShowLive do
   alias KubeServices.SystemState.SummaryBatteries
   alias KubeServices.SystemState.SummaryURLs
 
+  @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
     {:ok, socket}
   end
 
+  @impl Phoenix.LiveView
   def handle_params(%{"id" => id}, _, socket) do
     {:noreply,
      socket
@@ -77,6 +79,7 @@ defmodule ControlServerWeb.Projects.ShowLive do
     assign(socket, :grafana_dashboard_url, url)
   end
 
+  @impl Phoenix.LiveView
   def handle_event("delete", _params, socket) do
     case Projects.delete_project(socket.assigns.project) do
       {:ok, _} ->
@@ -97,6 +100,7 @@ defmodule ControlServerWeb.Projects.ShowLive do
     end
   end
 
+  @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
     <.page_header title={@page_title} back_link={~p"/projects"}>

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/projects/timeline.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/projects/timeline.ex
@@ -1,9 +1,10 @@
-defmodule ControlServerWeb.Projects.TimelineLive do
+defmodule ControlServerWeb.Live.ProjectsTimeline do
   @moduledoc false
   use ControlServerWeb, {:live_view, layout: :sidebar}
 
   alias ControlServer.Projects
 
+  @impl Phoenix.LiveView
   def mount(%{"id" => id}, _session, socket) do
     {:ok,
      socket
@@ -11,6 +12,7 @@ defmodule ControlServerWeb.Projects.TimelineLive do
      |> assign(:project, Projects.get_project!(id))}
   end
 
+  @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
     <.page_header title={@page_title} back_link={~p"/projects/#{@project.id}"} />

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/redis/index.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/redis/index.ex
@@ -1,4 +1,4 @@
-defmodule ControlServerWeb.Live.Redis do
+defmodule ControlServerWeb.Live.RedisIndex do
   @moduledoc false
   use ControlServerWeb, {:live_view, layout: :sidebar}
 
@@ -10,41 +10,26 @@ defmodule ControlServerWeb.Live.Redis do
   def mount(_params, _session, socket) do
     {:ok,
      socket
-     |> assign(current_page: :data)
-     |> assign_page_title("Redis Clusters")
-     |> assign_failover_clusters()}
+     |> assign(:current_page, :data)
+     |> assign(:page_title, "Redis Clusters")}
   end
 
   @impl Phoenix.LiveView
-  def handle_params(params, _url, socket) do
-    {:noreply, apply_action(socket, socket.assigns.live_action, params)}
-  end
-
-  defp apply_action(socket, :index, _params) do
-    assign(socket, :failover_cluster, nil)
-  end
-
-  def assign_page_title(socket, page_title) do
-    assign(socket, page_title: page_title)
-  end
-
-  defp assign_failover_clusters(socket) do
-    assign(socket, :failover_clusters, list_failover_clusters())
+  def handle_params(params, _session, socket) do
+    with {:ok, {failover_clusters, meta}} <- Redis.list_failover_clusters(params) do
+      {:noreply,
+       socket
+       |> assign(:meta, meta)
+       |> assign(:failover_clusters, failover_clusters)
+       |> assign(:form, to_form(meta))}
+    end
   end
 
   @impl Phoenix.LiveView
-  def handle_event("delete", %{"id" => id}, socket) do
-    failover_cluster = Redis.get_failover_cluster!(id)
-    {:ok, _} = Redis.delete_failover_cluster(failover_cluster)
-
-    {:noreply, assign(socket, :failover_clusters, list_failover_clusters())}
+  def handle_event("search", params, socket) do
+    params = Map.delete(params, "_target")
+    {:noreply, push_patch(socket, to: ~p"/redis?#{params}")}
   end
-
-  defp list_failover_clusters do
-    Redis.list_failover_clusters()
-  end
-
-  def new_url, do: ~p"/redis/new"
 
   @impl Phoenix.LiveView
   def render(assigns) do
@@ -54,9 +39,21 @@ defmodule ControlServerWeb.Live.Redis do
         New Redis Cluster
       </.button>
     </.page_header>
+
     <.panel title="All Clusters">
-      <.redis_table rows={@failover_clusters} />
+      <:menu>
+        <.table_search
+          meta={@meta}
+          fields={[name: [op: :ilike]]}
+          placeholder="Filter by name"
+          on_change="search"
+        />
+      </:menu>
+
+      <.redis_table rows={@failover_clusters} meta={@meta} />
     </.panel>
     """
   end
+
+  def new_url, do: ~p"/redis/new"
 end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/traditional_services/index.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/traditional_services/index.ex
@@ -7,14 +7,32 @@ defmodule ControlServerWeb.Live.TraditionalServicesIndex do
 
   alias ControlServer.TraditionalServices
 
+  @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
     {:ok,
      socket
      |> assign(:current_page, :devtools)
-     |> assign(:page_title, "Traditional Services")
-     |> assign(:services, TraditionalServices.list_traditional_services())}
+     |> assign(:page_title, "Traditional Services")}
   end
 
+  @impl Phoenix.LiveView
+  def handle_params(params, _session, socket) do
+    with {:ok, {services, meta}} <- TraditionalServices.list_traditional_services(params) do
+      {:noreply,
+       socket
+       |> assign(:meta, meta)
+       |> assign(:services, services)
+       |> assign(:form, to_form(meta))}
+    end
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("search", params, socket) do
+    params = Map.delete(params, "_target")
+    {:noreply, push_patch(socket, to: ~p"/traditional_services?#{params}")}
+  end
+
+  @impl Phoenix.LiveView
   def render(assigns) do
     ~H"""
     <.page_header title={@page_title} back_link={~p"/devtools"}>
@@ -24,7 +42,16 @@ defmodule ControlServerWeb.Live.TraditionalServicesIndex do
     </.page_header>
 
     <.panel title="All Services">
-      <.traditional_services_table rows={@services} />
+      <:menu>
+        <.table_search
+          meta={@meta}
+          fields={[name: [op: :ilike]]}
+          placeholder="Filter by name"
+          on_change="search"
+        />
+      </:menu>
+
+      <.traditional_services_table rows={@services} meta={@meta} />
     </.panel>
     """
   end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/router.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/router.ex
@@ -51,22 +51,22 @@ defmodule ControlServerWeb.Router do
     live "/:umbrella_id/keycloak/:id", Live.KeycloakSnapshotShow, :index
   end
 
-  scope "/batteries", ControlServerWeb.GroupBatteries do
+  scope "/batteries", ControlServerWeb do
     pipe_through :browser
 
-    live "/:group", IndexLive
-    live "/:group/new/:battery_type", NewLive
-    live "/:group/edit/:battery_type", EditLive
+    live "/:group", Live.GroupBatteriesIndex
+    live "/:group/new/:battery_type", Live.GroupBatteriesNew
+    live "/:group/edit/:battery_type", Live.GroupBatteriesEdit
   end
 
-  scope "/projects", ControlServerWeb.Projects do
+  scope "/projects", ControlServerWeb do
     pipe_through :browser
 
-    live "/", IndexLive
-    live "/new", NewLive
-    live "/:id", ShowLive
-    live "/:id/edit", EditLive
-    live "/:id/timeline", TimelineLive
+    live "/", Live.ProjectsIndex
+    live "/new", Live.ProjectsNew
+    live "/:id", Live.ProjectsShow
+    live "/:id/edit", Live.ProjectsEdit
+    live "/:id/timeline", Live.ProjectsTimeline
   end
 
   scope "/kube", ControlServerWeb do
@@ -80,21 +80,21 @@ defmodule ControlServerWeb.Router do
 
     live "/raw/:resource_type/:namespace/:name", Live.RawResource, :index
 
-    live "/pod/:namespace/:name/events", PodLive.Show, :events
-    live "/pod/:namespace/:name/labels", PodLive.Show, :labels
-    live "/pod/:namespace/:name/security", PodLive.Show, :security
-    live "/pod/:namespace/:name/logs", PodLive.Show, :logs
-    live "/pod/:namespace/:name/show", PodLive.Show, :index
+    live "/pod/:namespace/:name/events", Live.PodShow, :events
+    live "/pod/:namespace/:name/labels", Live.PodShow, :labels
+    live "/pod/:namespace/:name/security", Live.PodShow, :security
+    live "/pod/:namespace/:name/logs", Live.PodShow, :logs
+    live "/pod/:namespace/:name/show", Live.PodShow, :index
 
-    live "/deployment/:namespace/:name/show", DeploymentLive.Show
-    live "/stateful_set/:namespace/:name/show", StatefulSetLive.Show
-    live "/service/:namespace/:name/show", ServiceLive.Show
+    live "/deployment/:namespace/:name/show", Live.DeploymentShow
+    live "/stateful_set/:namespace/:name/show", Live.StatefulSetShow
+    live "/service/:namespace/:name/show", Live.ServiceShow
   end
 
   scope "/redis", ControlServerWeb do
     pipe_through :browser
 
-    live "/", Live.Redis, :index
+    live "/", Live.RedisIndex, :index
     live "/new", Live.RedisNew, :new
     live "/:id/edit", Live.RedisEdit, :edit
     live "/:id/show", Live.RedisShow, :show
@@ -104,7 +104,7 @@ defmodule ControlServerWeb.Router do
   scope "/postgres", ControlServerWeb do
     pipe_through :browser
 
-    live "/", Live.PostgresClusters, :index
+    live "/", Live.PostgresIndex, :index
     live "/new", Live.PostgresNew, :new
     live "/:id/edit", Live.PostgresEdit, :edit
     live "/:id/show", Live.PostgresShow, :show
@@ -136,7 +136,7 @@ defmodule ControlServerWeb.Router do
   scope "/knative", ControlServerWeb do
     pipe_through :browser
 
-    live "/services", Live.KnativeServicesIndex, :index
+    live "/services", Live.KnativeIndex, :index
     live "/services/new", Live.KnativeNew, :new
     live "/services/:id/edit", Live.KnativeEdit, :edit
     live "/services/:id/show", Live.KnativeShow, :show

--- a/platform_umbrella/apps/control_server_web/test/__snapshots__/components/keycloak/tables_test/test_keycloak_clients_table__1_with_a_client.heyya_snap
+++ b/platform_umbrella/apps/control_server_web/test/__snapshots__/components/keycloak/tables_test/test_keycloak_clients_table__1_with_a_client.heyya_snap
@@ -8,7 +8,7 @@
     </thead>
 
     <tbody id="keycloak-clients-table-body" class="relative text-sm leading-6 text-gray-darkest dark:text-gray-lighter before:content-[&#39;@&#39;] before:block before:leading-3 before:indent-[-99999px]">
-      <tr class="cursor-pointer hover:bg-gray-lightest dark:hover:bg-gray-darkest-tint">
+      <tr class="">
         <td class="px-2 py-4 align-top first:rounded-l-lg last:rounded-r-lg first:font-semibold">
           admin-cli
         </td><td class="px-2 py-4 align-top first:rounded-l-lg last:rounded-r-lg first:font-semibold">

--- a/platform_umbrella/apps/control_server_web/test/__snapshots__/components/keycloak/tables_test/test_keycloak_users_table__1_with_a_user.heyya_snap
+++ b/platform_umbrella/apps/control_server_web/test/__snapshots__/components/keycloak/tables_test/test_keycloak_users_table__1_with_a_user.heyya_snap
@@ -10,7 +10,7 @@
     </thead>
 
     <tbody id="keycloak-users-table-body" class="relative text-sm leading-6 text-gray-darkest dark:text-gray-lighter before:content-[&#39;@&#39;] before:block before:leading-3 before:indent-[-99999px]">
-      <tr class="cursor-pointer hover:bg-gray-lightest dark:hover:bg-gray-darkest-tint">
+      <tr class="">
         <td class="px-2 py-4 align-top first:rounded-l-lg last:rounded-r-lg first:font-semibold">
           00-00-00-00-00-00-00-00-00-00-01
         </td><td class="px-2 py-4 align-top first:rounded-l-lg last:rounded-r-lg first:font-semibold">


### PR DESCRIPTION
This PR closes #371 by adding pagination to the following resources:

- Edit Versions
- FerretDB Services
- Knative Services
- Traditional Services
- IP Address Pools
- Jupyter Notebooks
- Postgres Clusters
- Redis Clusters
- Deleted Resources
- System Batteries (on home page)

It also adds a "Filter by name" input to the following resources:

- FerretDB Services
- Knative Services
- Traditional Services
- IP Address Pools
- Postgres Clusters
- Redis Clusters
- Deleted Resources

## Other Changes

- Fixes issue with non-clickable table row hover
- Better consistency in context functions, live components, and live views
- Removes `name` param in some fixtures to prevent unique index errors
- Fixes double-fetching of snapshots when a new deploy is created