### PR TITLE
feat: fix port-forwarding and automatically detect if we are using docker desktop

### DIFF
--- a/bi/pkg/cluster/kind/desktop.go
+++ b/bi/pkg/cluster/kind/desktop.go
@@ -1,0 +1,24 @@
+package kind
+
+import (
+	"context"
+	"fmt"
+
+	dockerclient "github.com/docker/docker/client"
+)
+
+// IsDockerDesktop checks if the current environment is Docker Desktop.
+func IsDockerDesktop(ctx context.Context) (bool, error) {
+	cli, err := dockerclient.NewClientWithOpts(dockerclient.FromEnv, dockerclient.WithAPIVersionNegotiation())
+	if err != nil {
+		return false, fmt.Errorf("failed to create docker client: %w", err)
+	}
+
+	info, err := cli.Info(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to get docker server info: %w", err)
+	}
+
+	// Check if we are running in Docker Desktop.
+	return info.OperatingSystem == "Docker Desktop", nil
+}

--- a/bi/pkg/installs/env.go
+++ b/bi/pkg/installs/env.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"runtime"
 
 	"bi/pkg/specs"
 
@@ -53,7 +52,12 @@ func (env *InstallEnv) init(ctx context.Context) error {
 
 	switch provider {
 	case "kind":
-		gatewayEnabled := runtime.GOOS != "linux" && usage != "internal_dev"
+		dockerDesktop, err := kind.IsDockerDesktop(ctx)
+		if err != nil {
+			return err
+		}
+
+		gatewayEnabled := dockerDesktop && usage != "internal_dev"
 		env.clusterProvider = kind.NewClusterProvider(slog.Default(), env.Slug, gatewayEnabled)
 	case "aws":
 		env.clusterProvider = cluster.NewPulumiProvider(env.Slug)

--- a/bi/pkg/kube/port_forward.go
+++ b/bi/pkg/kube/port_forward.go
@@ -54,34 +54,22 @@ func (kubeClient *batteryKubeClient) portForward(
 
 	cfg := kubeClient.cfg
 
-	tlsConfig, err := restclient.TLSConfigFor(cfg)
-	if err != nil {
-		return nil, err
-	}
-
-	proxy := http.ProxyFromEnvironment
-	if cfg.Proxy != nil {
-		proxy = cfg.Proxy
-	}
-
 	upgradeTransport, err := restclient.TransportFor(cfg)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error getting transport for config: %w", err)
 	}
 
 	upgrader, err := httpstreamspdy.NewRoundTripperWithConfig(httpstreamspdy.RoundTripperConfig{
-		TLS:              tlsConfig,
-		Proxier:          proxy,
-		PingPeriod:       time.Second * 5,
 		UpgradeTransport: upgradeTransport,
+		PingPeriod:       time.Second * 5,
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error creating spdy round tripper: %w", err)
 	}
 
 	transport, err := restclient.HTTPWrappersForConfig(cfg, upgrader)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error creating http wrappers for config: %w", err)
 	}
 
 	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, http.MethodPost, url)


### PR DESCRIPTION
* For some reason, the client-go built in spdy helpers completely ignored the dialer in the rest.Config.
* Automatically detect if we are using docker desktop rather than relying on hardcoded OS assumptions.

Once merged we can tentatively look at reenabling the gateway in the dev configuration.