### PR TITLE
fix: typo in operational tools dropdown for static site

### DIFF
--- a/static/src/data/navigation.ts
+++ b/static/src/data/navigation.ts
@@ -50,7 +50,7 @@ export const headerData = [
       {
         label: 'Operational Tools',
         description:
-          'Ahe best tools for ops integrated into a single control panel.',
+          'All the best tools for ops integrated into a single control center.',
         icon: 'automation',
         link: '/solutions/sre_tools',
       },


### PR DESCRIPTION
Summary:
"Ahe best" -> "All the best tools"

Test Plan:
Netlify deploy preview
