### PR TITLE
fix: don't inject istio in postgres

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/resources/battery/battery_core.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/resources/battery/battery_core.ex
@@ -18,13 +18,14 @@ defmodule CommonCore.Resources.BatteryCore do
     |> B.build_resource()
     |> B.name(battery.config.base_namespace)
     |> B.label("elbv2.k8s.aws/service-webhook", "disabled")
+    |> B.label("istio-injection", "disabled")
   end
 
   resource(:data_namespace, battery, _state) do
     :namespace
     |> B.build_resource()
     |> B.name(battery.config.data_namespace)
-    |> B.label("istio-injection", "enabled")
+    |> B.label("istio-injection", "disabled")
   end
 
   resource(:ai_namespace, battery, _state) do


### PR DESCRIPTION
Summary:
Postgres uses certificates for authentication. So we don't want to
un-wrap the tls for databases.

Fixes: #612

Test Plan:
Started a 2 node postgres cluster.
