### PR TITLE
fix(internal-int-test): make homebase smaller and expose public services

### DIFF
--- a/bootstrap/damian.install.json
+++ b/bootstrap/damian.install.json
@@ -1,18 +1,18 @@
 {
-  "id": "batt_01917fb0f36f77e28fa574e3813a655e",
+  "id": "batt_0191808e3e3f7bdda5050d6e0ab1088f",
   "usage": "development",
   "default_size": "small",
   "control_jwk": {
     "crv": "Ed25519",
-    "d": "NLQRZk6PV8a8-jvsPRD7j4uHUiskJXbDkpcdvnbtgMs",
+    "d": "yWXzoUlvTdUvz7cjjcGHl-DU_cCkI8mZL1C3ijC6MfE",
     "kty": "OKP",
-    "x": "0fbzEPYDWplrPIr8tYQEbj6god9ZQFR6_RN0s-to7n0"
+    "x": "VGXREBG5MefdBSpVAu4oofh_Vgq_6e3xGNAhw6RJ7gc"
   },
   "inserted_at": null,
   "updated_at": null,
   "slug": "damian",
   "kube_provider": "aws",
-  "team_id": "batt_01917fb0f3187690a9b74a60fa13828c",
+  "team_id": "batt_0191808e3dee71769cb97e44ee965206",
   "kube_provider_config": {},
   "user_id": null
 }

--- a/bootstrap/damian.spec.json
+++ b/bootstrap/damian.spec.json
@@ -9,7 +9,7 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_01917fb0f37e7d7f997f63b09396defc",
+        "id": "batt_0191808e3e5071f99e49948366ae5eda",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -22,12 +22,12 @@
           "default_size": "small",
           "cluster_name": "damian",
           "server_in_cluster": true,
-          "install_id": "batt_01917fb0f36f77e28fa574e3813a655e",
+          "install_id": "batt_0191808e3e3f7bdda5050d6e0ab1088f",
           "control_jwk": {
             "crv": "Ed25519",
-            "d": "NLQRZk6PV8a8-jvsPRD7j4uHUiskJXbDkpcdvnbtgMs",
+            "d": "yWXzoUlvTdUvz7cjjcGHl-DU_cCkI8mZL1C3ijC6MfE",
             "kty": "OKP",
-            "x": "0fbzEPYDWplrPIr8tYQEbj6god9ZQFR6_RN0s-to7n0"
+            "x": "VGXREBG5MefdBSpVAu4oofh_Vgq_6e3xGNAhw6RJ7gc"
           },
           "upgrade_days_of_week": [
             true,
@@ -52,7 +52,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37e7e74a37963ef623953a1",
+        "id": "batt_0191808e3e50716f9d3b8c9080f49338",
         "type": "karpenter",
         "config": {
           "type": "karpenter",
@@ -67,7 +67,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37e7a30a36a3aac995cbe02",
+        "id": "batt_0191808e3e50791c98a104b04d24eb16",
         "type": "cert_manager",
         "config": {
           "type": "cert_manager",
@@ -88,7 +88,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37e74f7af10d75d3ff138f8",
+        "id": "batt_0191808e3e507d93b5b1f7eaf3b66c3b",
         "type": "battery_ca",
         "config": {
           "type": "battery_ca"
@@ -98,7 +98,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37e7c35b2c86d30e59d9040",
+        "id": "batt_0191808e3e50751f850154d8f03f1bfb",
         "type": "aws_load_balancer_controller",
         "config": {
           "type": "aws_load_balancer_controller",
@@ -113,7 +113,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37e79f4836991b4ed3d318e",
+        "id": "batt_0191808e3e50700f9873876ab4368bfb",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
@@ -125,7 +125,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37e7b1aad324f9e0ee69776",
+        "id": "batt_0191808e3e5072f8998641604f7e839a",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -139,7 +139,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37e74769b6848a80ecb71ac",
+        "id": "batt_0191808e3e507eb2b60890ee6388f7ba",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -151,7 +151,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37e738b839a4f2cd377692f",
+        "id": "batt_0191808e3e507a19816cb163797d3b6e",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -195,7 +195,7 @@
           {
             "version": 1,
             "username": "battery-control-user",
-            "password": "YU7N4HWQXNRP5KTTJ66WXBSI"
+            "password": "YQBYDS5TF5GSPYBGXHPOTRPJ"
           }
         ],
         "cpu_requested": 500,
@@ -221,7 +221,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "NZD2WQ5BJZHRTU55FQ7ZNDKA7FGI6XEFAMQCFJWFBK6BHWLF32NA===="
+          "battery/hash": "ZLZIPQZ4CK4RDU6WNM3K7ML3KXG6MZV5LKQVWRFJKGKSSUFKDOQQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -231,7 +231,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f37e7d7f997f63b09396defc",
+          "battery/owner": "batt_0191808e3e5071f99e49948366ae5eda",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -254,7 +254,7 @@
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "S47R4QSSVS5ZR7Z2TSETMYLPY3BTQAL56TVMHQ2RIR4OOIPDRJEA===="
+          "battery/hash": "L4KJMJGAC4OPMW2NRUYPRLAL7YC3XBROUKE4QQ2EWET4I2ZQMFPQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -264,7 +264,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f37e7d7f997f63b09396defc",
+          "battery/owner": "batt_0191808e3e5071f99e49948366ae5eda",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -288,7 +288,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_01917fb0f37e7d7f997f63b09396defc",
+              "battery/owner": "batt_0191808e3e5071f99e49948366ae5eda",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -301,7 +301,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "B7RJWCNNVSNBJJHWY4OTYUEA32BNYUDQJ5IZSC62R52YYAZJPMOE77PRGRB5Z77A"
+                    "value": "IE5WPOGUWMU2OJ3S4SHSDUIBBYQKZ36POQDLX5LAXJGLGIK4YH7X4XXRA3H5HLIO"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -349,7 +349,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "KCMAXUQE3REZ26NKHJZGHWMXP2VQNYXUAHYZCOZP4R6WF7TCX5MA===="
+          "battery/hash": "BPXWJBTYTABNQPK4LCLTCA3RUOQTVINLG2PCSWMPFLWFT4GSXZLA===="
         },
         "labels": {
           "app": "battery-core",
@@ -359,7 +359,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f37e7d7f997f63b09396defc",
+          "battery/owner": "batt_0191808e3e5071f99e49948366ae5eda",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -371,7 +371,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "JR2O3FOMUNDTMMWXLLSN2HY7DUGCFSVNXEBQ6YPB3PINUAWZBQAA===="
+          "battery/hash": "5EP44TNKVIUIO3AKIL5YAL6XCRYAY6XDQZNMNUUQTPRL3EYHCBNQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -381,7 +381,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f37e7d7f997f63b09396defc",
+          "battery/owner": "batt_0191808e3e5071f99e49948366ae5eda",
           "version": "latest"
         },
         "name": "bootstrap",
@@ -394,7 +394,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "IF6XAUSJKODHT7JZDJLL5NL4QVXOU47LN5QZUPC5IS3IMI3DO3NQ====",
+          "battery/hash": "6XI5776ZKHBJCES5HVLLRI7YLMSTHYUHDI5IGZ5SEIOAVGS6XS4A====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -405,7 +405,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f37e7d7f997f63b09396defc",
+          "battery/owner": "batt_0191808e3e5071f99e49948366ae5eda",
           "version": "latest"
         },
         "name": "gp2"
@@ -420,7 +420,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "2SEPJKEIFRYNJNS36YEIH25A72543T2Y44R7D74GM4CRKW56DQZA====",
+          "battery/hash": "3IDNBTT73KCWTBIEONNZRZRQGSUTMET6A4LEKUCY4VJETDQMQEFQ====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -431,7 +431,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f37e7d7f997f63b09396defc",
+          "battery/owner": "batt_0191808e3e5071f99e49948366ae5eda",
           "version": "latest"
         },
         "name": "gp2-90032408"
@@ -451,7 +451,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "YRSA52WASL2S2BCQOCCILP2TZU54KYFCIBZR4L4U6SYYK6XENE7A====",
+          "battery/hash": "ZTGQXSAG7HGCOISIO3DJP7UVTEWTI662G577DBBEN6NKFTJRWB5Q====",
           "storageclass.kubernetes.io/is-default-class": "true"
         },
         "labels": {
@@ -462,7 +462,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f37e7d7f997f63b09396defc",
+          "battery/owner": "batt_0191808e3e5071f99e49948366ae5eda",
           "version": "latest"
         },
         "name": "gp3-105457460"

--- a/bootstrap/dev.install.json
+++ b/bootstrap/dev.install.json
@@ -1,18 +1,18 @@
 {
-  "id": "batt_01917fb0f31b7f9ebb1f2ac7c23b7faa",
+  "id": "batt_0191808e3df17ddfb6af4642c1be833f",
   "usage": "internal_dev",
   "default_size": "tiny",
   "control_jwk": {
     "crv": "Ed25519",
-    "d": "RU5Y2TCrELsWN6XA6GVfXjbt8KN5fNU4EvskWVNeBns",
+    "d": "1QnM9jWw_EJnRuR-XunfjUx8AaQuLI6Qs1D05PhH-tU",
     "kty": "OKP",
-    "x": "AVooCGi1mJuUe0vqspQYwTT-d4EqP3rjyDJkhKOslIk"
+    "x": "imkCxdCjRg4AcmPe2-cvEfaXBSqk9JHq_nrOQcN08AM"
   },
   "inserted_at": null,
   "updated_at": null,
   "slug": "dev",
   "kube_provider": "kind",
-  "team_id": "batt_01917fb0f3187690a9b74a60fa13828c",
+  "team_id": "batt_0191808e3dee71769cb97e44ee965206",
   "kube_provider_config": {},
   "user_id": null
 }

--- a/bootstrap/dev.spec.json
+++ b/bootstrap/dev.spec.json
@@ -9,7 +9,7 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_01917fb0f3767634b0f61878b2efd57a",
+        "id": "batt_0191808e3e4973ed956a4a9ec0e90709",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -23,7 +23,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f3767da98ae1d4b65db031c9",
+        "id": "batt_0191808e3e49779d9dcf76445fd6ccd1",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -35,7 +35,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f376782f9bf5468aaaf18ab2",
+        "id": "batt_0191808e3e4979ed8a3f33c769dc4b0d",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -48,12 +48,12 @@
           "default_size": "tiny",
           "cluster_name": "dev",
           "server_in_cluster": false,
-          "install_id": "batt_01917fb0f31b7f9ebb1f2ac7c23b7faa",
+          "install_id": "batt_0191808e3df17ddfb6af4642c1be833f",
           "control_jwk": {
             "crv": "Ed25519",
-            "d": "RU5Y2TCrELsWN6XA6GVfXjbt8KN5fNU4EvskWVNeBns",
+            "d": "1QnM9jWw_EJnRuR-XunfjUx8AaQuLI6Qs1D05PhH-tU",
             "kty": "OKP",
-            "x": "AVooCGi1mJuUe0vqspQYwTT-d4EqP3rjyDJkhKOslIk"
+            "x": "imkCxdCjRg4AcmPe2-cvEfaXBSqk9JHq_nrOQcN08AM"
           },
           "upgrade_days_of_week": [
             true,
@@ -78,7 +78,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f3767f0897bcbb5cc14c8c14",
+        "id": "batt_0191808e3e497e55bb410576127529f0",
         "type": "metallb",
         "config": {
           "type": "metallb",
@@ -95,7 +95,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f3767c6696a60a041ddd474f",
+        "id": "batt_0191808e3e4974e0baaf07f1c6060d75",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
@@ -107,7 +107,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f376713d99828a5daa977438",
+        "id": "batt_0191808e3e497bb9bb794a1de929bc77",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -162,7 +162,7 @@
           {
             "version": 2,
             "username": "battery-control-user",
-            "password": "OLYBAXNIPB3B3I5HMRZMPGHC"
+            "password": "SM7A7SFGVMRWGDDYRY6RSUSL"
           },
           {
             "version": 1,
@@ -193,7 +193,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "BGCXRBZZSWMTFMLENZM345RTYTI6WQC3JYZS6PBFQERGOGS3VZBA===="
+          "battery/hash": "OYPNLDHZJLET6DGCCIZDTURFRBSY3UZGOUGGPPPWTLGMQ4ZROUDQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -203,7 +203,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f376782f9bf5468aaaf18ab2",
+          "battery/owner": "batt_0191808e3e4979ed8a3f33c769dc4b0d",
           "istio-injection": "enabled",
           "version": "latest"
         },

--- a/bootstrap/elliott.install.json
+++ b/bootstrap/elliott.install.json
@@ -1,18 +1,18 @@
 {
-  "id": "batt_01917fb0f36e775594e799bcf8d65142",
+  "id": "batt_0191808e3e3f7dc294b9c1b77978f4c7",
   "usage": "development",
   "default_size": "small",
   "control_jwk": {
     "crv": "Ed25519",
-    "d": "-sZ7COyAOgO12wEsdQfOHPCSLt8GztaXAJsBhsQo8jA",
+    "d": "ApxPU0jKmm6dVoLFpj3Y29Ij-LBqBDtCJtAkozK9_Xk",
     "kty": "OKP",
-    "x": "CWrlQclRHrt1MjJYVDwbvxhxMqTUzZVxC5hYC1msDjo"
+    "x": "fEYb84z6KcLZ9hkPl9-NlqQGxYYgOSzLLY1_FyjonJY"
   },
   "inserted_at": null,
   "updated_at": null,
   "slug": "elliott",
   "kube_provider": "aws",
-  "team_id": "batt_01917fb0f3187690a9b74a60fa13828c",
+  "team_id": "batt_0191808e3dee71769cb97e44ee965206",
   "kube_provider_config": {},
   "user_id": null
 }

--- a/bootstrap/elliott.spec.json
+++ b/bootstrap/elliott.spec.json
@@ -9,7 +9,7 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_01917fb0f37c73c48d05114bc286dbe0",
+        "id": "batt_0191808e3e4e7a6491f41de5372e4ce1",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -22,12 +22,12 @@
           "default_size": "small",
           "cluster_name": "elliott",
           "server_in_cluster": true,
-          "install_id": "batt_01917fb0f36e775594e799bcf8d65142",
+          "install_id": "batt_0191808e3e3f7dc294b9c1b77978f4c7",
           "control_jwk": {
             "crv": "Ed25519",
-            "d": "-sZ7COyAOgO12wEsdQfOHPCSLt8GztaXAJsBhsQo8jA",
+            "d": "ApxPU0jKmm6dVoLFpj3Y29Ij-LBqBDtCJtAkozK9_Xk",
             "kty": "OKP",
-            "x": "CWrlQclRHrt1MjJYVDwbvxhxMqTUzZVxC5hYC1msDjo"
+            "x": "fEYb84z6KcLZ9hkPl9-NlqQGxYYgOSzLLY1_FyjonJY"
           },
           "upgrade_days_of_week": [
             true,
@@ -52,7 +52,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37c705fac421f0bf8aa17d9",
+        "id": "batt_0191808e3e4e72d4919b72cdb407e1c1",
         "type": "karpenter",
         "config": {
           "type": "karpenter",
@@ -67,7 +67,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37c7880a990382afad5292b",
+        "id": "batt_0191808e3e4e705ba0e47f3041f7d318",
         "type": "cert_manager",
         "config": {
           "type": "cert_manager",
@@ -88,7 +88,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37c77e4bade0306b21d100d",
+        "id": "batt_0191808e3e4e7c68ae87a3b796303fec",
         "type": "battery_ca",
         "config": {
           "type": "battery_ca"
@@ -98,7 +98,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37c7ba49404692319a7a027",
+        "id": "batt_0191808e3e4e7adb95be0a3ac8ca003b",
         "type": "aws_load_balancer_controller",
         "config": {
           "type": "aws_load_balancer_controller",
@@ -113,7 +113,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37c77719386148846ebc2d7",
+        "id": "batt_0191808e3e4e7e9899b4d6db5970e36d",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
@@ -125,7 +125,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37c77b297787c2f72b9f229",
+        "id": "batt_0191808e3e4e7e8ab90c54c65e09d7e7",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -139,7 +139,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37c749da6f1291deb90fa7f",
+        "id": "batt_0191808e3e4e76aa82ec313514f59425",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -151,7 +151,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37c722a876f0ce0fcd98c47",
+        "id": "batt_0191808e3e4e7dac8340875a437875b1",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -195,7 +195,7 @@
           {
             "version": 1,
             "username": "battery-control-user",
-            "password": "ZUWKQK65WRIOZTRENDZ6GSWM"
+            "password": "LYVWJL2OZAQS6L2PRD6CGPOP"
           }
         ],
         "cpu_requested": 500,
@@ -221,7 +221,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "AESYPNIUYMVLF3ASLAIPAF5XIBPKXHNXDLO7HWMXYSEQ75627N3A===="
+          "battery/hash": "H6WMOLSJ4NMIHFNHQBDF2X33MGX4O2GIUVDS2PXSXEK2N5DY7QBA===="
         },
         "labels": {
           "app": "battery-core",
@@ -231,7 +231,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f37c73c48d05114bc286dbe0",
+          "battery/owner": "batt_0191808e3e4e7a6491f41de5372e4ce1",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -254,7 +254,7 @@
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "TVPPZLB2B5MC4E75FKTYXWSOYUMQM5NU2CDTNE5WJ6CFQ2M4ARBQ===="
+          "battery/hash": "RW7RSH5CCQ73G54JQ5D7SAMCIKOXJXSD4ZBNFIZ7UQG7QFVXYVYQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -264,7 +264,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f37c73c48d05114bc286dbe0",
+          "battery/owner": "batt_0191808e3e4e7a6491f41de5372e4ce1",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -288,7 +288,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_01917fb0f37c73c48d05114bc286dbe0",
+              "battery/owner": "batt_0191808e3e4e7a6491f41de5372e4ce1",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -301,7 +301,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "XSJVALTXCWDIY5YBUEK63FJHEL4QN4FR5RE3CZAPPFKV4T6XSKL5IOT4P2D3P6LI"
+                    "value": "57CNSNUU33ZOCYSLA642ARRPM5TTK6LZL3RS4RS4I7SCMRIR2UOMG5M4LP7SBY7T"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -349,7 +349,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "PJPAK5NNMVXOS2DS3CM5L5QVMDOVPP25J7WQXGARMRVJ3R2XZQJQ===="
+          "battery/hash": "43PJUZYJH3HCCCPAUEMOMJMS4MOVROCDAOILGUFD65TN6SZ6QCXA===="
         },
         "labels": {
           "app": "battery-core",
@@ -359,7 +359,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f37c73c48d05114bc286dbe0",
+          "battery/owner": "batt_0191808e3e4e7a6491f41de5372e4ce1",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -371,7 +371,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "SHPTDCE45O2RVY2JYBXW5EOXUU2VIVG3OMJQA6EHW3HEUTVMSXYQ===="
+          "battery/hash": "63DFFVCD2PCFKPRTMR67LTLODPRP2F7CRJVEHXAEGBPHREO6VPSQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -381,7 +381,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f37c73c48d05114bc286dbe0",
+          "battery/owner": "batt_0191808e3e4e7a6491f41de5372e4ce1",
           "version": "latest"
         },
         "name": "bootstrap",
@@ -394,7 +394,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "MK3PXCU6AEN6ERLMLJHJHYYP6ULZDBXSJNRJE43HGKZQ3PQFC42Q====",
+          "battery/hash": "JLSMHVFPC23DDIKAMQ5TWMB7TD7H6KSOEORGJ3EFWWYFFPPRQNGQ====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -405,7 +405,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f37c73c48d05114bc286dbe0",
+          "battery/owner": "batt_0191808e3e4e7a6491f41de5372e4ce1",
           "version": "latest"
         },
         "name": "gp2"
@@ -420,7 +420,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "PCLRVCLNTZBGHH3P4G734DPRNRQWOYRJ3WFZQ6BKKSDPWZS3Z44A====",
+          "battery/hash": "56RMIZU6RW3UNA7QP7GHWTLZI4GQVFE57XCCPLGDBY2UCP6LYB6Q====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -431,7 +431,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f37c73c48d05114bc286dbe0",
+          "battery/owner": "batt_0191808e3e4e7a6491f41de5372e4ce1",
           "version": "latest"
         },
         "name": "gp2-90032408"
@@ -451,7 +451,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "W4S33A2I6ON52KMW4IMDLL4X2GXKSWU7VT6ZTIKZQZOJRUNFT3KQ====",
+          "battery/hash": "NEPJ2F43Y56TJAT33BBQ7XOJUF3MWWAYR4VBXY2FWNDUEZJS32QA====",
           "storageclass.kubernetes.io/is-default-class": "true"
         },
         "labels": {
@@ -462,7 +462,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f37c73c48d05114bc286dbe0",
+          "battery/owner": "batt_0191808e3e4e7a6491f41de5372e4ce1",
           "version": "latest"
         },
         "name": "gp3-105457460"

--- a/bootstrap/int-prod.install.json
+++ b/bootstrap/int-prod.install.json
@@ -1,18 +1,18 @@
 {
-  "id": "batt_01917fb0f36e7705bf1b78dcbe5c1e60",
+  "id": "batt_0191808e3e3f72108db3cdc66ea159f9",
   "usage": "internal_prod",
   "default_size": "medium",
   "control_jwk": {
     "crv": "Ed25519",
-    "d": "nCAtEeRvFaCeSW2B4CDZHjZtLkpxwOHNCfcGp37MqwI",
+    "d": "H_vq3IC05FqzxkdD_npx0tPUes8fKCrZoVjSMRckpC0",
     "kty": "OKP",
-    "x": "dOHWv4tYz9PclVpymZB032m0uAfYfRj9VYsOXKOozTs"
+    "x": "25tJDeP3yEoh0OBeZv6l7Qp_nw-VhT5p5GrC1OF93hg"
   },
   "inserted_at": null,
   "updated_at": null,
   "slug": "int-prod",
   "kube_provider": "kind",
-  "team_id": "batt_01917fb0f3187690a9b74a60fa13828c",
+  "team_id": "batt_0191808e3dee71769cb97e44ee965206",
   "kube_provider_config": {},
   "user_id": null
 }

--- a/bootstrap/int-prod.spec.json
+++ b/bootstrap/int-prod.spec.json
@@ -9,7 +9,7 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_01917fb0f37a779e973ae870af35db1f",
+        "id": "batt_0191808e3e4c7681b6a82ad1ab054994",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -23,7 +23,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37a78bab446b273b6363f6e",
+        "id": "batt_0191808e3e4c7415bbc4a2a6238aa72d",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -35,7 +35,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37a77719fc23ae0ce44ca4e",
+        "id": "batt_0191808e3e4c733bb07dd9af9758bf84",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -48,12 +48,12 @@
           "default_size": "medium",
           "cluster_name": "int-prod",
           "server_in_cluster": true,
-          "install_id": "batt_01917fb0f36e7705bf1b78dcbe5c1e60",
+          "install_id": "batt_0191808e3e3f72108db3cdc66ea159f9",
           "control_jwk": {
             "crv": "Ed25519",
-            "d": "nCAtEeRvFaCeSW2B4CDZHjZtLkpxwOHNCfcGp37MqwI",
+            "d": "H_vq3IC05FqzxkdD_npx0tPUes8fKCrZoVjSMRckpC0",
             "kty": "OKP",
-            "x": "dOHWv4tYz9PclVpymZB032m0uAfYfRj9VYsOXKOozTs"
+            "x": "25tJDeP3yEoh0OBeZv6l7Qp_nw-VhT5p5GrC1OF93hg"
           },
           "upgrade_days_of_week": [
             true,
@@ -78,7 +78,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37a71ad8c75d797db231589",
+        "id": "batt_0191808e3e4c7012aaae401568ce3025",
         "type": "metallb",
         "config": {
           "type": "metallb",
@@ -95,7 +95,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37a75a8870d733d0897e689",
+        "id": "batt_0191808e3e4c7a2fa4517e18d2d4e81b",
         "type": "traditional_services",
         "config": {
           "type": "traditional_services",
@@ -107,7 +107,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37a718f8d428670d0e94bb3",
+        "id": "batt_0191808e3e4c71de897093427870480a",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
@@ -119,7 +119,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37a7126b38500d3600addc7",
+        "id": "batt_0191808e3e4c7d8aa760ac7796160a87",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -147,7 +147,7 @@
         "env_values": [
           {
             "name": "SECRET_KEY_BASE",
-            "value": "6NID6L3OVY6YPD6RNJERGFV6Y6PSUN7M7RTXOPUXQXTO6WAHBRG67L7W4WXVLO6I",
+            "value": "X7PBNMH22BMGTETFR2STBNLMSL3VSJFGIDFPPSJE5IHIB3OFSTOHRCSAMOKIJFPL",
             "source_name": null,
             "source_type": "value",
             "source_key": null,
@@ -270,7 +270,7 @@
           {
             "version": 1,
             "username": "battery-control-user",
-            "password": "ZGHWB3JMSKTMYADJF4SQ4KFQ"
+            "password": "6LJB7KVH37NU3BEG3BU25BK5"
           }
         ],
         "cpu_requested": 4000,
@@ -311,7 +311,7 @@
           {
             "version": 1,
             "username": "home-base",
-            "password": "BTMWNF7EXJD5TKJH7TA4JO37"
+            "password": "NNSUFUQVDEWRFMHPFFUITVY7"
           }
         ],
         "cpu_requested": 4000,
@@ -337,7 +337,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "V6BVBLZ4HSR2IDYIUNGITBI4D4Z7DJIOASO4PAA6YAT22P37GLFA===="
+          "battery/hash": "5PRW6KUTYPHXPVR7LK5ANUEW2VFUAAUAXYOEMQYIPKM3CHGRR3HQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -347,7 +347,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f37a77719fc23ae0ce44ca4e",
+          "battery/owner": "batt_0191808e3e4c733bb07dd9af9758bf84",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -368,20 +368,20 @@
     "/config_map/home_base_seed_data": {
       "apiVersion": "v1",
       "data": {
-        "batt_01917fb0f3187690a9b74a60fa13828c.team.json": "{\"id\":\"batt_01917fb0f3187690a9b74a60fa13828c\",\"name\":\"Batteries Included Team\",\"inserted_at\":null,\"updated_at\":null,\"op_email\":\"elliott@batteriesincl.com\"}",
-        "damian.install.json": "{\"id\":\"batt_01917fb0f36f77e28fa574e3813a655e\",\"usage\":\"development\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"NLQRZk6PV8a8-jvsPRD7j4uHUiskJXbDkpcdvnbtgMs\",\"kty\":\"OKP\",\"x\":\"0fbzEPYDWplrPIr8tYQEbj6god9ZQFR6_RN0s-to7n0\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"damian\",\"kube_provider\":\"aws\",\"team_id\":\"batt_01917fb0f3187690a9b74a60fa13828c\",\"kube_provider_config\":{},\"user_id\":null}",
-        "dev.install.json": "{\"id\":\"batt_01917fb0f31b7f9ebb1f2ac7c23b7faa\",\"usage\":\"internal_dev\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"RU5Y2TCrELsWN6XA6GVfXjbt8KN5fNU4EvskWVNeBns\",\"kty\":\"OKP\",\"x\":\"AVooCGi1mJuUe0vqspQYwTT-d4EqP3rjyDJkhKOslIk\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"dev\",\"kube_provider\":\"kind\",\"team_id\":\"batt_01917fb0f3187690a9b74a60fa13828c\",\"kube_provider_config\":{},\"user_id\":null}",
-        "elliott.install.json": "{\"id\":\"batt_01917fb0f36e775594e799bcf8d65142\",\"usage\":\"development\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"-sZ7COyAOgO12wEsdQfOHPCSLt8GztaXAJsBhsQo8jA\",\"kty\":\"OKP\",\"x\":\"CWrlQclRHrt1MjJYVDwbvxhxMqTUzZVxC5hYC1msDjo\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"elliott\",\"kube_provider\":\"aws\",\"team_id\":\"batt_01917fb0f3187690a9b74a60fa13828c\",\"kube_provider_config\":{},\"user_id\":null}",
-        "int-prod.install.json": "{\"id\":\"batt_01917fb0f36e7705bf1b78dcbe5c1e60\",\"usage\":\"internal_prod\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"nCAtEeRvFaCeSW2B4CDZHjZtLkpxwOHNCfcGp37MqwI\",\"kty\":\"OKP\",\"x\":\"dOHWv4tYz9PclVpymZB032m0uAfYfRj9VYsOXKOozTs\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"int-prod\",\"kube_provider\":\"kind\",\"team_id\":\"batt_01917fb0f3187690a9b74a60fa13828c\",\"kube_provider_config\":{},\"user_id\":null}",
-        "int-test.install.json": "{\"id\":\"batt_01917fb0f36e7049b9fa9690f94a494c\",\"usage\":\"internal_int_test\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"-vba3-GB_3klw4NrgwoGwyTS44JggohqSCRSeJF7I2A\",\"kty\":\"OKP\",\"x\":\"6h2Z0OwagDcLvzI3fQmv1OkNWJ42YP794uJT9y-NCA4\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"int-test\",\"kube_provider\":\"kind\",\"team_id\":\"batt_01917fb0f3187690a9b74a60fa13828c\",\"kube_provider_config\":{},\"user_id\":null}",
-        "jason.install.json": "{\"id\":\"batt_01917fb0f36f7d2ebd4690ff52ad3198\",\"usage\":\"development\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"WVGBDmC6tZhOQBcFrs9j0I8vsHTybHstAkq1l6bjya8\",\"kty\":\"OKP\",\"x\":\"usRWlro_Wl2dPOZkYEHtipi9026rVZyp8u5v_8rTJ6M\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"jason\",\"kube_provider\":\"aws\",\"team_id\":\"batt_01917fb0f3187690a9b74a60fa13828c\",\"kube_provider_config\":{},\"user_id\":null}",
-        "local.install.json": "{\"id\":\"batt_01917fb0f36e760e992c0d6cb9a807a3\",\"usage\":\"development\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"XCG2bD5RwUqCzJqEkC0EKnYtVVakuvDVsGpaGWGqmPY\",\"kty\":\"OKP\",\"x\":\"y2KY2VucdH8bhdsDXWb4UF02_LXBEXaudae-h__LIwM\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"local\",\"kube_provider\":\"kind\",\"team_id\":\"batt_01917fb0f3187690a9b74a60fa13828c\",\"kube_provider_config\":{},\"user_id\":null}",
-        "maurer.install.json": "{\"id\":\"batt_01917fb0f36f71448bd9c50a0231dab0\",\"usage\":\"development\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"1smOp3FS6LSlnRUG3U-D55kKbWBMmmhX3v9UW8ye9ZA\",\"kty\":\"OKP\",\"x\":\"ZJEv8RxKg6cHrV1UpXaWtZwOhFCwBH26yHZ2P2PJbDI\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"maurer\",\"kube_provider\":\"aws\",\"team_id\":\"batt_01917fb0f3187690a9b74a60fa13828c\",\"kube_provider_config\":{},\"user_id\":null}"
+        "batt_0191808e3dee71769cb97e44ee965206.team.json": "{\"id\":\"batt_0191808e3dee71769cb97e44ee965206\",\"name\":\"Batteries Included Team\",\"inserted_at\":null,\"updated_at\":null,\"op_email\":\"elliott@batteriesincl.com\"}",
+        "damian.install.json": "{\"id\":\"batt_0191808e3e3f7bdda5050d6e0ab1088f\",\"usage\":\"development\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"yWXzoUlvTdUvz7cjjcGHl-DU_cCkI8mZL1C3ijC6MfE\",\"kty\":\"OKP\",\"x\":\"VGXREBG5MefdBSpVAu4oofh_Vgq_6e3xGNAhw6RJ7gc\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"damian\",\"kube_provider\":\"aws\",\"team_id\":\"batt_0191808e3dee71769cb97e44ee965206\",\"kube_provider_config\":{},\"user_id\":null}",
+        "dev.install.json": "{\"id\":\"batt_0191808e3df17ddfb6af4642c1be833f\",\"usage\":\"internal_dev\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"1QnM9jWw_EJnRuR-XunfjUx8AaQuLI6Qs1D05PhH-tU\",\"kty\":\"OKP\",\"x\":\"imkCxdCjRg4AcmPe2-cvEfaXBSqk9JHq_nrOQcN08AM\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"dev\",\"kube_provider\":\"kind\",\"team_id\":\"batt_0191808e3dee71769cb97e44ee965206\",\"kube_provider_config\":{},\"user_id\":null}",
+        "elliott.install.json": "{\"id\":\"batt_0191808e3e3f7dc294b9c1b77978f4c7\",\"usage\":\"development\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"ApxPU0jKmm6dVoLFpj3Y29Ij-LBqBDtCJtAkozK9_Xk\",\"kty\":\"OKP\",\"x\":\"fEYb84z6KcLZ9hkPl9-NlqQGxYYgOSzLLY1_FyjonJY\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"elliott\",\"kube_provider\":\"aws\",\"team_id\":\"batt_0191808e3dee71769cb97e44ee965206\",\"kube_provider_config\":{},\"user_id\":null}",
+        "int-prod.install.json": "{\"id\":\"batt_0191808e3e3f72108db3cdc66ea159f9\",\"usage\":\"internal_prod\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"H_vq3IC05FqzxkdD_npx0tPUes8fKCrZoVjSMRckpC0\",\"kty\":\"OKP\",\"x\":\"25tJDeP3yEoh0OBeZv6l7Qp_nw-VhT5p5GrC1OF93hg\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"int-prod\",\"kube_provider\":\"kind\",\"team_id\":\"batt_0191808e3dee71769cb97e44ee965206\",\"kube_provider_config\":{},\"user_id\":null}",
+        "int-test.install.json": "{\"id\":\"batt_0191808e3e3f709eae6709bce86f4170\",\"usage\":\"internal_int_test\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"CMxg-RubQnce8u7qx_1LrwGTtNBZgRXrx9uTj0ofw0Y\",\"kty\":\"OKP\",\"x\":\"c6pB0o0sGNQDbddIDiDeynZcLKt-6CXe9wBr058W4uk\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"int-test\",\"kube_provider\":\"kind\",\"team_id\":\"batt_0191808e3dee71769cb97e44ee965206\",\"kube_provider_config\":{},\"user_id\":null}",
+        "jason.install.json": "{\"id\":\"batt_0191808e3e3f7b2e9568d09b80d0fdef\",\"usage\":\"development\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"EA3p37UbqPoZKK91sDHsXnNkdBZXAMiXJxry5GCD6pQ\",\"kty\":\"OKP\",\"x\":\"4LMreGz5zNDzhAV4_Z9TLoNSO5PFasNwyBHCdseCW7Y\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"jason\",\"kube_provider\":\"aws\",\"team_id\":\"batt_0191808e3dee71769cb97e44ee965206\",\"kube_provider_config\":{},\"user_id\":null}",
+        "local.install.json": "{\"id\":\"batt_0191808e3e3f7837a713bb440fcfc8a2\",\"usage\":\"development\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"E9Dbpr4_Cx0c1sk4Hfa8wh-RQdgRZZeJ8qju0L4zGp0\",\"kty\":\"OKP\",\"x\":\"ZrSliZtdwlh_IdU8tk0qOSyfu3-qWLlCKmPPOaY6RBg\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"local\",\"kube_provider\":\"kind\",\"team_id\":\"batt_0191808e3dee71769cb97e44ee965206\",\"kube_provider_config\":{},\"user_id\":null}",
+        "maurer.install.json": "{\"id\":\"batt_0191808e3e3f7e418cb896523114c49c\",\"usage\":\"development\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"qhySDvyjQ0BxDXtCog27873ggsVDWp9ZzyT3YieQcFo\",\"kty\":\"OKP\",\"x\":\"5yF4IY_NZixwex39RkwYcEeyZLe1Wfn8tpLMZ03B3-E\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"maurer\",\"kube_provider\":\"aws\",\"team_id\":\"batt_0191808e3dee71769cb97e44ee965206\",\"kube_provider_config\":{},\"user_id\":null}"
       },
       "kind": "ConfigMap",
       "metadata": {
         "annotations": {
-          "battery/hash": "T53XDQURDFCT63FBNNGAS4JF7FT4ERS5PIOEVAOVFA5N2N3CN5MA===="
+          "battery/hash": "EGDB7MPEFSM2JPDHZCDKTIAHOM57ETZPP6FREBFNOLLGNJMRWOCA===="
         },
         "labels": {
           "app": "traditional-services",
@@ -391,7 +391,7 @@
           "battery/app": "traditional-services",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f37a75a8870d733d0897e689",
+          "battery/owner": "batt_0191808e3e4c7a2fa4517e18d2d4e81b",
           "version": "latest"
         },
         "name": "home-base-seed-data",
@@ -403,7 +403,7 @@
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "7WED47HWKUHUPF2S3PGYBZO5GTJMNJ3SZGIZJ5UOEJ6WGYW47PLQ===="
+          "battery/hash": "7E7KNKSHZ4ZPT44YH3LCZI2C5Y5ZATVP3BNPOPQB7NEWNDEXEBTA===="
         },
         "labels": {
           "app": "battery-core",
@@ -413,7 +413,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f37a77719fc23ae0ce44ca4e",
+          "battery/owner": "batt_0191808e3e4c733bb07dd9af9758bf84",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -437,7 +437,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_01917fb0f37a77719fc23ae0ce44ca4e",
+              "battery/owner": "batt_0191808e3e4c733bb07dd9af9758bf84",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -450,7 +450,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "35HAO4HMMZY5NG4KBG436XNMVP5EQHLPIK3C2TPT6A5RVRTCZWEX3VHV6MA4GMXJ"
+                    "value": "LI4H4QZERO7XI6XT7XHW3JSWG75I4J3EUGYHLJ4JF5OFDQ3KRVCDZH45MDJ5WR7I"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -498,7 +498,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "VW6SMQN43B2XXCO553I2FP7ROIO4WPN2RSXAPOIFF6GVYTNBHRJQ===="
+          "battery/hash": "B2LJHKKR4WC2FXMF2BWKHOKDEWMB4CYF3CI3HYSZNZA7FNIPF2JA===="
         },
         "labels": {
           "app": "battery-core",
@@ -508,7 +508,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f37a77719fc23ae0ce44ca4e",
+          "battery/owner": "batt_0191808e3e4c733bb07dd9af9758bf84",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -520,7 +520,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "MPUCBINZMPTWGC3OVFTOUVT4US7RAPNCXEXLKP6CQYE3B24A7ENA===="
+          "battery/hash": "AXM5TLMQXZTGZ53LDNJJIVAR6BFPFPPVZCG3DSNYJBGWXFL567RA===="
         },
         "labels": {
           "app": "traditional-services",
@@ -530,7 +530,7 @@
           "battery/app": "traditional-services",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f37a75a8870d733d0897e689",
+          "battery/owner": "batt_0191808e3e4c7a2fa4517e18d2d4e81b",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -542,7 +542,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "A6FXQQEF474KVQYXYOICZPJDUDUZY2XGWCPL7VG5I37XPECPIU6A===="
+          "battery/hash": "DCQQ2OWQZZGRVHKHZDDMNPG7AA57E6M3NBITVQDGSLIUR7HPCZ3A===="
         },
         "labels": {
           "app": "battery-core",
@@ -552,7 +552,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f37a77719fc23ae0ce44ca4e",
+          "battery/owner": "batt_0191808e3e4c733bb07dd9af9758bf84",
           "version": "latest"
         },
         "name": "bootstrap",

--- a/bootstrap/int-test.install.json
+++ b/bootstrap/int-test.install.json
@@ -1,18 +1,18 @@
 {
-  "id": "batt_01917fb0f36e7049b9fa9690f94a494c",
+  "id": "batt_0191808e3e3f709eae6709bce86f4170",
   "usage": "internal_int_test",
   "default_size": "medium",
   "control_jwk": {
     "crv": "Ed25519",
-    "d": "-vba3-GB_3klw4NrgwoGwyTS44JggohqSCRSeJF7I2A",
+    "d": "CMxg-RubQnce8u7qx_1LrwGTtNBZgRXrx9uTj0ofw0Y",
     "kty": "OKP",
-    "x": "6h2Z0OwagDcLvzI3fQmv1OkNWJ42YP794uJT9y-NCA4"
+    "x": "c6pB0o0sGNQDbddIDiDeynZcLKt-6CXe9wBr058W4uk"
   },
   "inserted_at": null,
   "updated_at": null,
   "slug": "int-test",
   "kube_provider": "kind",
-  "team_id": "batt_01917fb0f3187690a9b74a60fa13828c",
+  "team_id": "batt_0191808e3dee71769cb97e44ee965206",
   "kube_provider_config": {},
   "user_id": null
 }

--- a/bootstrap/int-test.spec.json
+++ b/bootstrap/int-test.spec.json
@@ -9,7 +9,7 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_01917fb0f379734bb400d7bf364a700e",
+        "id": "batt_0191808e3e4b7916b60b3d46b1a7069e",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -22,12 +22,12 @@
           "default_size": "medium",
           "cluster_name": "int-test",
           "server_in_cluster": true,
-          "install_id": "batt_01917fb0f36e7049b9fa9690f94a494c",
+          "install_id": "batt_0191808e3e3f709eae6709bce86f4170",
           "control_jwk": {
             "crv": "Ed25519",
-            "d": "-vba3-GB_3klw4NrgwoGwyTS44JggohqSCRSeJF7I2A",
+            "d": "CMxg-RubQnce8u7qx_1LrwGTtNBZgRXrx9uTj0ofw0Y",
             "kty": "OKP",
-            "x": "6h2Z0OwagDcLvzI3fQmv1OkNWJ42YP794uJT9y-NCA4"
+            "x": "c6pB0o0sGNQDbddIDiDeynZcLKt-6CXe9wBr058W4uk"
           },
           "upgrade_days_of_week": [
             true,
@@ -52,7 +52,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f3797650ababcafc7e484d31",
+        "id": "batt_0191808e3e4b734b8dd2143ae2dc6267",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
@@ -64,7 +64,50 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f3797e529636966ab36e4cde",
+        "id": "batt_0191808e3e4b766a81f475562b8e06d6",
+        "type": "istio",
+        "config": {
+          "type": "istio",
+          "namespace": "battery-istio",
+          "pilot_image": "docker.io/istio/pilot:1.22.3-distroless",
+          "namespace_override": null,
+          "pilot_image_override": null
+        },
+        "group": "net_sec",
+        "inserted_at": null,
+        "updated_at": null
+      },
+      {
+        "id": "batt_0191808e3e4b7a538d36e6b55e24b27b",
+        "type": "istio_gateway",
+        "config": {
+          "type": "istio_gateway",
+          "proxy_image": "docker.io/istio/proxyv2:1.22.3-distroless",
+          "proxy_image_override": null
+        },
+        "group": "net_sec",
+        "inserted_at": null,
+        "updated_at": null
+      },
+      {
+        "id": "batt_0191808e3e4b7c7980547c60a8348c7b",
+        "type": "metallb",
+        "config": {
+          "type": "metallb",
+          "controller_image": "quay.io/metallb/controller:v0.14.8",
+          "speaker_image": "quay.io/metallb/speaker:v0.14.8",
+          "frrouting_image": "quay.io/frrouting/frr:9.1.0",
+          "enable_pod_monitor": false,
+          "speaker_image_override": null,
+          "controller_image_override": null,
+          "frrouting_image_override": null
+        },
+        "group": "net_sec",
+        "inserted_at": null,
+        "updated_at": null
+      },
+      {
+        "id": "batt_0191808e3e4b7040b1a0443641cca554",
         "type": "traditional_services",
         "config": {
           "type": "traditional_services",
@@ -92,7 +135,7 @@
         "env_values": [
           {
             "name": "SECRET_KEY_BASE",
-            "value": "EINN7KDBZKGRRPCCTFGYKAGKLS43A4B6I55YHVC7QICIC3CEOO7V6SYUOZJDVGSE",
+            "value": "GEZIKKX7RXBASVXOCSOOQPJKFDE5U4VQKCMOP3WYMRZRFIKROVRBFSXHVH7ARQQA",
             "source_name": null,
             "source_type": "value",
             "source_key": null,
@@ -132,11 +175,11 @@
           }
         ],
         "num_instances": 1,
-        "virtual_size": "medium",
-        "cpu_requested": 4000,
-        "cpu_limits": 4000,
-        "memory_requested": 8589934592,
-        "memory_limits": 8589934592,
+        "virtual_size": "small",
+        "cpu_requested": 500,
+        "cpu_limits": 2000,
+        "memory_requested": 1073741824,
+        "memory_limits": 4294967296,
         "project_id": null,
         "init_containers": [
           {
@@ -226,7 +269,7 @@
           {
             "version": 2,
             "username": "battery-control-user",
-            "password": "HXEE6JHSI6AFET3ID4JPIPHN"
+            "password": "NKA7XSIJPY256XH5GW3BAO2D"
           },
           {
             "version": 1,
@@ -272,7 +315,7 @@
           {
             "version": 1,
             "username": "home-base",
-            "password": "PW3QZ34M3FN6JVB22CYBA4YT"
+            "password": "ERJTWFIGUOZDLYDBL46QHYWG"
           }
         ],
         "cpu_requested": 4000,
@@ -298,7 +341,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "NR4K6KXDERPMYXOMLRNDIKVKT3XM7OIRUKOEEYF7YORNY4YYCGUA===="
+          "battery/hash": "3FI65NME2LGT5ULVY4URNO3C6B5QXRUNG2BLDIIYWL6GLUFZNILA===="
         },
         "labels": {
           "app": "battery-core",
@@ -308,7 +351,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f379734bb400d7bf364a700e",
+          "battery/owner": "batt_0191808e3e4b7916b60b3d46b1a7069e",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -329,20 +372,20 @@
     "/config_map/home_base_seed_data": {
       "apiVersion": "v1",
       "data": {
-        "batt_01917fb0f3187690a9b74a60fa13828c.team.json": "{\"id\":\"batt_01917fb0f3187690a9b74a60fa13828c\",\"name\":\"Batteries Included Team\",\"inserted_at\":null,\"updated_at\":null,\"op_email\":\"elliott@batteriesincl.com\"}",
-        "damian.install.json": "{\"id\":\"batt_01917fb0f36f77e28fa574e3813a655e\",\"usage\":\"development\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"NLQRZk6PV8a8-jvsPRD7j4uHUiskJXbDkpcdvnbtgMs\",\"kty\":\"OKP\",\"x\":\"0fbzEPYDWplrPIr8tYQEbj6god9ZQFR6_RN0s-to7n0\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"damian\",\"kube_provider\":\"aws\",\"team_id\":\"batt_01917fb0f3187690a9b74a60fa13828c\",\"kube_provider_config\":{},\"user_id\":null}",
-        "dev.install.json": "{\"id\":\"batt_01917fb0f31b7f9ebb1f2ac7c23b7faa\",\"usage\":\"internal_dev\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"RU5Y2TCrELsWN6XA6GVfXjbt8KN5fNU4EvskWVNeBns\",\"kty\":\"OKP\",\"x\":\"AVooCGi1mJuUe0vqspQYwTT-d4EqP3rjyDJkhKOslIk\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"dev\",\"kube_provider\":\"kind\",\"team_id\":\"batt_01917fb0f3187690a9b74a60fa13828c\",\"kube_provider_config\":{},\"user_id\":null}",
-        "elliott.install.json": "{\"id\":\"batt_01917fb0f36e775594e799bcf8d65142\",\"usage\":\"development\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"-sZ7COyAOgO12wEsdQfOHPCSLt8GztaXAJsBhsQo8jA\",\"kty\":\"OKP\",\"x\":\"CWrlQclRHrt1MjJYVDwbvxhxMqTUzZVxC5hYC1msDjo\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"elliott\",\"kube_provider\":\"aws\",\"team_id\":\"batt_01917fb0f3187690a9b74a60fa13828c\",\"kube_provider_config\":{},\"user_id\":null}",
-        "int-prod.install.json": "{\"id\":\"batt_01917fb0f36e7705bf1b78dcbe5c1e60\",\"usage\":\"internal_prod\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"nCAtEeRvFaCeSW2B4CDZHjZtLkpxwOHNCfcGp37MqwI\",\"kty\":\"OKP\",\"x\":\"dOHWv4tYz9PclVpymZB032m0uAfYfRj9VYsOXKOozTs\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"int-prod\",\"kube_provider\":\"kind\",\"team_id\":\"batt_01917fb0f3187690a9b74a60fa13828c\",\"kube_provider_config\":{},\"user_id\":null}",
-        "int-test.install.json": "{\"id\":\"batt_01917fb0f36e7049b9fa9690f94a494c\",\"usage\":\"internal_int_test\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"-vba3-GB_3klw4NrgwoGwyTS44JggohqSCRSeJF7I2A\",\"kty\":\"OKP\",\"x\":\"6h2Z0OwagDcLvzI3fQmv1OkNWJ42YP794uJT9y-NCA4\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"int-test\",\"kube_provider\":\"kind\",\"team_id\":\"batt_01917fb0f3187690a9b74a60fa13828c\",\"kube_provider_config\":{},\"user_id\":null}",
-        "jason.install.json": "{\"id\":\"batt_01917fb0f36f7d2ebd4690ff52ad3198\",\"usage\":\"development\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"WVGBDmC6tZhOQBcFrs9j0I8vsHTybHstAkq1l6bjya8\",\"kty\":\"OKP\",\"x\":\"usRWlro_Wl2dPOZkYEHtipi9026rVZyp8u5v_8rTJ6M\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"jason\",\"kube_provider\":\"aws\",\"team_id\":\"batt_01917fb0f3187690a9b74a60fa13828c\",\"kube_provider_config\":{},\"user_id\":null}",
-        "local.install.json": "{\"id\":\"batt_01917fb0f36e760e992c0d6cb9a807a3\",\"usage\":\"development\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"XCG2bD5RwUqCzJqEkC0EKnYtVVakuvDVsGpaGWGqmPY\",\"kty\":\"OKP\",\"x\":\"y2KY2VucdH8bhdsDXWb4UF02_LXBEXaudae-h__LIwM\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"local\",\"kube_provider\":\"kind\",\"team_id\":\"batt_01917fb0f3187690a9b74a60fa13828c\",\"kube_provider_config\":{},\"user_id\":null}",
-        "maurer.install.json": "{\"id\":\"batt_01917fb0f36f71448bd9c50a0231dab0\",\"usage\":\"development\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"1smOp3FS6LSlnRUG3U-D55kKbWBMmmhX3v9UW8ye9ZA\",\"kty\":\"OKP\",\"x\":\"ZJEv8RxKg6cHrV1UpXaWtZwOhFCwBH26yHZ2P2PJbDI\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"maurer\",\"kube_provider\":\"aws\",\"team_id\":\"batt_01917fb0f3187690a9b74a60fa13828c\",\"kube_provider_config\":{},\"user_id\":null}"
+        "batt_0191808e3dee71769cb97e44ee965206.team.json": "{\"id\":\"batt_0191808e3dee71769cb97e44ee965206\",\"name\":\"Batteries Included Team\",\"inserted_at\":null,\"updated_at\":null,\"op_email\":\"elliott@batteriesincl.com\"}",
+        "damian.install.json": "{\"id\":\"batt_0191808e3e3f7bdda5050d6e0ab1088f\",\"usage\":\"development\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"yWXzoUlvTdUvz7cjjcGHl-DU_cCkI8mZL1C3ijC6MfE\",\"kty\":\"OKP\",\"x\":\"VGXREBG5MefdBSpVAu4oofh_Vgq_6e3xGNAhw6RJ7gc\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"damian\",\"kube_provider\":\"aws\",\"team_id\":\"batt_0191808e3dee71769cb97e44ee965206\",\"kube_provider_config\":{},\"user_id\":null}",
+        "dev.install.json": "{\"id\":\"batt_0191808e3df17ddfb6af4642c1be833f\",\"usage\":\"internal_dev\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"1QnM9jWw_EJnRuR-XunfjUx8AaQuLI6Qs1D05PhH-tU\",\"kty\":\"OKP\",\"x\":\"imkCxdCjRg4AcmPe2-cvEfaXBSqk9JHq_nrOQcN08AM\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"dev\",\"kube_provider\":\"kind\",\"team_id\":\"batt_0191808e3dee71769cb97e44ee965206\",\"kube_provider_config\":{},\"user_id\":null}",
+        "elliott.install.json": "{\"id\":\"batt_0191808e3e3f7dc294b9c1b77978f4c7\",\"usage\":\"development\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"ApxPU0jKmm6dVoLFpj3Y29Ij-LBqBDtCJtAkozK9_Xk\",\"kty\":\"OKP\",\"x\":\"fEYb84z6KcLZ9hkPl9-NlqQGxYYgOSzLLY1_FyjonJY\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"elliott\",\"kube_provider\":\"aws\",\"team_id\":\"batt_0191808e3dee71769cb97e44ee965206\",\"kube_provider_config\":{},\"user_id\":null}",
+        "int-prod.install.json": "{\"id\":\"batt_0191808e3e3f72108db3cdc66ea159f9\",\"usage\":\"internal_prod\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"H_vq3IC05FqzxkdD_npx0tPUes8fKCrZoVjSMRckpC0\",\"kty\":\"OKP\",\"x\":\"25tJDeP3yEoh0OBeZv6l7Qp_nw-VhT5p5GrC1OF93hg\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"int-prod\",\"kube_provider\":\"kind\",\"team_id\":\"batt_0191808e3dee71769cb97e44ee965206\",\"kube_provider_config\":{},\"user_id\":null}",
+        "int-test.install.json": "{\"id\":\"batt_0191808e3e3f709eae6709bce86f4170\",\"usage\":\"internal_int_test\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"CMxg-RubQnce8u7qx_1LrwGTtNBZgRXrx9uTj0ofw0Y\",\"kty\":\"OKP\",\"x\":\"c6pB0o0sGNQDbddIDiDeynZcLKt-6CXe9wBr058W4uk\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"int-test\",\"kube_provider\":\"kind\",\"team_id\":\"batt_0191808e3dee71769cb97e44ee965206\",\"kube_provider_config\":{},\"user_id\":null}",
+        "jason.install.json": "{\"id\":\"batt_0191808e3e3f7b2e9568d09b80d0fdef\",\"usage\":\"development\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"EA3p37UbqPoZKK91sDHsXnNkdBZXAMiXJxry5GCD6pQ\",\"kty\":\"OKP\",\"x\":\"4LMreGz5zNDzhAV4_Z9TLoNSO5PFasNwyBHCdseCW7Y\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"jason\",\"kube_provider\":\"aws\",\"team_id\":\"batt_0191808e3dee71769cb97e44ee965206\",\"kube_provider_config\":{},\"user_id\":null}",
+        "local.install.json": "{\"id\":\"batt_0191808e3e3f7837a713bb440fcfc8a2\",\"usage\":\"development\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"E9Dbpr4_Cx0c1sk4Hfa8wh-RQdgRZZeJ8qju0L4zGp0\",\"kty\":\"OKP\",\"x\":\"ZrSliZtdwlh_IdU8tk0qOSyfu3-qWLlCKmPPOaY6RBg\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"local\",\"kube_provider\":\"kind\",\"team_id\":\"batt_0191808e3dee71769cb97e44ee965206\",\"kube_provider_config\":{},\"user_id\":null}",
+        "maurer.install.json": "{\"id\":\"batt_0191808e3e3f7e418cb896523114c49c\",\"usage\":\"development\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"qhySDvyjQ0BxDXtCog27873ggsVDWp9ZzyT3YieQcFo\",\"kty\":\"OKP\",\"x\":\"5yF4IY_NZixwex39RkwYcEeyZLe1Wfn8tpLMZ03B3-E\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"maurer\",\"kube_provider\":\"aws\",\"team_id\":\"batt_0191808e3dee71769cb97e44ee965206\",\"kube_provider_config\":{},\"user_id\":null}"
       },
       "kind": "ConfigMap",
       "metadata": {
         "annotations": {
-          "battery/hash": "R7GT4CZWI3JCOQGU54WVKLRCP22QGALOITXG6T5OPHK6QYHJLQPA===="
+          "battery/hash": "WQGOOHYPTKKAC3TRJMXWVH7JGOZPFV5LUAVCZUK734H6DF4KGEOA===="
         },
         "labels": {
           "app": "traditional-services",
@@ -352,7 +395,7 @@
           "battery/app": "traditional-services",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f3797e529636966ab36e4cde",
+          "battery/owner": "batt_0191808e3e4b7040b1a0443641cca554",
           "version": "latest"
         },
         "name": "home-base-seed-data",
@@ -364,7 +407,7 @@
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "IUVDTZBSIKL7YKVAXIE3S33Z5U2H2QGBIAWSCBE4M22COMAXATSA===="
+          "battery/hash": "VFBHEAMTIZCS23GSY56CWULAZU2S3ANQ4VSPG2B4UROK3POKWMMQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -374,7 +417,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f379734bb400d7bf364a700e",
+          "battery/owner": "batt_0191808e3e4b7916b60b3d46b1a7069e",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -398,7 +441,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_01917fb0f379734bb400d7bf364a700e",
+              "battery/owner": "batt_0191808e3e4b7916b60b3d46b1a7069e",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -411,7 +454,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "MDYUMOYPAN4R4BH36PMSBHIOGWCRIYTXRHYZBFNFFWSU4OO34MS2ANLEPCY5NHPI"
+                    "value": "7ULXKBL24D4IL6R4QXBLDFZEN44FNXBNUKLR5TQ24YSRFXOTNFP5UNIL6L4ZIYCN"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -459,7 +502,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "HDBRSWIZ57BIQWBQ32Z37LBM55IEYI2HZ7JDIDVWDF7RWSZZ6V7A===="
+          "battery/hash": "NDANGCU3TGPYRSDHPBRHAMAMKHZNLPSLW7D3YCYWAFM72YVI43QQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -469,7 +512,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f379734bb400d7bf364a700e",
+          "battery/owner": "batt_0191808e3e4b7916b60b3d46b1a7069e",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -481,7 +524,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "ZTTXOLSWNJP7IF4YT3HOK3IPT4ZY2UEF5VODKZHZSOCCP55QBYKQ===="
+          "battery/hash": "L6RTZ2LDHM2GUMXMXXPXMIURPWOH6V4I7C323L3YCG7TGY7Q5PRQ===="
         },
         "labels": {
           "app": "traditional-services",
@@ -491,7 +534,7 @@
           "battery/app": "traditional-services",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f3797e529636966ab36e4cde",
+          "battery/owner": "batt_0191808e3e4b7040b1a0443641cca554",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -503,7 +546,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "K6TUOLVWWPHRWXP2D5XTGU47VUMS72FIEYMWDVFXLDKBBYFQX6EA===="
+          "battery/hash": "EUJDLOA3EH45H53V7TFRR57CSXPZVEN7PQF33URTXPLNSVJS75MA===="
         },
         "labels": {
           "app": "battery-core",
@@ -513,7 +556,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f379734bb400d7bf364a700e",
+          "battery/owner": "batt_0191808e3e4b7916b60b3d46b1a7069e",
           "version": "latest"
         },
         "name": "bootstrap",

--- a/bootstrap/jason.install.json
+++ b/bootstrap/jason.install.json
@@ -1,18 +1,18 @@
 {
-  "id": "batt_01917fb0f36f7d2ebd4690ff52ad3198",
+  "id": "batt_0191808e3e3f7b2e9568d09b80d0fdef",
   "usage": "development",
   "default_size": "small",
   "control_jwk": {
     "crv": "Ed25519",
-    "d": "WVGBDmC6tZhOQBcFrs9j0I8vsHTybHstAkq1l6bjya8",
+    "d": "EA3p37UbqPoZKK91sDHsXnNkdBZXAMiXJxry5GCD6pQ",
     "kty": "OKP",
-    "x": "usRWlro_Wl2dPOZkYEHtipi9026rVZyp8u5v_8rTJ6M"
+    "x": "4LMreGz5zNDzhAV4_Z9TLoNSO5PFasNwyBHCdseCW7Y"
   },
   "inserted_at": null,
   "updated_at": null,
   "slug": "jason",
   "kube_provider": "aws",
-  "team_id": "batt_01917fb0f3187690a9b74a60fa13828c",
+  "team_id": "batt_0191808e3dee71769cb97e44ee965206",
   "kube_provider_config": {},
   "user_id": null
 }

--- a/bootstrap/jason.spec.json
+++ b/bootstrap/jason.spec.json
@@ -9,7 +9,7 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_01917fb0f37d7295a3ff91b5f2f076c5",
+        "id": "batt_0191808e3e4f76b98930f4a9bfa89d8c",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -22,12 +22,12 @@
           "default_size": "small",
           "cluster_name": "jason",
           "server_in_cluster": true,
-          "install_id": "batt_01917fb0f36f7d2ebd4690ff52ad3198",
+          "install_id": "batt_0191808e3e3f7b2e9568d09b80d0fdef",
           "control_jwk": {
             "crv": "Ed25519",
-            "d": "WVGBDmC6tZhOQBcFrs9j0I8vsHTybHstAkq1l6bjya8",
+            "d": "EA3p37UbqPoZKK91sDHsXnNkdBZXAMiXJxry5GCD6pQ",
             "kty": "OKP",
-            "x": "usRWlro_Wl2dPOZkYEHtipi9026rVZyp8u5v_8rTJ6M"
+            "x": "4LMreGz5zNDzhAV4_Z9TLoNSO5PFasNwyBHCdseCW7Y"
           },
           "upgrade_days_of_week": [
             true,
@@ -52,7 +52,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37d72a2b824d669440c2018",
+        "id": "batt_0191808e3e4f70ac93855cad11bef67b",
         "type": "karpenter",
         "config": {
           "type": "karpenter",
@@ -67,7 +67,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37d7fd1b32cf72237ad9acd",
+        "id": "batt_0191808e3e4f76d09b3c0f0ee7f7dcba",
         "type": "cert_manager",
         "config": {
           "type": "cert_manager",
@@ -88,7 +88,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37d7ca3b371b993c701fa0c",
+        "id": "batt_0191808e3e4f78cabda6e4c0bfe95581",
         "type": "battery_ca",
         "config": {
           "type": "battery_ca"
@@ -98,7 +98,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37d70f2a8af7c1ff995e212",
+        "id": "batt_0191808e3e4f7ef1a176a2b354c4eb49",
         "type": "aws_load_balancer_controller",
         "config": {
           "type": "aws_load_balancer_controller",
@@ -113,7 +113,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37d77ee99532cf376c97585",
+        "id": "batt_0191808e3e4f73089b39c9c2f72d2c1e",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
@@ -125,7 +125,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37d752aa838b112a4b2faa4",
+        "id": "batt_0191808e3e4f72b7abdbb82bffb072b4",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -139,7 +139,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37d778ba8612c383d100915",
+        "id": "batt_0191808e3e4f723fa1156429e3a84cdc",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -151,7 +151,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37d78aeb93bca14ec6f2b1d",
+        "id": "batt_0191808e3e4f779abe2c0ac210757414",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -195,7 +195,7 @@
           {
             "version": 1,
             "username": "battery-control-user",
-            "password": "4XR745XWAKQWP5TXHSUWSXBW"
+            "password": "EWAS5NEDAA7IL5MBI23E2WD3"
           }
         ],
         "cpu_requested": 500,
@@ -221,7 +221,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "57TKM3XN7KO7TH5QLNT2F2MFIKC5KIF35SNMZD6VSDRX42VGJBJA===="
+          "battery/hash": "3LNBXFGACSQMJKZCIFZOWZOUG2DO54NIYG5KXMWCMKKKTYYS3Q2Q===="
         },
         "labels": {
           "app": "battery-core",
@@ -231,7 +231,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f37d7295a3ff91b5f2f076c5",
+          "battery/owner": "batt_0191808e3e4f76b98930f4a9bfa89d8c",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -254,7 +254,7 @@
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "7PUVWTC7AMYMQEJWM5QIXNREHHFRGYDCF4BSIFGYHHAUZ2KSELYQ===="
+          "battery/hash": "CFSQ3EFS33EZIMWE3V67YGSWYIXJ72BVN2L7XHWJDRQ3KCSM4R4A===="
         },
         "labels": {
           "app": "battery-core",
@@ -264,7 +264,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f37d7295a3ff91b5f2f076c5",
+          "battery/owner": "batt_0191808e3e4f76b98930f4a9bfa89d8c",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -288,7 +288,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_01917fb0f37d7295a3ff91b5f2f076c5",
+              "battery/owner": "batt_0191808e3e4f76b98930f4a9bfa89d8c",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -301,7 +301,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "YZUHYOS2ODHJ2WJ2QIUZDNR4H3EJ5AMJDKLTKHBUFEESTQBPFE4BI5AOQJUXGX7C"
+                    "value": "KYMSA2WO5T626LZZNI2VUYFP7RNEAAR52KPH3LWMBTT5Y4GNYZVCFWLG6L47ZNTO"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -349,7 +349,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "P3NCOYTJICJCVLGSUY7UPR7HITMS7HELHU6Y6P6VRDKBLSFRYX4Q===="
+          "battery/hash": "DTJ5GT6JTO6NHBD3JVXMTWKDQJZBCVGDDXH5LS4K7FHCWJTA3ZOA===="
         },
         "labels": {
           "app": "battery-core",
@@ -359,7 +359,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f37d7295a3ff91b5f2f076c5",
+          "battery/owner": "batt_0191808e3e4f76b98930f4a9bfa89d8c",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -371,7 +371,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "6LUPBVM7X6RVLYLRVFMFR42C3JU65QQGH7KAEN3DFDQ7FEYXSKSA===="
+          "battery/hash": "7MTZJCATCNCGZMC4IGP2BWCLKQG3RZLMEGOFTB7ABJAIP227ZG5A===="
         },
         "labels": {
           "app": "battery-core",
@@ -381,7 +381,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f37d7295a3ff91b5f2f076c5",
+          "battery/owner": "batt_0191808e3e4f76b98930f4a9bfa89d8c",
           "version": "latest"
         },
         "name": "bootstrap",
@@ -394,7 +394,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "N2PUPE4XU65YGNAIP4KHORUUAINWVT74ACR3UAI3AHRG3TUT6NOQ====",
+          "battery/hash": "BAYJHNZXR4Y4646MVOCSVSNH4E4RPLBANEQJZHIKFDCALPDI7AMA====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -405,7 +405,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f37d7295a3ff91b5f2f076c5",
+          "battery/owner": "batt_0191808e3e4f76b98930f4a9bfa89d8c",
           "version": "latest"
         },
         "name": "gp2"
@@ -420,7 +420,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "UFS52VNR77N2UFSPYTOWA4MLG7FBUWIFK6TEB7ICJKTFGHCXZQGA====",
+          "battery/hash": "EZISVM2KW65WPR5LIQJQPXKAVFSM3YOGFD7IN7DV7JX3K2N7BFZQ====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -431,7 +431,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f37d7295a3ff91b5f2f076c5",
+          "battery/owner": "batt_0191808e3e4f76b98930f4a9bfa89d8c",
           "version": "latest"
         },
         "name": "gp2-90032408"
@@ -451,7 +451,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "GRJQI2VPXY4FJDT3QBXYZVJUUNHFIK5FWVD2BYWC6ZNWR24AUN7Q====",
+          "battery/hash": "C4SB6P42EEOAYALBF2HWPAT4SWZNORMWPLP2KSLGYLSEOICVUYOA====",
           "storageclass.kubernetes.io/is-default-class": "true"
         },
         "labels": {
@@ -462,7 +462,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f37d7295a3ff91b5f2f076c5",
+          "battery/owner": "batt_0191808e3e4f76b98930f4a9bfa89d8c",
           "version": "latest"
         },
         "name": "gp3-105457460"

--- a/bootstrap/local.install.json
+++ b/bootstrap/local.install.json
@@ -1,18 +1,18 @@
 {
-  "id": "batt_01917fb0f36e760e992c0d6cb9a807a3",
+  "id": "batt_0191808e3e3f7837a713bb440fcfc8a2",
   "usage": "development",
   "default_size": "tiny",
   "control_jwk": {
     "crv": "Ed25519",
-    "d": "XCG2bD5RwUqCzJqEkC0EKnYtVVakuvDVsGpaGWGqmPY",
+    "d": "E9Dbpr4_Cx0c1sk4Hfa8wh-RQdgRZZeJ8qju0L4zGp0",
     "kty": "OKP",
-    "x": "y2KY2VucdH8bhdsDXWb4UF02_LXBEXaudae-h__LIwM"
+    "x": "ZrSliZtdwlh_IdU8tk0qOSyfu3-qWLlCKmPPOaY6RBg"
   },
   "inserted_at": null,
   "updated_at": null,
   "slug": "local",
   "kube_provider": "kind",
-  "team_id": "batt_01917fb0f3187690a9b74a60fa13828c",
+  "team_id": "batt_0191808e3dee71769cb97e44ee965206",
   "kube_provider_config": {},
   "user_id": null
 }

--- a/bootstrap/local.spec.json
+++ b/bootstrap/local.spec.json
@@ -9,7 +9,7 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_01917fb0f37b744f91df93a2b1e9e43b",
+        "id": "batt_0191808e3e4d7a47978fbb4c5182a401",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -23,7 +23,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37b7cc1b883c77ddee421be",
+        "id": "batt_0191808e3e4d7c929491c36c12479a07",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -35,7 +35,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37b7c4ca2356efbb64ddaf3",
+        "id": "batt_0191808e3e4d792aa90e713e68cbbd0d",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -48,12 +48,12 @@
           "default_size": "tiny",
           "cluster_name": "local",
           "server_in_cluster": true,
-          "install_id": "batt_01917fb0f36e760e992c0d6cb9a807a3",
+          "install_id": "batt_0191808e3e3f7837a713bb440fcfc8a2",
           "control_jwk": {
             "crv": "Ed25519",
-            "d": "XCG2bD5RwUqCzJqEkC0EKnYtVVakuvDVsGpaGWGqmPY",
+            "d": "E9Dbpr4_Cx0c1sk4Hfa8wh-RQdgRZZeJ8qju0L4zGp0",
             "kty": "OKP",
-            "x": "y2KY2VucdH8bhdsDXWb4UF02_LXBEXaudae-h__LIwM"
+            "x": "ZrSliZtdwlh_IdU8tk0qOSyfu3-qWLlCKmPPOaY6RBg"
           },
           "upgrade_days_of_week": [
             true,
@@ -78,7 +78,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37b7fa8879989c8f240dcd0",
+        "id": "batt_0191808e3e4d71e49de9001e63676a8a",
         "type": "metallb",
         "config": {
           "type": "metallb",
@@ -95,7 +95,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37b735192123bc755aa4bff",
+        "id": "batt_0191808e3e4d7695b63127030c663b26",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
@@ -107,7 +107,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37b7236a617ad6d0597bae6",
+        "id": "batt_0191808e3e4d73c8a126518a0b2efe80",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -151,7 +151,7 @@
           {
             "version": 1,
             "username": "battery-control-user",
-            "password": "RBTGHK4VMU7GFTHOXO5WYH5U"
+            "password": "S54S6DBAUQSK53L3TOAXVLKL"
           }
         ],
         "cpu_requested": 500,
@@ -177,7 +177,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "JVVEIZMXUAVFKSOWMVUFUIPRJC7AYAV2XVKLEC6Q62XYGICY4M6A===="
+          "battery/hash": "Z4XOGLUNFZJXODRI5HKTIL6Z45TMHUUCRT4323FTQSYHSIKAKR5A===="
         },
         "labels": {
           "app": "battery-core",
@@ -187,7 +187,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f37b7c4ca2356efbb64ddaf3",
+          "battery/owner": "batt_0191808e3e4d792aa90e713e68cbbd0d",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -210,7 +210,7 @@
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "TLEZKBMEBF4V73XH5RRZ73U4QVE3S3LKEB6MWLSO27GVJDRB5AEQ===="
+          "battery/hash": "7IA4GW6ZDK3DOB35TFEMDLMPFQWV72EW3SCRTPN47ZHUAUJQ7TKQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -220,7 +220,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f37b7c4ca2356efbb64ddaf3",
+          "battery/owner": "batt_0191808e3e4d792aa90e713e68cbbd0d",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -244,7 +244,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_01917fb0f37b7c4ca2356efbb64ddaf3",
+              "battery/owner": "batt_0191808e3e4d792aa90e713e68cbbd0d",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -257,7 +257,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "VUTFAIFIX7C4V3RJLF4WX7BEREAHH4YUY334ARYKSLLNXYGDXHTHYUAJOAE6RQIQ"
+                    "value": "W36O2FZR3765RFJBNIY6EOVIJOND24NY33G6HLI64QNSJXZG5TBEPP4QCG5Z6VHW"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -305,7 +305,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "F7LCEDJ7X2PLZBG7554ZEHUEHDACMQPXKAIYKWNVGMPV7TYKSFOQ===="
+          "battery/hash": "7K53U34C33HWRQEK5DGNSEGKORMBDR5NFBXD5EEOQ7J3J27EWJDA===="
         },
         "labels": {
           "app": "battery-core",
@@ -315,7 +315,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f37b7c4ca2356efbb64ddaf3",
+          "battery/owner": "batt_0191808e3e4d792aa90e713e68cbbd0d",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -327,7 +327,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "EIAI53ANAUB3XUFFNKNIM2XWCQU4ANBIFH7PK2HFLB3HM54KSRMA===="
+          "battery/hash": "UEOJ334ERLC7GOYQ3B3YJCBI3WLTVPYVB4PWSWTNFRMQFCUDGAPQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -337,7 +337,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f37b7c4ca2356efbb64ddaf3",
+          "battery/owner": "batt_0191808e3e4d792aa90e713e68cbbd0d",
           "version": "latest"
         },
         "name": "bootstrap",

--- a/bootstrap/maurer.install.json
+++ b/bootstrap/maurer.install.json
@@ -1,18 +1,18 @@
 {
-  "id": "batt_01917fb0f36f71448bd9c50a0231dab0",
+  "id": "batt_0191808e3e3f7e418cb896523114c49c",
   "usage": "development",
   "default_size": "small",
   "control_jwk": {
     "crv": "Ed25519",
-    "d": "1smOp3FS6LSlnRUG3U-D55kKbWBMmmhX3v9UW8ye9ZA",
+    "d": "qhySDvyjQ0BxDXtCog27873ggsVDWp9ZzyT3YieQcFo",
     "kty": "OKP",
-    "x": "ZJEv8RxKg6cHrV1UpXaWtZwOhFCwBH26yHZ2P2PJbDI"
+    "x": "5yF4IY_NZixwex39RkwYcEeyZLe1Wfn8tpLMZ03B3-E"
   },
   "inserted_at": null,
   "updated_at": null,
   "slug": "maurer",
   "kube_provider": "aws",
-  "team_id": "batt_01917fb0f3187690a9b74a60fa13828c",
+  "team_id": "batt_0191808e3dee71769cb97e44ee965206",
   "kube_provider_config": {},
   "user_id": null
 }

--- a/bootstrap/maurer.spec.json
+++ b/bootstrap/maurer.spec.json
@@ -9,7 +9,7 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_01917fb0f37d7a7c8cd4ffc411dbf372",
+        "id": "batt_0191808e3e507822ae682631d8700a63",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -22,12 +22,12 @@
           "default_size": "small",
           "cluster_name": "maurer",
           "server_in_cluster": true,
-          "install_id": "batt_01917fb0f36f71448bd9c50a0231dab0",
+          "install_id": "batt_0191808e3e3f7e418cb896523114c49c",
           "control_jwk": {
             "crv": "Ed25519",
-            "d": "1smOp3FS6LSlnRUG3U-D55kKbWBMmmhX3v9UW8ye9ZA",
+            "d": "qhySDvyjQ0BxDXtCog27873ggsVDWp9ZzyT3YieQcFo",
             "kty": "OKP",
-            "x": "ZJEv8RxKg6cHrV1UpXaWtZwOhFCwBH26yHZ2P2PJbDI"
+            "x": "5yF4IY_NZixwex39RkwYcEeyZLe1Wfn8tpLMZ03B3-E"
           },
           "upgrade_days_of_week": [
             true,
@@ -52,7 +52,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37d7c638137a81d1244af96",
+        "id": "batt_0191808e3e50708f8ca488f6a74652be",
         "type": "karpenter",
         "config": {
           "type": "karpenter",
@@ -67,7 +67,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37d77e0ae2c0829765a6543",
+        "id": "batt_0191808e3e507df583cb11c887ee2ea6",
         "type": "cert_manager",
         "config": {
           "type": "cert_manager",
@@ -88,7 +88,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37d785385578b709c05fe8b",
+        "id": "batt_0191808e3e507c329c2fce8fa67990e1",
         "type": "battery_ca",
         "config": {
           "type": "battery_ca"
@@ -98,7 +98,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37d768e8e44064b302fbed6",
+        "id": "batt_0191808e3e507ad191d783e527365dce",
         "type": "aws_load_balancer_controller",
         "config": {
           "type": "aws_load_balancer_controller",
@@ -113,7 +113,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37d740d84d9a4eb3fc76c69",
+        "id": "batt_0191808e3e5078349d376f321155c47c",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
@@ -125,7 +125,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37e7b1bb88ef6b3cfba4551",
+        "id": "batt_0191808e3e507aaba62f3059413ac708",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -139,7 +139,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37e70489e13efa84ec46548",
+        "id": "batt_0191808e3e5073308e5eb3558c93cab8",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -151,7 +151,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_01917fb0f37e78a2b05f2cd4219b1b86",
+        "id": "batt_0191808e3e507dd695e8a52e0436e0e3",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -195,7 +195,7 @@
           {
             "version": 1,
             "username": "battery-control-user",
-            "password": "KCJNFFL6JCX3YHYVKOFMNIQS"
+            "password": "DNU24TTY3VXZAC76OMOSM56R"
           }
         ],
         "cpu_requested": 500,
@@ -221,7 +221,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "ZOH2YOPHMJZUS25J6FAAZWNSPX7ZCYK3BOZ7GO7NA33LCTNVN6JQ===="
+          "battery/hash": "ZHYOP5ANMPUUQEBDJYTS3FKXY2RNNZCPVMQ263NCWIAB3KZNBTFA===="
         },
         "labels": {
           "app": "battery-core",
@@ -231,7 +231,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f37d7a7c8cd4ffc411dbf372",
+          "battery/owner": "batt_0191808e3e507822ae682631d8700a63",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -254,7 +254,7 @@
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "T7CA3WAQWTF2FVRPNNV74F6RO7EB52OVVALLVPRQ2H4HDQSM3RZA===="
+          "battery/hash": "5FRPIO3MAZDMRMMVWNFHB2GPMBMUMLPLKYI7SBJRGYGYOQZWTBNQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -264,7 +264,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f37d7a7c8cd4ffc411dbf372",
+          "battery/owner": "batt_0191808e3e507822ae682631d8700a63",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -288,7 +288,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_01917fb0f37d7a7c8cd4ffc411dbf372",
+              "battery/owner": "batt_0191808e3e507822ae682631d8700a63",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -301,7 +301,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "LIYS5CBLZBKFNKC2QY7SETSYS5F2HFSDX74OJNI3R6E5ZBAIQYNUAIMVAKQ3TDN7"
+                    "value": "5IBFXLHKYS4N4XX25YLZBMQFS5AYP2NM2JPSNMTQR7QNZNZRZ3CDGFYWO5OOIN2O"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -349,7 +349,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "FMW5WG4MUFNWYPGV73YDR65SKOCK4PQGERS3JQN3OCRBV6CCMDBA===="
+          "battery/hash": "56SCC2OD4XD3XRSICB4OKQH2GF5LLB2OUEQLVKTSONB45IN2SL6Q===="
         },
         "labels": {
           "app": "battery-core",
@@ -359,7 +359,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f37d7a7c8cd4ffc411dbf372",
+          "battery/owner": "batt_0191808e3e507822ae682631d8700a63",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -371,7 +371,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "EQ5IPOFPH7BATXIECGCI4X2V5DBZIMDK72DYUIQB2E2AFKZK5JIA===="
+          "battery/hash": "UIHL6NVHYSQH5EIUA5ETOBHYVUA2DORCYVAGISDEUS7BOJHN3SAA===="
         },
         "labels": {
           "app": "battery-core",
@@ -381,7 +381,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f37d7a7c8cd4ffc411dbf372",
+          "battery/owner": "batt_0191808e3e507822ae682631d8700a63",
           "version": "latest"
         },
         "name": "bootstrap",
@@ -394,7 +394,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "75VRR3GK634S5YEVAW2ZQNBW2AI75BFHV5WRNT4VGLW7AZVIFO6A====",
+          "battery/hash": "AFINJSYX3SRLE27PWNHUAGXBJAMQRGY7WFNLVGPO2UTY75FE2YPQ====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -405,7 +405,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f37d7a7c8cd4ffc411dbf372",
+          "battery/owner": "batt_0191808e3e507822ae682631d8700a63",
           "version": "latest"
         },
         "name": "gp2"
@@ -420,7 +420,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "GY3ZGOEMBH3HPZTOAL62THUDIPMLJ3TU7F3WZDNF2LB3RCCQZN2Q====",
+          "battery/hash": "2THVFEJOHXIFP2AGD6AZASJPAKQVEVRNIOEXSB5MSAP5W5PXW7AQ====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -431,7 +431,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f37d7a7c8cd4ffc411dbf372",
+          "battery/owner": "batt_0191808e3e507822ae682631d8700a63",
           "version": "latest"
         },
         "name": "gp2-90032408"
@@ -451,7 +451,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "YPGWVV5JNJIPGO3RDJLEE5U4GI6T7Z3OCNMMD3EP6X2XGM4FC5AA====",
+          "battery/hash": "35OC7TQ2NNEG4K6H3UH4L4GCJRMVZ6SFHT4SKOQ64TT4HBGCXPMQ====",
           "storageclass.kubernetes.io/is-default-class": "true"
         },
         "labels": {
@@ -462,7 +462,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_01917fb0f37d7a7c8cd4ffc411dbf372",
+          "battery/owner": "batt_0191808e3e507822ae682631d8700a63",
           "version": "latest"
         },
         "name": "gp3-105457460"

--- a/bootstrap/team.json
+++ b/bootstrap/team.json
@@ -1,5 +1,5 @@
 {
-  "id": "batt_01917fb0f3187690a9b74a60fa13828c",
+  "id": "batt_0191808e3dee71769cb97e44ee965206",
   "name": "Batteries Included Team",
   "inserted_at": null,
   "updated_at": null,

--- a/platform_umbrella/apps/common_core/lib/common_core/installs/batteries.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/installs/batteries.ex
@@ -75,7 +75,7 @@ defmodule CommonCore.Installs.Batteries do
       # We have a special case where kind is used for integration tests
       # that needs to be slim for now to keep GH's runners happy. They run on fucking potatos.
       :internal_int_test ->
-        ~w(battery_core cloudnative_pg traditional_services)a
+        ~w(battery_core cloudnative_pg istio_gateway metallb traditional_services)a
 
       :internal_prod ->
         ~w(metallb traditional_services)a ++ @standard_battery_types

--- a/platform_umbrella/apps/common_core/lib/common_core/installs/traditional_services.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/installs/traditional_services.ex
@@ -38,6 +38,8 @@ defmodule CommonCore.Installs.TraditionalServices do
 
   def services(%{usage: _} = _installation), do: []
 
+  defp install_size(%{usage: :internal_int_test} = _install), do: "small"
+
   # The install sizes and service sizes match up but they may? not always
   defp install_size(install), do: Atom.to_string(install.default_size)
 

--- a/platform_umbrella/apps/common_core/lib/common_core/state_summary/access_spec.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/state_summary/access_spec.ex
@@ -32,13 +32,6 @@ defmodule CommonCore.StateSummary.AccessSpec do
     }
   end
 
-  defp valid_host?(host, usage) when usage in [:internal_int_test] do
-    host != nil and
-      String.length(host) > 0 and
-      !String.contains?(host, "..batrsinc.co") and
-      valid_uri?(host)
-  end
-
   defp valid_host?(host, _usage) do
     host != nil and
       String.length(host) > 0 and


### PR DESCRIPTION
This starts to address issues running the integration testing install.

- make control server and home-base accessible from outside the cluster
- make home-base slightly smaller to conserve resources