### PR TITLE
chore(core): validate image struct

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/defaults/image.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/defaults/image.ex
@@ -2,9 +2,25 @@ defmodule CommonCore.Defaults.Image do
   @moduledoc false
   use CommonCore, :embedded_schema
 
+  @required_fields ~w(name tags default_tag)a
+
   batt_embedded_schema do
     field :name, :string
     field :tags, {:array, :string}
     field :default_tag, :string
+  end
+
+  @doc false
+  def changeset(image, attrs) do
+    image
+    |> CommonCore.Ecto.Schema.schema_changeset(attrs)
+    |> default_tag_in_tags()
+  end
+
+  def default_tag_in_tags(changeset) do
+    changeset
+    |> Ecto.Changeset.get_field(:tags, [])
+    |> Kernel.||([])
+    |> then(&Ecto.Changeset.validate_inclusion(changeset, :default_tag, &1))
   end
 end

--- a/platform_umbrella/apps/common_core/test/common_core/defaults/image_test.exs
+++ b/platform_umbrella/apps/common_core/test/common_core/defaults/image_test.exs
@@ -1,0 +1,32 @@
+defmodule CommonCore.Defaults.ImageTest do
+  use ExUnit.Case
+
+  alias CommonCore.Defaults.Image
+
+  @valid_image_attrs %{name: "bi/image", tags: ~w(a b c), default_tag: "a"}
+
+  describe "CommonCore.Defaults.Image" do
+    test "valid image can be new'd" do
+      assert {:ok, image} = Image.new(@valid_image_attrs)
+      assert image.name == "bi/image"
+      assert image.tags == ~w(a b c)
+      assert image.default_tag == "a"
+    end
+
+    test "name is a required field" do
+      assert {:error, _} = Image.new(Map.delete(@valid_image_attrs, :name))
+    end
+
+    test "tags is a required field" do
+      assert {:error, _} = Image.new(Map.delete(@valid_image_attrs, :tags))
+    end
+
+    test "default_tag is a required field" do
+      assert {:error, _} = Image.new(Map.delete(@valid_image_attrs, :default_tag))
+    end
+
+    test "default_tag must be in tags" do
+      assert {:error, _} = Image.new(%{@valid_image_attrs | default_tag: "not in tags"})
+    end
+  end
+end


### PR DESCRIPTION
It's probably valuable to have some good validation on these as we can use them at compile time to set up defaultable image fields.