### PR TITLE
fix: don't error out with no stable report

### DIFF
--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/state_summary.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/state_summary.ex
@@ -20,6 +20,7 @@ defmodule ControlServerWeb.Live.StateSummary do
       upgrade_control_server:
         state_summary
         |> Map.get(:stable_versions_report, %{})
+        |> Kernel.||(%{})
         |> Map.get(:control_server, CommonCore.Defaults.Images.control_server_image())
     )
   end
@@ -44,7 +45,7 @@ defmodule ControlServerWeb.Live.StateSummary do
       ) %>
     </.page_header>
 
-    <.grid columns={%{sm: 1, lg: 2, xl: 3}}>
+    <.grid columns={%{sm: 1, xl: 2}}>
       <.panel title="Batteries">
         <ul>
           <%= for battery <- @state_summary.batteries do %>


### PR DESCRIPTION
Summary:

Don't error out if there's no status report for getting the next version.
