### PR TITLE
refactor(core): migrate default images to use registry

### DIFF
--- a/bootstrap/damian.install.json
+++ b/bootstrap/damian.install.json
@@ -1,18 +1,18 @@
 {
-  "id": "batt_0191808e3e3f7bdda5050d6e0ab1088f",
+  "id": "batt_01919ae7df3077a5a860d0d034632cf7",
   "usage": "development",
   "default_size": "small",
   "control_jwk": {
     "crv": "Ed25519",
-    "d": "yWXzoUlvTdUvz7cjjcGHl-DU_cCkI8mZL1C3ijC6MfE",
+    "d": "gr6VF6pAhDyUSZXq2we9-LAbB0KqzTEnAP9EqvvizS8",
     "kty": "OKP",
-    "x": "VGXREBG5MefdBSpVAu4oofh_Vgq_6e3xGNAhw6RJ7gc"
+    "x": "kreXjG_7gB-gXLrpOx7xTmM6bn_8ybnwAyI6Mp2F5eA"
   },
   "inserted_at": null,
   "updated_at": null,
   "slug": "damian",
   "kube_provider": "aws",
-  "team_id": "batt_0191808e3dee71769cb97e44ee965206",
+  "team_id": "batt_01919ae7dee477ae8b21960049e4c9bf",
   "kube_provider_config": {},
   "user_id": null
 }

--- a/bootstrap/damian.spec.json
+++ b/bootstrap/damian.spec.json
@@ -9,7 +9,7 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_0191808e3e5071f99e49948366ae5eda",
+        "id": "batt_01919ae7df3e7c61b234165a28de88ec",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -22,12 +22,12 @@
           "default_size": "small",
           "cluster_name": "damian",
           "server_in_cluster": true,
-          "install_id": "batt_0191808e3e3f7bdda5050d6e0ab1088f",
+          "install_id": "batt_01919ae7df3077a5a860d0d034632cf7",
           "control_jwk": {
             "crv": "Ed25519",
-            "d": "yWXzoUlvTdUvz7cjjcGHl-DU_cCkI8mZL1C3ijC6MfE",
+            "d": "gr6VF6pAhDyUSZXq2we9-LAbB0KqzTEnAP9EqvvizS8",
             "kty": "OKP",
-            "x": "VGXREBG5MefdBSpVAu4oofh_Vgq_6e3xGNAhw6RJ7gc"
+            "x": "kreXjG_7gB-gXLrpOx7xTmM6bn_8ybnwAyI6Mp2F5eA"
           },
           "upgrade_days_of_week": [
             true,
@@ -52,7 +52,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e50716f9d3b8c9080f49338",
+        "id": "batt_01919ae7df3e7a72adce4c35fedd47b2",
         "type": "karpenter",
         "config": {
           "type": "karpenter",
@@ -60,14 +60,15 @@
           "service_role_arn": null,
           "queue_name": null,
           "node_role_name": null,
-          "image_override": null
+          "image_tag_override": null,
+          "image_name_override": null
         },
         "group": "magic",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e50791c98a104b04d24eb16",
+        "id": "batt_01919ae7df3e72ea946e760a26adcbf6",
         "type": "cert_manager",
         "config": {
           "type": "cert_manager",
@@ -77,18 +78,23 @@
           "controller_image": "quay.io/jetstack/cert-manager-controller:v1.15.1",
           "ctl_image": "quay.io/jetstack/cert-manager-ctl:v1.15.1",
           "webhook_image": "quay.io/jetstack/cert-manager-webhook:v1.15.1",
-          "controller_image_override": null,
-          "webhook_image_override": null,
-          "acmesolver_image_override": null,
-          "cainjector_image_override": null,
-          "ctl_image_override": null
+          "acmesolver_image_name_override": null,
+          "acmesolver_image_tag_override": null,
+          "cainjector_image_name_override": null,
+          "cainjector_image_tag_override": null,
+          "controller_image_name_override": null,
+          "controller_image_tag_override": null,
+          "ctl_image_name_override": null,
+          "ctl_image_tag_override": null,
+          "webhook_image_name_override": null,
+          "webhook_image_tag_override": null
         },
         "group": "net_sec",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e507d93b5b1f7eaf3b66c3b",
+        "id": "batt_01919ae7df3e7759980b9b90f76013b5",
         "type": "battery_ca",
         "config": {
           "type": "battery_ca"
@@ -98,7 +104,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e50751f850154d8f03f1bfb",
+        "id": "batt_01919ae7df3e7cf68680e9bd05b7672d",
         "type": "aws_load_balancer_controller",
         "config": {
           "type": "aws_load_balancer_controller",
@@ -106,52 +112,56 @@
           "service_role_arn": null,
           "subnets": null,
           "eip_allocations": null,
-          "image_override": null
+          "image_tag_override": null,
+          "image_name_override": null
         },
         "group": "magic",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e50700f9873876ab4368bfb",
+        "id": "batt_01919ae7df3e759aa371a8f095af1226",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
           "image": "ghcr.io/cloudnative-pg/cloudnative-pg:1.23.2",
-          "image_override": null
+          "image_tag_override": null,
+          "image_name_override": null
         },
         "group": "data",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e5072f8998641604f7e839a",
+        "id": "batt_01919ae7df3e7f97a205ad2c687754f7",
         "type": "istio",
         "config": {
           "type": "istio",
           "namespace": "battery-istio",
           "pilot_image": "docker.io/istio/pilot:1.22.3-distroless",
           "namespace_override": null,
-          "pilot_image_override": null
+          "pilot_image_name_override": null,
+          "pilot_image_tag_override": null
         },
         "group": "net_sec",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e507eb2b60890ee6388f7ba",
+        "id": "batt_01919ae7df3e7afda7f8b51392f4216b",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
           "proxy_image": "docker.io/istio/proxyv2:1.22.3-distroless",
-          "proxy_image_override": null
+          "proxy_image_name_override": null,
+          "proxy_image_tag_override": null
         },
         "group": "net_sec",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e507a19816cb163797d3b6e",
+        "id": "batt_01919ae7df3e7a3cad4411a73d49ae2f",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -195,7 +205,7 @@
           {
             "version": 1,
             "username": "battery-control-user",
-            "password": "YQBYDS5TF5GSPYBGXHPOTRPJ"
+            "password": "NONXN6472TFRRXQYEBA67XX4"
           }
         ],
         "cpu_requested": 500,
@@ -221,7 +231,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "ZLZIPQZ4CK4RDU6WNM3K7ML3KXG6MZV5LKQVWRFJKGKSSUFKDOQQ===="
+          "battery/hash": "5IZF6FSZWMVQR6LJDQBSL33SN4JM32W5OTAZXF7LVZ7SULZFUEXQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -231,7 +241,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e5071f99e49948366ae5eda",
+          "battery/owner": "batt_01919ae7df3e7c61b234165a28de88ec",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -254,7 +264,7 @@
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "L4KJMJGAC4OPMW2NRUYPRLAL7YC3XBROUKE4QQ2EWET4I2ZQMFPQ===="
+          "battery/hash": "KQCO3IUQYPIHZSZT5YID632NRMZO5AWTRRD4EWE32FDGOWZY3KNQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -264,7 +274,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e5071f99e49948366ae5eda",
+          "battery/owner": "batt_01919ae7df3e7c61b234165a28de88ec",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -288,7 +298,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_0191808e3e5071f99e49948366ae5eda",
+              "battery/owner": "batt_01919ae7df3e7c61b234165a28de88ec",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -301,7 +311,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "IE5WPOGUWMU2OJ3S4SHSDUIBBYQKZ36POQDLX5LAXJGLGIK4YH7X4XXRA3H5HLIO"
+                    "value": "FVQO4CHWEI6DZPJ5CAEQ4NOSWA5H6MCSJWHGVLAY7PHTOTO7VQHYDU5VTGD7AIIF"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -349,7 +359,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "BPXWJBTYTABNQPK4LCLTCA3RUOQTVINLG2PCSWMPFLWFT4GSXZLA===="
+          "battery/hash": "MLKO6MG4VC2STIIQQPH6E6IRZXJFDZ7LG3MP6MXL6W54L5BR5T2Q===="
         },
         "labels": {
           "app": "battery-core",
@@ -359,7 +369,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e5071f99e49948366ae5eda",
+          "battery/owner": "batt_01919ae7df3e7c61b234165a28de88ec",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -371,7 +381,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "5EP44TNKVIUIO3AKIL5YAL6XCRYAY6XDQZNMNUUQTPRL3EYHCBNQ===="
+          "battery/hash": "MKTRWBR2IE6YVYG65SQX7DYF6AWJW7KFF3AIWD76WLKQIMDDDYKA===="
         },
         "labels": {
           "app": "battery-core",
@@ -381,7 +391,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e5071f99e49948366ae5eda",
+          "battery/owner": "batt_01919ae7df3e7c61b234165a28de88ec",
           "version": "latest"
         },
         "name": "bootstrap",
@@ -394,7 +404,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "6XI5776ZKHBJCES5HVLLRI7YLMSTHYUHDI5IGZ5SEIOAVGS6XS4A====",
+          "battery/hash": "GLOO2BVPK2PW5UY4DE7SJHSF4TS5JNWCWXE3PD3ZKPLBJ35KYNTA====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -405,7 +415,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e5071f99e49948366ae5eda",
+          "battery/owner": "batt_01919ae7df3e7c61b234165a28de88ec",
           "version": "latest"
         },
         "name": "gp2"
@@ -420,7 +430,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "3IDNBTT73KCWTBIEONNZRZRQGSUTMET6A4LEKUCY4VJETDQMQEFQ====",
+          "battery/hash": "36TNWZ6RGO7NDRMQGRB5NUXUNJ2NEDUT7QB3L4RDWO65YHT372OA====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -431,7 +441,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e5071f99e49948366ae5eda",
+          "battery/owner": "batt_01919ae7df3e7c61b234165a28de88ec",
           "version": "latest"
         },
         "name": "gp2-90032408"
@@ -451,7 +461,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "ZTGQXSAG7HGCOISIO3DJP7UVTEWTI662G577DBBEN6NKFTJRWB5Q====",
+          "battery/hash": "J23ZWVNRCEAPOBVKIUKYZRFPCJMZVPECSIVI7CEF4NVHXI2CZ3WQ====",
           "storageclass.kubernetes.io/is-default-class": "true"
         },
         "labels": {
@@ -462,7 +472,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e5071f99e49948366ae5eda",
+          "battery/owner": "batt_01919ae7df3e7c61b234165a28de88ec",
           "version": "latest"
         },
         "name": "gp3-105457460"

--- a/bootstrap/dev.install.json
+++ b/bootstrap/dev.install.json
@@ -1,18 +1,18 @@
 {
-  "id": "batt_0191808e3df17ddfb6af4642c1be833f",
+  "id": "batt_01919ae7dee67a6f90887e0e5bbcc816",
   "usage": "internal_dev",
   "default_size": "tiny",
   "control_jwk": {
     "crv": "Ed25519",
-    "d": "1QnM9jWw_EJnRuR-XunfjUx8AaQuLI6Qs1D05PhH-tU",
+    "d": "f3akk6-z6fiMhcOhIQmqfTTFir0jufzkzxMC0oGCjmM",
     "kty": "OKP",
-    "x": "imkCxdCjRg4AcmPe2-cvEfaXBSqk9JHq_nrOQcN08AM"
+    "x": "2JBfseC26hjodlINbme0hVIQNK-8WfUeOyPfPJV4C-s"
   },
   "inserted_at": null,
   "updated_at": null,
   "slug": "dev",
   "kube_provider": "kind",
-  "team_id": "batt_0191808e3dee71769cb97e44ee965206",
+  "team_id": "batt_01919ae7dee477ae8b21960049e4c9bf",
   "kube_provider_config": {},
   "user_id": null
 }

--- a/bootstrap/dev.spec.json
+++ b/bootstrap/dev.spec.json
@@ -9,33 +9,35 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_0191808e3e4973ed956a4a9ec0e90709",
+        "id": "batt_01919ae7df357f4b8c52ec95615fbfec",
         "type": "istio",
         "config": {
           "type": "istio",
           "namespace": "battery-istio",
           "pilot_image": "docker.io/istio/pilot:1.22.3-distroless",
           "namespace_override": null,
-          "pilot_image_override": null
+          "pilot_image_name_override": null,
+          "pilot_image_tag_override": null
         },
         "group": "net_sec",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e49779d9dcf76445fd6ccd1",
+        "id": "batt_01919ae7df3576258f7d14aefeac661b",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
           "proxy_image": "docker.io/istio/proxyv2:1.22.3-distroless",
-          "proxy_image_override": null
+          "proxy_image_name_override": null,
+          "proxy_image_tag_override": null
         },
         "group": "net_sec",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e4979ed8a3f33c769dc4b0d",
+        "id": "batt_01919ae7df35715889d1fc0b08e6dfb0",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -48,12 +50,12 @@
           "default_size": "tiny",
           "cluster_name": "dev",
           "server_in_cluster": false,
-          "install_id": "batt_0191808e3df17ddfb6af4642c1be833f",
+          "install_id": "batt_01919ae7dee67a6f90887e0e5bbcc816",
           "control_jwk": {
             "crv": "Ed25519",
-            "d": "1QnM9jWw_EJnRuR-XunfjUx8AaQuLI6Qs1D05PhH-tU",
+            "d": "f3akk6-z6fiMhcOhIQmqfTTFir0jufzkzxMC0oGCjmM",
             "kty": "OKP",
-            "x": "imkCxdCjRg4AcmPe2-cvEfaXBSqk9JHq_nrOQcN08AM"
+            "x": "2JBfseC26hjodlINbme0hVIQNK-8WfUeOyPfPJV4C-s"
           },
           "upgrade_days_of_week": [
             true,
@@ -78,7 +80,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e497e55bb410576127529f0",
+        "id": "batt_01919ae7df357edd9a0883242788f0ff",
         "type": "metallb",
         "config": {
           "type": "metallb",
@@ -86,28 +88,32 @@
           "speaker_image": "quay.io/metallb/speaker:v0.14.8",
           "frrouting_image": "quay.io/frrouting/frr:9.1.0",
           "enable_pod_monitor": false,
-          "speaker_image_override": null,
-          "controller_image_override": null,
-          "frrouting_image_override": null
+          "speaker_image_name_override": null,
+          "speaker_image_tag_override": null,
+          "controller_image_name_override": null,
+          "controller_image_tag_override": null,
+          "frrouting_image_name_override": null,
+          "frrouting_image_tag_override": null
         },
         "group": "net_sec",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e4974e0baaf07f1c6060d75",
+        "id": "batt_01919ae7df3576848482b0ebcfba284a",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
           "image": "ghcr.io/cloudnative-pg/cloudnative-pg:1.23.2",
-          "image_override": null
+          "image_tag_override": null,
+          "image_name_override": null
         },
         "group": "data",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e497bb9bb794a1de929bc77",
+        "id": "batt_01919ae7df35783c8d3cdb6ba66e4b18",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -162,7 +168,7 @@
           {
             "version": 2,
             "username": "battery-control-user",
-            "password": "SM7A7SFGVMRWGDDYRY6RSUSL"
+            "password": "LUUN55DMHIMYLO2BF4HAN5UY"
           },
           {
             "version": 1,
@@ -193,7 +199,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "OYPNLDHZJLET6DGCCIZDTURFRBSY3UZGOUGGPPPWTLGMQ4ZROUDQ===="
+          "battery/hash": "O52DYPPVJARGBAMWG7GROMXW3SUSYJS74G6NIFGQL3LX2MVAE6DQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -203,7 +209,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e4979ed8a3f33c769dc4b0d",
+          "battery/owner": "batt_01919ae7df35715889d1fc0b08e6dfb0",
           "istio-injection": "enabled",
           "version": "latest"
         },

--- a/bootstrap/elliott.install.json
+++ b/bootstrap/elliott.install.json
@@ -1,18 +1,18 @@
 {
-  "id": "batt_0191808e3e3f7dc294b9c1b77978f4c7",
+  "id": "batt_01919ae7df30700da9ae7105d4bf0e92",
   "usage": "development",
   "default_size": "small",
   "control_jwk": {
     "crv": "Ed25519",
-    "d": "ApxPU0jKmm6dVoLFpj3Y29Ij-LBqBDtCJtAkozK9_Xk",
+    "d": "LczlkyefQIhHXgyQdd25V9MQLsSPPrIPDbAdACtJm24",
     "kty": "OKP",
-    "x": "fEYb84z6KcLZ9hkPl9-NlqQGxYYgOSzLLY1_FyjonJY"
+    "x": "nozFYtlHNSlvoGwerMd_4zgEKjW_MZUhs4OFMf0MDyg"
   },
   "inserted_at": null,
   "updated_at": null,
   "slug": "elliott",
   "kube_provider": "aws",
-  "team_id": "batt_0191808e3dee71769cb97e44ee965206",
+  "team_id": "batt_01919ae7dee477ae8b21960049e4c9bf",
   "kube_provider_config": {},
   "user_id": null
 }

--- a/bootstrap/elliott.spec.json
+++ b/bootstrap/elliott.spec.json
@@ -9,7 +9,7 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_0191808e3e4e7a6491f41de5372e4ce1",
+        "id": "batt_01919ae7df3b742aad059b00bd33ec23",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -22,12 +22,12 @@
           "default_size": "small",
           "cluster_name": "elliott",
           "server_in_cluster": true,
-          "install_id": "batt_0191808e3e3f7dc294b9c1b77978f4c7",
+          "install_id": "batt_01919ae7df30700da9ae7105d4bf0e92",
           "control_jwk": {
             "crv": "Ed25519",
-            "d": "ApxPU0jKmm6dVoLFpj3Y29Ij-LBqBDtCJtAkozK9_Xk",
+            "d": "LczlkyefQIhHXgyQdd25V9MQLsSPPrIPDbAdACtJm24",
             "kty": "OKP",
-            "x": "fEYb84z6KcLZ9hkPl9-NlqQGxYYgOSzLLY1_FyjonJY"
+            "x": "nozFYtlHNSlvoGwerMd_4zgEKjW_MZUhs4OFMf0MDyg"
           },
           "upgrade_days_of_week": [
             true,
@@ -52,7 +52,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e4e72d4919b72cdb407e1c1",
+        "id": "batt_01919ae7df3b7b02ad76cdbe803b1391",
         "type": "karpenter",
         "config": {
           "type": "karpenter",
@@ -60,14 +60,15 @@
           "service_role_arn": null,
           "queue_name": null,
           "node_role_name": null,
-          "image_override": null
+          "image_tag_override": null,
+          "image_name_override": null
         },
         "group": "magic",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e4e705ba0e47f3041f7d318",
+        "id": "batt_01919ae7df3b740ea01da16a0a425655",
         "type": "cert_manager",
         "config": {
           "type": "cert_manager",
@@ -77,18 +78,23 @@
           "controller_image": "quay.io/jetstack/cert-manager-controller:v1.15.1",
           "ctl_image": "quay.io/jetstack/cert-manager-ctl:v1.15.1",
           "webhook_image": "quay.io/jetstack/cert-manager-webhook:v1.15.1",
-          "controller_image_override": null,
-          "webhook_image_override": null,
-          "acmesolver_image_override": null,
-          "cainjector_image_override": null,
-          "ctl_image_override": null
+          "acmesolver_image_name_override": null,
+          "acmesolver_image_tag_override": null,
+          "cainjector_image_name_override": null,
+          "cainjector_image_tag_override": null,
+          "controller_image_name_override": null,
+          "controller_image_tag_override": null,
+          "ctl_image_name_override": null,
+          "ctl_image_tag_override": null,
+          "webhook_image_name_override": null,
+          "webhook_image_tag_override": null
         },
         "group": "net_sec",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e4e7c68ae87a3b796303fec",
+        "id": "batt_01919ae7df3b791e9cf35c1af9b7b124",
         "type": "battery_ca",
         "config": {
           "type": "battery_ca"
@@ -98,7 +104,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e4e7adb95be0a3ac8ca003b",
+        "id": "batt_01919ae7df3b73c9bb2d01d5f9ad2d5c",
         "type": "aws_load_balancer_controller",
         "config": {
           "type": "aws_load_balancer_controller",
@@ -106,52 +112,56 @@
           "service_role_arn": null,
           "subnets": null,
           "eip_allocations": null,
-          "image_override": null
+          "image_tag_override": null,
+          "image_name_override": null
         },
         "group": "magic",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e4e7e9899b4d6db5970e36d",
+        "id": "batt_01919ae7df3b798e9ad94b5542749f2e",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
           "image": "ghcr.io/cloudnative-pg/cloudnative-pg:1.23.2",
-          "image_override": null
+          "image_tag_override": null,
+          "image_name_override": null
         },
         "group": "data",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e4e7e8ab90c54c65e09d7e7",
+        "id": "batt_01919ae7df3b7c2ab404d110468cb909",
         "type": "istio",
         "config": {
           "type": "istio",
           "namespace": "battery-istio",
           "pilot_image": "docker.io/istio/pilot:1.22.3-distroless",
           "namespace_override": null,
-          "pilot_image_override": null
+          "pilot_image_name_override": null,
+          "pilot_image_tag_override": null
         },
         "group": "net_sec",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e4e76aa82ec313514f59425",
+        "id": "batt_01919ae7df3b7400b4b826d14911ed9c",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
           "proxy_image": "docker.io/istio/proxyv2:1.22.3-distroless",
-          "proxy_image_override": null
+          "proxy_image_name_override": null,
+          "proxy_image_tag_override": null
         },
         "group": "net_sec",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e4e7dac8340875a437875b1",
+        "id": "batt_01919ae7df3b7c10a22c77f82db32349",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -195,7 +205,7 @@
           {
             "version": 1,
             "username": "battery-control-user",
-            "password": "LYVWJL2OZAQS6L2PRD6CGPOP"
+            "password": "KXKEN62UVOYKAF4FBA5YOB7J"
           }
         ],
         "cpu_requested": 500,
@@ -221,7 +231,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "H6WMOLSJ4NMIHFNHQBDF2X33MGX4O2GIUVDS2PXSXEK2N5DY7QBA===="
+          "battery/hash": "YKDZ44BFU6NSTAAR7XAI2DSNWYCTM7VYAJAK4QTUKX3Y3LFE5SVA===="
         },
         "labels": {
           "app": "battery-core",
@@ -231,7 +241,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e4e7a6491f41de5372e4ce1",
+          "battery/owner": "batt_01919ae7df3b742aad059b00bd33ec23",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -254,7 +264,7 @@
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "RW7RSH5CCQ73G54JQ5D7SAMCIKOXJXSD4ZBNFIZ7UQG7QFVXYVYQ===="
+          "battery/hash": "DTPVG6VD67VCTF4MCXWVPTZJZRMZV2CYBNREIMGCRMC6ZOKWAVRA===="
         },
         "labels": {
           "app": "battery-core",
@@ -264,7 +274,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e4e7a6491f41de5372e4ce1",
+          "battery/owner": "batt_01919ae7df3b742aad059b00bd33ec23",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -288,7 +298,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_0191808e3e4e7a6491f41de5372e4ce1",
+              "battery/owner": "batt_01919ae7df3b742aad059b00bd33ec23",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -301,7 +311,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "57CNSNUU33ZOCYSLA642ARRPM5TTK6LZL3RS4RS4I7SCMRIR2UOMG5M4LP7SBY7T"
+                    "value": "XNQUIELRCRHSQXLPL246TTMZTG4FJTPJVSS55CSMJOFRUTBFARK2OS6BQVLT5VOV"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -349,7 +359,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "43PJUZYJH3HCCCPAUEMOMJMS4MOVROCDAOILGUFD65TN6SZ6QCXA===="
+          "battery/hash": "3LZMI2HAUMHMKKVTPBHYK4PAMC5YPOEVKQCFSBQQBKYOTDUHKJYQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -359,7 +369,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e4e7a6491f41de5372e4ce1",
+          "battery/owner": "batt_01919ae7df3b742aad059b00bd33ec23",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -371,7 +381,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "63DFFVCD2PCFKPRTMR67LTLODPRP2F7CRJVEHXAEGBPHREO6VPSQ===="
+          "battery/hash": "KYQHPWHU2YSJPBEN4P2SABKGXJPISS4AYKCTVBNPN2P6A7SZZB4Q===="
         },
         "labels": {
           "app": "battery-core",
@@ -381,7 +391,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e4e7a6491f41de5372e4ce1",
+          "battery/owner": "batt_01919ae7df3b742aad059b00bd33ec23",
           "version": "latest"
         },
         "name": "bootstrap",
@@ -394,7 +404,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "JLSMHVFPC23DDIKAMQ5TWMB7TD7H6KSOEORGJ3EFWWYFFPPRQNGQ====",
+          "battery/hash": "I53KE7UIZBP3Z4X5OKDB3FMWXNKRMWMAQFS4MHYPANMPHON25HMA====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -405,7 +415,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e4e7a6491f41de5372e4ce1",
+          "battery/owner": "batt_01919ae7df3b742aad059b00bd33ec23",
           "version": "latest"
         },
         "name": "gp2"
@@ -420,7 +430,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "56RMIZU6RW3UNA7QP7GHWTLZI4GQVFE57XCCPLGDBY2UCP6LYB6Q====",
+          "battery/hash": "OTQSQRHMHLHM6LUSJ5D3TVTBVRYMRKUN5BYTOEFABWVUNZTVBHWQ====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -431,7 +441,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e4e7a6491f41de5372e4ce1",
+          "battery/owner": "batt_01919ae7df3b742aad059b00bd33ec23",
           "version": "latest"
         },
         "name": "gp2-90032408"
@@ -451,7 +461,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "NEPJ2F43Y56TJAT33BBQ7XOJUF3MWWAYR4VBXY2FWNDUEZJS32QA====",
+          "battery/hash": "2KM6LT2YHYQ2K7IYYNDFKISBKT4OKQ7J3C2VJWBK3NVYBNGXZCFQ====",
           "storageclass.kubernetes.io/is-default-class": "true"
         },
         "labels": {
@@ -462,7 +472,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e4e7a6491f41de5372e4ce1",
+          "battery/owner": "batt_01919ae7df3b742aad059b00bd33ec23",
           "version": "latest"
         },
         "name": "gp3-105457460"

--- a/bootstrap/int-prod.install.json
+++ b/bootstrap/int-prod.install.json
@@ -1,18 +1,18 @@
 {
-  "id": "batt_0191808e3e3f72108db3cdc66ea159f9",
+  "id": "batt_01919ae7df307850a6cc10fc0422df35",
   "usage": "internal_prod",
   "default_size": "medium",
   "control_jwk": {
     "crv": "Ed25519",
-    "d": "H_vq3IC05FqzxkdD_npx0tPUes8fKCrZoVjSMRckpC0",
+    "d": "E3ktl9O4qFPQDu5_X3i47DUgTkgXzZm50QlHBr4yd1s",
     "kty": "OKP",
-    "x": "25tJDeP3yEoh0OBeZv6l7Qp_nw-VhT5p5GrC1OF93hg"
+    "x": "uP0osYEOOeB3qvec9xqPTXLzR0TXczjRUuawvbosPz4"
   },
   "inserted_at": null,
   "updated_at": null,
   "slug": "int-prod",
   "kube_provider": "kind",
-  "team_id": "batt_0191808e3dee71769cb97e44ee965206",
+  "team_id": "batt_01919ae7dee477ae8b21960049e4c9bf",
   "kube_provider_config": {},
   "user_id": null
 }

--- a/bootstrap/int-prod.spec.json
+++ b/bootstrap/int-prod.spec.json
@@ -9,33 +9,35 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_0191808e3e4c7681b6a82ad1ab054994",
+        "id": "batt_01919ae7df3976908f50c6570cf93b98",
         "type": "istio",
         "config": {
           "type": "istio",
           "namespace": "battery-istio",
           "pilot_image": "docker.io/istio/pilot:1.22.3-distroless",
           "namespace_override": null,
-          "pilot_image_override": null
+          "pilot_image_name_override": null,
+          "pilot_image_tag_override": null
         },
         "group": "net_sec",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e4c7415bbc4a2a6238aa72d",
+        "id": "batt_01919ae7df397d9d83e1c43b94e86f07",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
           "proxy_image": "docker.io/istio/proxyv2:1.22.3-distroless",
-          "proxy_image_override": null
+          "proxy_image_name_override": null,
+          "proxy_image_tag_override": null
         },
         "group": "net_sec",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e4c733bb07dd9af9758bf84",
+        "id": "batt_01919ae7df3972d7af26c39baae734a1",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -48,12 +50,12 @@
           "default_size": "medium",
           "cluster_name": "int-prod",
           "server_in_cluster": true,
-          "install_id": "batt_0191808e3e3f72108db3cdc66ea159f9",
+          "install_id": "batt_01919ae7df307850a6cc10fc0422df35",
           "control_jwk": {
             "crv": "Ed25519",
-            "d": "H_vq3IC05FqzxkdD_npx0tPUes8fKCrZoVjSMRckpC0",
+            "d": "E3ktl9O4qFPQDu5_X3i47DUgTkgXzZm50QlHBr4yd1s",
             "kty": "OKP",
-            "x": "25tJDeP3yEoh0OBeZv6l7Qp_nw-VhT5p5GrC1OF93hg"
+            "x": "uP0osYEOOeB3qvec9xqPTXLzR0TXczjRUuawvbosPz4"
           },
           "upgrade_days_of_week": [
             true,
@@ -78,7 +80,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e4c7012aaae401568ce3025",
+        "id": "batt_01919ae7df397a4a86c6a93ac588b1e8",
         "type": "metallb",
         "config": {
           "type": "metallb",
@@ -86,16 +88,19 @@
           "speaker_image": "quay.io/metallb/speaker:v0.14.8",
           "frrouting_image": "quay.io/frrouting/frr:9.1.0",
           "enable_pod_monitor": false,
-          "speaker_image_override": null,
-          "controller_image_override": null,
-          "frrouting_image_override": null
+          "speaker_image_name_override": null,
+          "speaker_image_tag_override": null,
+          "controller_image_name_override": null,
+          "controller_image_tag_override": null,
+          "frrouting_image_name_override": null,
+          "frrouting_image_tag_override": null
         },
         "group": "net_sec",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e4c7a2fa4517e18d2d4e81b",
+        "id": "batt_01919ae7df397ad7b1f93e37af9c5ef7",
         "type": "traditional_services",
         "config": {
           "type": "traditional_services",
@@ -107,19 +112,20 @@
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e4c71de897093427870480a",
+        "id": "batt_01919ae7df397247b56308b9cbf0635a",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
           "image": "ghcr.io/cloudnative-pg/cloudnative-pg:1.23.2",
-          "image_override": null
+          "image_tag_override": null,
+          "image_name_override": null
         },
         "group": "data",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e4c7d8aa760ac7796160a87",
+        "id": "batt_01919ae7df3a744eb012985eb054bcac",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -147,7 +153,7 @@
         "env_values": [
           {
             "name": "SECRET_KEY_BASE",
-            "value": "X7PBNMH22BMGTETFR2STBNLMSL3VSJFGIDFPPSJE5IHIB3OFSTOHRCSAMOKIJFPL",
+            "value": "47ZIIGYNHJHG2QTKGORDQN7V3R7MAV4B4EB45GYP534GU2UNETPXGEVIHEKFNMBJ",
             "source_name": null,
             "source_type": "value",
             "source_key": null,
@@ -270,7 +276,7 @@
           {
             "version": 1,
             "username": "battery-control-user",
-            "password": "6LJB7KVH37NU3BEG3BU25BK5"
+            "password": "QG5P5EMU53WB5E5BWAZBWICB"
           }
         ],
         "cpu_requested": 4000,
@@ -311,7 +317,7 @@
           {
             "version": 1,
             "username": "home-base",
-            "password": "NNSUFUQVDEWRFMHPFFUITVY7"
+            "password": "EDMWKQPE2ZRCKCLDOSKI6L2I"
           }
         ],
         "cpu_requested": 4000,
@@ -337,7 +343,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "5PRW6KUTYPHXPVR7LK5ANUEW2VFUAAUAXYOEMQYIPKM3CHGRR3HQ===="
+          "battery/hash": "BOJM2BMTBYUCDDADIOLNMMHRIF5Q33ZSV24YT6YZD43VWCUUR4NA===="
         },
         "labels": {
           "app": "battery-core",
@@ -347,7 +353,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e4c733bb07dd9af9758bf84",
+          "battery/owner": "batt_01919ae7df3972d7af26c39baae734a1",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -368,20 +374,20 @@
     "/config_map/home_base_seed_data": {
       "apiVersion": "v1",
       "data": {
-        "batt_0191808e3dee71769cb97e44ee965206.team.json": "{\"id\":\"batt_0191808e3dee71769cb97e44ee965206\",\"name\":\"Batteries Included Team\",\"inserted_at\":null,\"updated_at\":null,\"op_email\":\"elliott@batteriesincl.com\"}",
-        "damian.install.json": "{\"id\":\"batt_0191808e3e3f7bdda5050d6e0ab1088f\",\"usage\":\"development\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"yWXzoUlvTdUvz7cjjcGHl-DU_cCkI8mZL1C3ijC6MfE\",\"kty\":\"OKP\",\"x\":\"VGXREBG5MefdBSpVAu4oofh_Vgq_6e3xGNAhw6RJ7gc\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"damian\",\"kube_provider\":\"aws\",\"team_id\":\"batt_0191808e3dee71769cb97e44ee965206\",\"kube_provider_config\":{},\"user_id\":null}",
-        "dev.install.json": "{\"id\":\"batt_0191808e3df17ddfb6af4642c1be833f\",\"usage\":\"internal_dev\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"1QnM9jWw_EJnRuR-XunfjUx8AaQuLI6Qs1D05PhH-tU\",\"kty\":\"OKP\",\"x\":\"imkCxdCjRg4AcmPe2-cvEfaXBSqk9JHq_nrOQcN08AM\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"dev\",\"kube_provider\":\"kind\",\"team_id\":\"batt_0191808e3dee71769cb97e44ee965206\",\"kube_provider_config\":{},\"user_id\":null}",
-        "elliott.install.json": "{\"id\":\"batt_0191808e3e3f7dc294b9c1b77978f4c7\",\"usage\":\"development\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"ApxPU0jKmm6dVoLFpj3Y29Ij-LBqBDtCJtAkozK9_Xk\",\"kty\":\"OKP\",\"x\":\"fEYb84z6KcLZ9hkPl9-NlqQGxYYgOSzLLY1_FyjonJY\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"elliott\",\"kube_provider\":\"aws\",\"team_id\":\"batt_0191808e3dee71769cb97e44ee965206\",\"kube_provider_config\":{},\"user_id\":null}",
-        "int-prod.install.json": "{\"id\":\"batt_0191808e3e3f72108db3cdc66ea159f9\",\"usage\":\"internal_prod\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"H_vq3IC05FqzxkdD_npx0tPUes8fKCrZoVjSMRckpC0\",\"kty\":\"OKP\",\"x\":\"25tJDeP3yEoh0OBeZv6l7Qp_nw-VhT5p5GrC1OF93hg\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"int-prod\",\"kube_provider\":\"kind\",\"team_id\":\"batt_0191808e3dee71769cb97e44ee965206\",\"kube_provider_config\":{},\"user_id\":null}",
-        "int-test.install.json": "{\"id\":\"batt_0191808e3e3f709eae6709bce86f4170\",\"usage\":\"internal_int_test\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"CMxg-RubQnce8u7qx_1LrwGTtNBZgRXrx9uTj0ofw0Y\",\"kty\":\"OKP\",\"x\":\"c6pB0o0sGNQDbddIDiDeynZcLKt-6CXe9wBr058W4uk\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"int-test\",\"kube_provider\":\"kind\",\"team_id\":\"batt_0191808e3dee71769cb97e44ee965206\",\"kube_provider_config\":{},\"user_id\":null}",
-        "jason.install.json": "{\"id\":\"batt_0191808e3e3f7b2e9568d09b80d0fdef\",\"usage\":\"development\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"EA3p37UbqPoZKK91sDHsXnNkdBZXAMiXJxry5GCD6pQ\",\"kty\":\"OKP\",\"x\":\"4LMreGz5zNDzhAV4_Z9TLoNSO5PFasNwyBHCdseCW7Y\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"jason\",\"kube_provider\":\"aws\",\"team_id\":\"batt_0191808e3dee71769cb97e44ee965206\",\"kube_provider_config\":{},\"user_id\":null}",
-        "local.install.json": "{\"id\":\"batt_0191808e3e3f7837a713bb440fcfc8a2\",\"usage\":\"development\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"E9Dbpr4_Cx0c1sk4Hfa8wh-RQdgRZZeJ8qju0L4zGp0\",\"kty\":\"OKP\",\"x\":\"ZrSliZtdwlh_IdU8tk0qOSyfu3-qWLlCKmPPOaY6RBg\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"local\",\"kube_provider\":\"kind\",\"team_id\":\"batt_0191808e3dee71769cb97e44ee965206\",\"kube_provider_config\":{},\"user_id\":null}",
-        "maurer.install.json": "{\"id\":\"batt_0191808e3e3f7e418cb896523114c49c\",\"usage\":\"development\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"qhySDvyjQ0BxDXtCog27873ggsVDWp9ZzyT3YieQcFo\",\"kty\":\"OKP\",\"x\":\"5yF4IY_NZixwex39RkwYcEeyZLe1Wfn8tpLMZ03B3-E\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"maurer\",\"kube_provider\":\"aws\",\"team_id\":\"batt_0191808e3dee71769cb97e44ee965206\",\"kube_provider_config\":{},\"user_id\":null}"
+        "batt_01919ae7dee477ae8b21960049e4c9bf.team.json": "{\"id\":\"batt_01919ae7dee477ae8b21960049e4c9bf\",\"name\":\"Batteries Included Team\",\"inserted_at\":null,\"updated_at\":null,\"op_email\":\"elliott@batteriesincl.com\"}",
+        "damian.install.json": "{\"id\":\"batt_01919ae7df3077a5a860d0d034632cf7\",\"usage\":\"development\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"gr6VF6pAhDyUSZXq2we9-LAbB0KqzTEnAP9EqvvizS8\",\"kty\":\"OKP\",\"x\":\"kreXjG_7gB-gXLrpOx7xTmM6bn_8ybnwAyI6Mp2F5eA\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"damian\",\"kube_provider\":\"aws\",\"team_id\":\"batt_01919ae7dee477ae8b21960049e4c9bf\",\"kube_provider_config\":{},\"user_id\":null}",
+        "dev.install.json": "{\"id\":\"batt_01919ae7dee67a6f90887e0e5bbcc816\",\"usage\":\"internal_dev\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"f3akk6-z6fiMhcOhIQmqfTTFir0jufzkzxMC0oGCjmM\",\"kty\":\"OKP\",\"x\":\"2JBfseC26hjodlINbme0hVIQNK-8WfUeOyPfPJV4C-s\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"dev\",\"kube_provider\":\"kind\",\"team_id\":\"batt_01919ae7dee477ae8b21960049e4c9bf\",\"kube_provider_config\":{},\"user_id\":null}",
+        "elliott.install.json": "{\"id\":\"batt_01919ae7df30700da9ae7105d4bf0e92\",\"usage\":\"development\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"LczlkyefQIhHXgyQdd25V9MQLsSPPrIPDbAdACtJm24\",\"kty\":\"OKP\",\"x\":\"nozFYtlHNSlvoGwerMd_4zgEKjW_MZUhs4OFMf0MDyg\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"elliott\",\"kube_provider\":\"aws\",\"team_id\":\"batt_01919ae7dee477ae8b21960049e4c9bf\",\"kube_provider_config\":{},\"user_id\":null}",
+        "int-prod.install.json": "{\"id\":\"batt_01919ae7df307850a6cc10fc0422df35\",\"usage\":\"internal_prod\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"E3ktl9O4qFPQDu5_X3i47DUgTkgXzZm50QlHBr4yd1s\",\"kty\":\"OKP\",\"x\":\"uP0osYEOOeB3qvec9xqPTXLzR0TXczjRUuawvbosPz4\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"int-prod\",\"kube_provider\":\"kind\",\"team_id\":\"batt_01919ae7dee477ae8b21960049e4c9bf\",\"kube_provider_config\":{},\"user_id\":null}",
+        "int-test.install.json": "{\"id\":\"batt_01919ae7df307e098aae8402bafacb8e\",\"usage\":\"internal_int_test\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"7kM5hGNjhSjS6IjU-SwAmWfnXB2ahh5nd57EGLgwhAU\",\"kty\":\"OKP\",\"x\":\"uBGZqbJb7SQV_9lwOKTzc_vOWBmkNsGZm_0kOs0AEbc\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"int-test\",\"kube_provider\":\"kind\",\"team_id\":\"batt_01919ae7dee477ae8b21960049e4c9bf\",\"kube_provider_config\":{},\"user_id\":null}",
+        "jason.install.json": "{\"id\":\"batt_01919ae7df307e31bf7f84c4b05c3c85\",\"usage\":\"development\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"sNMN7pGcIzNNPb6oo7_8r4gPDa6SAVWFyj8HMQGpz6Y\",\"kty\":\"OKP\",\"x\":\"vvP_l7351oXHCkU-3OqPGKEdnqYYDqxCaW7mfaSkAFQ\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"jason\",\"kube_provider\":\"aws\",\"team_id\":\"batt_01919ae7dee477ae8b21960049e4c9bf\",\"kube_provider_config\":{},\"user_id\":null}",
+        "local.install.json": "{\"id\":\"batt_01919ae7df30744d86050a32a7ae9274\",\"usage\":\"development\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"9Ih_BFfGzQb9XrQjo9Qp6-690u-MNE--EKYgR8A3T1U\",\"kty\":\"OKP\",\"x\":\"IXsClMYGV4ea8Vr587RMntpWJozkh56Q9yGqzDm7W5Q\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"local\",\"kube_provider\":\"kind\",\"team_id\":\"batt_01919ae7dee477ae8b21960049e4c9bf\",\"kube_provider_config\":{},\"user_id\":null}",
+        "maurer.install.json": "{\"id\":\"batt_01919ae7df30729fa562480604afecb1\",\"usage\":\"development\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"WArmkusB1tatV7xQybv1PZlJmYh9BxfarYNkinZuqWQ\",\"kty\":\"OKP\",\"x\":\"OQ_sQ9Jrmdvm8cCUhPchh5u4PNUWQRqzbYt-GLTHja4\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"maurer\",\"kube_provider\":\"aws\",\"team_id\":\"batt_01919ae7dee477ae8b21960049e4c9bf\",\"kube_provider_config\":{},\"user_id\":null}"
       },
       "kind": "ConfigMap",
       "metadata": {
         "annotations": {
-          "battery/hash": "EGDB7MPEFSM2JPDHZCDKTIAHOM57ETZPP6FREBFNOLLGNJMRWOCA===="
+          "battery/hash": "ST7F2YSFLQ6YUVHI5MKUEJXX2KAK2V5MGJ2O3YJZW5MGTOCONGBA===="
         },
         "labels": {
           "app": "traditional-services",
@@ -391,7 +397,7 @@
           "battery/app": "traditional-services",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e4c7a2fa4517e18d2d4e81b",
+          "battery/owner": "batt_01919ae7df397ad7b1f93e37af9c5ef7",
           "version": "latest"
         },
         "name": "home-base-seed-data",
@@ -403,7 +409,7 @@
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "7E7KNKSHZ4ZPT44YH3LCZI2C5Y5ZATVP3BNPOPQB7NEWNDEXEBTA===="
+          "battery/hash": "J6YEPK4ALR6SDK4OAZDNJ6WT5UFZ3MKKQTABM6IJ6QEZHAHHJQEQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -413,7 +419,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e4c733bb07dd9af9758bf84",
+          "battery/owner": "batt_01919ae7df3972d7af26c39baae734a1",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -437,7 +443,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_0191808e3e4c733bb07dd9af9758bf84",
+              "battery/owner": "batt_01919ae7df3972d7af26c39baae734a1",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -450,7 +456,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "LI4H4QZERO7XI6XT7XHW3JSWG75I4J3EUGYHLJ4JF5OFDQ3KRVCDZH45MDJ5WR7I"
+                    "value": "EESTCXS5DZSEXMETDNBYHHA3TTWG2SS3L7KBAPTGC4WCAL3CSO5P32FVNKTYQNPR"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -498,7 +504,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "B2LJHKKR4WC2FXMF2BWKHOKDEWMB4CYF3CI3HYSZNZA7FNIPF2JA===="
+          "battery/hash": "UD4VTOPDAGFI6YZNXC6G7H7LPYU2JDUBW3XYUAQ5BCAI43OHUQ3A===="
         },
         "labels": {
           "app": "battery-core",
@@ -508,7 +514,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e4c733bb07dd9af9758bf84",
+          "battery/owner": "batt_01919ae7df3972d7af26c39baae734a1",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -520,7 +526,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "AXM5TLMQXZTGZ53LDNJJIVAR6BFPFPPVZCG3DSNYJBGWXFL567RA===="
+          "battery/hash": "DGQ2DZ4N7TQURYZ6EJPP3KZY3NJRZOIQOJGBAT5GVXMZFXFXYZFQ===="
         },
         "labels": {
           "app": "traditional-services",
@@ -530,7 +536,7 @@
           "battery/app": "traditional-services",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e4c7a2fa4517e18d2d4e81b",
+          "battery/owner": "batt_01919ae7df397ad7b1f93e37af9c5ef7",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -542,7 +548,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "DCQQ2OWQZZGRVHKHZDDMNPG7AA57E6M3NBITVQDGSLIUR7HPCZ3A===="
+          "battery/hash": "HPO4GABU3S7YCVE5ULVMFAJOEC7BQXKQBM7QPAQV7MNLM6POJGWQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -552,7 +558,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e4c733bb07dd9af9758bf84",
+          "battery/owner": "batt_01919ae7df3972d7af26c39baae734a1",
           "version": "latest"
         },
         "name": "bootstrap",

--- a/bootstrap/int-test.install.json
+++ b/bootstrap/int-test.install.json
@@ -1,18 +1,18 @@
 {
-  "id": "batt_0191808e3e3f709eae6709bce86f4170",
+  "id": "batt_01919ae7df307e098aae8402bafacb8e",
   "usage": "internal_int_test",
   "default_size": "medium",
   "control_jwk": {
     "crv": "Ed25519",
-    "d": "CMxg-RubQnce8u7qx_1LrwGTtNBZgRXrx9uTj0ofw0Y",
+    "d": "7kM5hGNjhSjS6IjU-SwAmWfnXB2ahh5nd57EGLgwhAU",
     "kty": "OKP",
-    "x": "c6pB0o0sGNQDbddIDiDeynZcLKt-6CXe9wBr058W4uk"
+    "x": "uBGZqbJb7SQV_9lwOKTzc_vOWBmkNsGZm_0kOs0AEbc"
   },
   "inserted_at": null,
   "updated_at": null,
   "slug": "int-test",
   "kube_provider": "kind",
-  "team_id": "batt_0191808e3dee71769cb97e44ee965206",
+  "team_id": "batt_01919ae7dee477ae8b21960049e4c9bf",
   "kube_provider_config": {},
   "user_id": null
 }

--- a/bootstrap/int-test.spec.json
+++ b/bootstrap/int-test.spec.json
@@ -9,7 +9,7 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_0191808e3e4b7916b60b3d46b1a7069e",
+        "id": "batt_01919ae7df38729fafff6944e51bae62",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -22,12 +22,12 @@
           "default_size": "medium",
           "cluster_name": "int-test",
           "server_in_cluster": true,
-          "install_id": "batt_0191808e3e3f709eae6709bce86f4170",
+          "install_id": "batt_01919ae7df307e098aae8402bafacb8e",
           "control_jwk": {
             "crv": "Ed25519",
-            "d": "CMxg-RubQnce8u7qx_1LrwGTtNBZgRXrx9uTj0ofw0Y",
+            "d": "7kM5hGNjhSjS6IjU-SwAmWfnXB2ahh5nd57EGLgwhAU",
             "kty": "OKP",
-            "x": "c6pB0o0sGNQDbddIDiDeynZcLKt-6CXe9wBr058W4uk"
+            "x": "uBGZqbJb7SQV_9lwOKTzc_vOWBmkNsGZm_0kOs0AEbc"
           },
           "upgrade_days_of_week": [
             true,
@@ -52,45 +52,48 @@
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e4b734b8dd2143ae2dc6267",
+        "id": "batt_01919ae7df3879618648e33f5f5a316b",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
           "image": "ghcr.io/cloudnative-pg/cloudnative-pg:1.23.2",
-          "image_override": null
+          "image_tag_override": null,
+          "image_name_override": null
         },
         "group": "data",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e4b766a81f475562b8e06d6",
+        "id": "batt_01919ae7df387df098841306dc039c40",
         "type": "istio",
         "config": {
           "type": "istio",
           "namespace": "battery-istio",
           "pilot_image": "docker.io/istio/pilot:1.22.3-distroless",
           "namespace_override": null,
-          "pilot_image_override": null
+          "pilot_image_name_override": null,
+          "pilot_image_tag_override": null
         },
         "group": "net_sec",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e4b7a538d36e6b55e24b27b",
+        "id": "batt_01919ae7df387466bb1a13cea28c0059",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
           "proxy_image": "docker.io/istio/proxyv2:1.22.3-distroless",
-          "proxy_image_override": null
+          "proxy_image_name_override": null,
+          "proxy_image_tag_override": null
         },
         "group": "net_sec",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e4b7c7980547c60a8348c7b",
+        "id": "batt_01919ae7df387dfbb70696401e753f73",
         "type": "metallb",
         "config": {
           "type": "metallb",
@@ -98,16 +101,19 @@
           "speaker_image": "quay.io/metallb/speaker:v0.14.8",
           "frrouting_image": "quay.io/frrouting/frr:9.1.0",
           "enable_pod_monitor": false,
-          "speaker_image_override": null,
-          "controller_image_override": null,
-          "frrouting_image_override": null
+          "speaker_image_name_override": null,
+          "speaker_image_tag_override": null,
+          "controller_image_name_override": null,
+          "controller_image_tag_override": null,
+          "frrouting_image_name_override": null,
+          "frrouting_image_tag_override": null
         },
         "group": "net_sec",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e4b7040b1a0443641cca554",
+        "id": "batt_01919ae7df3876399b2a0d88884e12af",
         "type": "traditional_services",
         "config": {
           "type": "traditional_services",
@@ -135,7 +141,7 @@
         "env_values": [
           {
             "name": "SECRET_KEY_BASE",
-            "value": "GEZIKKX7RXBASVXOCSOOQPJKFDE5U4VQKCMOP3WYMRZRFIKROVRBFSXHVH7ARQQA",
+            "value": "2BR2EUBNESOHOE6MN53VAFCJVUP45WP5VDDQ57TXOT4KAZGRR6NXNGOLZAJEOMKA",
             "source_name": null,
             "source_type": "value",
             "source_key": null,
@@ -269,7 +275,7 @@
           {
             "version": 2,
             "username": "battery-control-user",
-            "password": "NKA7XSIJPY256XH5GW3BAO2D"
+            "password": "EEJA77LVFBH5MOZIEN3LDMVR"
           },
           {
             "version": 1,
@@ -315,7 +321,7 @@
           {
             "version": 1,
             "username": "home-base",
-            "password": "ERJTWFIGUOZDLYDBL46QHYWG"
+            "password": "Q5E3Q52YLCROOUSHYD7PJNJN"
           }
         ],
         "cpu_requested": 4000,
@@ -341,7 +347,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "3FI65NME2LGT5ULVY4URNO3C6B5QXRUNG2BLDIIYWL6GLUFZNILA===="
+          "battery/hash": "MGHLB4WO3BGN63ZPKQ44YBQFO7OZBRK5XUN2MGVDQZXP7KXV4BUA===="
         },
         "labels": {
           "app": "battery-core",
@@ -351,7 +357,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e4b7916b60b3d46b1a7069e",
+          "battery/owner": "batt_01919ae7df38729fafff6944e51bae62",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -372,20 +378,20 @@
     "/config_map/home_base_seed_data": {
       "apiVersion": "v1",
       "data": {
-        "batt_0191808e3dee71769cb97e44ee965206.team.json": "{\"id\":\"batt_0191808e3dee71769cb97e44ee965206\",\"name\":\"Batteries Included Team\",\"inserted_at\":null,\"updated_at\":null,\"op_email\":\"elliott@batteriesincl.com\"}",
-        "damian.install.json": "{\"id\":\"batt_0191808e3e3f7bdda5050d6e0ab1088f\",\"usage\":\"development\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"yWXzoUlvTdUvz7cjjcGHl-DU_cCkI8mZL1C3ijC6MfE\",\"kty\":\"OKP\",\"x\":\"VGXREBG5MefdBSpVAu4oofh_Vgq_6e3xGNAhw6RJ7gc\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"damian\",\"kube_provider\":\"aws\",\"team_id\":\"batt_0191808e3dee71769cb97e44ee965206\",\"kube_provider_config\":{},\"user_id\":null}",
-        "dev.install.json": "{\"id\":\"batt_0191808e3df17ddfb6af4642c1be833f\",\"usage\":\"internal_dev\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"1QnM9jWw_EJnRuR-XunfjUx8AaQuLI6Qs1D05PhH-tU\",\"kty\":\"OKP\",\"x\":\"imkCxdCjRg4AcmPe2-cvEfaXBSqk9JHq_nrOQcN08AM\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"dev\",\"kube_provider\":\"kind\",\"team_id\":\"batt_0191808e3dee71769cb97e44ee965206\",\"kube_provider_config\":{},\"user_id\":null}",
-        "elliott.install.json": "{\"id\":\"batt_0191808e3e3f7dc294b9c1b77978f4c7\",\"usage\":\"development\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"ApxPU0jKmm6dVoLFpj3Y29Ij-LBqBDtCJtAkozK9_Xk\",\"kty\":\"OKP\",\"x\":\"fEYb84z6KcLZ9hkPl9-NlqQGxYYgOSzLLY1_FyjonJY\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"elliott\",\"kube_provider\":\"aws\",\"team_id\":\"batt_0191808e3dee71769cb97e44ee965206\",\"kube_provider_config\":{},\"user_id\":null}",
-        "int-prod.install.json": "{\"id\":\"batt_0191808e3e3f72108db3cdc66ea159f9\",\"usage\":\"internal_prod\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"H_vq3IC05FqzxkdD_npx0tPUes8fKCrZoVjSMRckpC0\",\"kty\":\"OKP\",\"x\":\"25tJDeP3yEoh0OBeZv6l7Qp_nw-VhT5p5GrC1OF93hg\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"int-prod\",\"kube_provider\":\"kind\",\"team_id\":\"batt_0191808e3dee71769cb97e44ee965206\",\"kube_provider_config\":{},\"user_id\":null}",
-        "int-test.install.json": "{\"id\":\"batt_0191808e3e3f709eae6709bce86f4170\",\"usage\":\"internal_int_test\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"CMxg-RubQnce8u7qx_1LrwGTtNBZgRXrx9uTj0ofw0Y\",\"kty\":\"OKP\",\"x\":\"c6pB0o0sGNQDbddIDiDeynZcLKt-6CXe9wBr058W4uk\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"int-test\",\"kube_provider\":\"kind\",\"team_id\":\"batt_0191808e3dee71769cb97e44ee965206\",\"kube_provider_config\":{},\"user_id\":null}",
-        "jason.install.json": "{\"id\":\"batt_0191808e3e3f7b2e9568d09b80d0fdef\",\"usage\":\"development\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"EA3p37UbqPoZKK91sDHsXnNkdBZXAMiXJxry5GCD6pQ\",\"kty\":\"OKP\",\"x\":\"4LMreGz5zNDzhAV4_Z9TLoNSO5PFasNwyBHCdseCW7Y\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"jason\",\"kube_provider\":\"aws\",\"team_id\":\"batt_0191808e3dee71769cb97e44ee965206\",\"kube_provider_config\":{},\"user_id\":null}",
-        "local.install.json": "{\"id\":\"batt_0191808e3e3f7837a713bb440fcfc8a2\",\"usage\":\"development\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"E9Dbpr4_Cx0c1sk4Hfa8wh-RQdgRZZeJ8qju0L4zGp0\",\"kty\":\"OKP\",\"x\":\"ZrSliZtdwlh_IdU8tk0qOSyfu3-qWLlCKmPPOaY6RBg\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"local\",\"kube_provider\":\"kind\",\"team_id\":\"batt_0191808e3dee71769cb97e44ee965206\",\"kube_provider_config\":{},\"user_id\":null}",
-        "maurer.install.json": "{\"id\":\"batt_0191808e3e3f7e418cb896523114c49c\",\"usage\":\"development\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"qhySDvyjQ0BxDXtCog27873ggsVDWp9ZzyT3YieQcFo\",\"kty\":\"OKP\",\"x\":\"5yF4IY_NZixwex39RkwYcEeyZLe1Wfn8tpLMZ03B3-E\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"maurer\",\"kube_provider\":\"aws\",\"team_id\":\"batt_0191808e3dee71769cb97e44ee965206\",\"kube_provider_config\":{},\"user_id\":null}"
+        "batt_01919ae7dee477ae8b21960049e4c9bf.team.json": "{\"id\":\"batt_01919ae7dee477ae8b21960049e4c9bf\",\"name\":\"Batteries Included Team\",\"inserted_at\":null,\"updated_at\":null,\"op_email\":\"elliott@batteriesincl.com\"}",
+        "damian.install.json": "{\"id\":\"batt_01919ae7df3077a5a860d0d034632cf7\",\"usage\":\"development\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"gr6VF6pAhDyUSZXq2we9-LAbB0KqzTEnAP9EqvvizS8\",\"kty\":\"OKP\",\"x\":\"kreXjG_7gB-gXLrpOx7xTmM6bn_8ybnwAyI6Mp2F5eA\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"damian\",\"kube_provider\":\"aws\",\"team_id\":\"batt_01919ae7dee477ae8b21960049e4c9bf\",\"kube_provider_config\":{},\"user_id\":null}",
+        "dev.install.json": "{\"id\":\"batt_01919ae7dee67a6f90887e0e5bbcc816\",\"usage\":\"internal_dev\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"f3akk6-z6fiMhcOhIQmqfTTFir0jufzkzxMC0oGCjmM\",\"kty\":\"OKP\",\"x\":\"2JBfseC26hjodlINbme0hVIQNK-8WfUeOyPfPJV4C-s\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"dev\",\"kube_provider\":\"kind\",\"team_id\":\"batt_01919ae7dee477ae8b21960049e4c9bf\",\"kube_provider_config\":{},\"user_id\":null}",
+        "elliott.install.json": "{\"id\":\"batt_01919ae7df30700da9ae7105d4bf0e92\",\"usage\":\"development\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"LczlkyefQIhHXgyQdd25V9MQLsSPPrIPDbAdACtJm24\",\"kty\":\"OKP\",\"x\":\"nozFYtlHNSlvoGwerMd_4zgEKjW_MZUhs4OFMf0MDyg\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"elliott\",\"kube_provider\":\"aws\",\"team_id\":\"batt_01919ae7dee477ae8b21960049e4c9bf\",\"kube_provider_config\":{},\"user_id\":null}",
+        "int-prod.install.json": "{\"id\":\"batt_01919ae7df307850a6cc10fc0422df35\",\"usage\":\"internal_prod\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"E3ktl9O4qFPQDu5_X3i47DUgTkgXzZm50QlHBr4yd1s\",\"kty\":\"OKP\",\"x\":\"uP0osYEOOeB3qvec9xqPTXLzR0TXczjRUuawvbosPz4\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"int-prod\",\"kube_provider\":\"kind\",\"team_id\":\"batt_01919ae7dee477ae8b21960049e4c9bf\",\"kube_provider_config\":{},\"user_id\":null}",
+        "int-test.install.json": "{\"id\":\"batt_01919ae7df307e098aae8402bafacb8e\",\"usage\":\"internal_int_test\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"7kM5hGNjhSjS6IjU-SwAmWfnXB2ahh5nd57EGLgwhAU\",\"kty\":\"OKP\",\"x\":\"uBGZqbJb7SQV_9lwOKTzc_vOWBmkNsGZm_0kOs0AEbc\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"int-test\",\"kube_provider\":\"kind\",\"team_id\":\"batt_01919ae7dee477ae8b21960049e4c9bf\",\"kube_provider_config\":{},\"user_id\":null}",
+        "jason.install.json": "{\"id\":\"batt_01919ae7df307e31bf7f84c4b05c3c85\",\"usage\":\"development\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"sNMN7pGcIzNNPb6oo7_8r4gPDa6SAVWFyj8HMQGpz6Y\",\"kty\":\"OKP\",\"x\":\"vvP_l7351oXHCkU-3OqPGKEdnqYYDqxCaW7mfaSkAFQ\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"jason\",\"kube_provider\":\"aws\",\"team_id\":\"batt_01919ae7dee477ae8b21960049e4c9bf\",\"kube_provider_config\":{},\"user_id\":null}",
+        "local.install.json": "{\"id\":\"batt_01919ae7df30744d86050a32a7ae9274\",\"usage\":\"development\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"9Ih_BFfGzQb9XrQjo9Qp6-690u-MNE--EKYgR8A3T1U\",\"kty\":\"OKP\",\"x\":\"IXsClMYGV4ea8Vr587RMntpWJozkh56Q9yGqzDm7W5Q\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"local\",\"kube_provider\":\"kind\",\"team_id\":\"batt_01919ae7dee477ae8b21960049e4c9bf\",\"kube_provider_config\":{},\"user_id\":null}",
+        "maurer.install.json": "{\"id\":\"batt_01919ae7df30729fa562480604afecb1\",\"usage\":\"development\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"WArmkusB1tatV7xQybv1PZlJmYh9BxfarYNkinZuqWQ\",\"kty\":\"OKP\",\"x\":\"OQ_sQ9Jrmdvm8cCUhPchh5u4PNUWQRqzbYt-GLTHja4\"},\"inserted_at\":null,\"updated_at\":null,\"slug\":\"maurer\",\"kube_provider\":\"aws\",\"team_id\":\"batt_01919ae7dee477ae8b21960049e4c9bf\",\"kube_provider_config\":{},\"user_id\":null}"
       },
       "kind": "ConfigMap",
       "metadata": {
         "annotations": {
-          "battery/hash": "WQGOOHYPTKKAC3TRJMXWVH7JGOZPFV5LUAVCZUK734H6DF4KGEOA===="
+          "battery/hash": "2GMXEMIV4T5LJ5YA56HFLJMOJPVUQ6J3QABKPNUBPSGQQPXP4PCA===="
         },
         "labels": {
           "app": "traditional-services",
@@ -395,7 +401,7 @@
           "battery/app": "traditional-services",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e4b7040b1a0443641cca554",
+          "battery/owner": "batt_01919ae7df3876399b2a0d88884e12af",
           "version": "latest"
         },
         "name": "home-base-seed-data",
@@ -407,7 +413,7 @@
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "VFBHEAMTIZCS23GSY56CWULAZU2S3ANQ4VSPG2B4UROK3POKWMMQ===="
+          "battery/hash": "TJWY3QOKCB56XJ3S5UESCVHLSP2IKY3QCVMJOYS66NC5IEFL4KVQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -417,7 +423,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e4b7916b60b3d46b1a7069e",
+          "battery/owner": "batt_01919ae7df38729fafff6944e51bae62",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -441,7 +447,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_0191808e3e4b7916b60b3d46b1a7069e",
+              "battery/owner": "batt_01919ae7df38729fafff6944e51bae62",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -454,7 +460,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "7ULXKBL24D4IL6R4QXBLDFZEN44FNXBNUKLR5TQ24YSRFXOTNFP5UNIL6L4ZIYCN"
+                    "value": "LQY6XU44OCQREANCJZ64PJVFXYRM5JOM2BRGIRAX4H7ZYTBOPFLYYPNKDLGNJAB2"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -502,7 +508,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "NDANGCU3TGPYRSDHPBRHAMAMKHZNLPSLW7D3YCYWAFM72YVI43QQ===="
+          "battery/hash": "ZSHSJYLM7RER4ZVOFQ7AHI7SUYNJVZWOZHOI2BVMVSAHP7AU5U5A===="
         },
         "labels": {
           "app": "battery-core",
@@ -512,7 +518,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e4b7916b60b3d46b1a7069e",
+          "battery/owner": "batt_01919ae7df38729fafff6944e51bae62",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -524,7 +530,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "L6RTZ2LDHM2GUMXMXXPXMIURPWOH6V4I7C323L3YCG7TGY7Q5PRQ===="
+          "battery/hash": "ZMBI6O623ZH6JUBAL6H5RWGQWLNULE5SRGDXC7OGZELPLPF3AZAA===="
         },
         "labels": {
           "app": "traditional-services",
@@ -534,7 +540,7 @@
           "battery/app": "traditional-services",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e4b7040b1a0443641cca554",
+          "battery/owner": "batt_01919ae7df3876399b2a0d88884e12af",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -546,7 +552,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "EUJDLOA3EH45H53V7TFRR57CSXPZVEN7PQF33URTXPLNSVJS75MA===="
+          "battery/hash": "7FT4BW45LTGWJY3SVXO7DTD6WJWKWDWQJJDCCZGOTRQSLOPPWB3A===="
         },
         "labels": {
           "app": "battery-core",
@@ -556,7 +562,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e4b7916b60b3d46b1a7069e",
+          "battery/owner": "batt_01919ae7df38729fafff6944e51bae62",
           "version": "latest"
         },
         "name": "bootstrap",

--- a/bootstrap/jason.install.json
+++ b/bootstrap/jason.install.json
@@ -1,18 +1,18 @@
 {
-  "id": "batt_0191808e3e3f7b2e9568d09b80d0fdef",
+  "id": "batt_01919ae7df307e31bf7f84c4b05c3c85",
   "usage": "development",
   "default_size": "small",
   "control_jwk": {
     "crv": "Ed25519",
-    "d": "EA3p37UbqPoZKK91sDHsXnNkdBZXAMiXJxry5GCD6pQ",
+    "d": "sNMN7pGcIzNNPb6oo7_8r4gPDa6SAVWFyj8HMQGpz6Y",
     "kty": "OKP",
-    "x": "4LMreGz5zNDzhAV4_Z9TLoNSO5PFasNwyBHCdseCW7Y"
+    "x": "vvP_l7351oXHCkU-3OqPGKEdnqYYDqxCaW7mfaSkAFQ"
   },
   "inserted_at": null,
   "updated_at": null,
   "slug": "jason",
   "kube_provider": "aws",
-  "team_id": "batt_0191808e3dee71769cb97e44ee965206",
+  "team_id": "batt_01919ae7dee477ae8b21960049e4c9bf",
   "kube_provider_config": {},
   "user_id": null
 }

--- a/bootstrap/jason.spec.json
+++ b/bootstrap/jason.spec.json
@@ -9,7 +9,7 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_0191808e3e4f76b98930f4a9bfa89d8c",
+        "id": "batt_01919ae7df3c77c2935dd4e7ac7db9e5",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -22,12 +22,12 @@
           "default_size": "small",
           "cluster_name": "jason",
           "server_in_cluster": true,
-          "install_id": "batt_0191808e3e3f7b2e9568d09b80d0fdef",
+          "install_id": "batt_01919ae7df307e31bf7f84c4b05c3c85",
           "control_jwk": {
             "crv": "Ed25519",
-            "d": "EA3p37UbqPoZKK91sDHsXnNkdBZXAMiXJxry5GCD6pQ",
+            "d": "sNMN7pGcIzNNPb6oo7_8r4gPDa6SAVWFyj8HMQGpz6Y",
             "kty": "OKP",
-            "x": "4LMreGz5zNDzhAV4_Z9TLoNSO5PFasNwyBHCdseCW7Y"
+            "x": "vvP_l7351oXHCkU-3OqPGKEdnqYYDqxCaW7mfaSkAFQ"
           },
           "upgrade_days_of_week": [
             true,
@@ -52,7 +52,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e4f70ac93855cad11bef67b",
+        "id": "batt_01919ae7df3c7351b54d83d0fa8e87c6",
         "type": "karpenter",
         "config": {
           "type": "karpenter",
@@ -60,14 +60,15 @@
           "service_role_arn": null,
           "queue_name": null,
           "node_role_name": null,
-          "image_override": null
+          "image_tag_override": null,
+          "image_name_override": null
         },
         "group": "magic",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e4f76d09b3c0f0ee7f7dcba",
+        "id": "batt_01919ae7df3c746e88c40f1ac462d121",
         "type": "cert_manager",
         "config": {
           "type": "cert_manager",
@@ -77,18 +78,23 @@
           "controller_image": "quay.io/jetstack/cert-manager-controller:v1.15.1",
           "ctl_image": "quay.io/jetstack/cert-manager-ctl:v1.15.1",
           "webhook_image": "quay.io/jetstack/cert-manager-webhook:v1.15.1",
-          "controller_image_override": null,
-          "webhook_image_override": null,
-          "acmesolver_image_override": null,
-          "cainjector_image_override": null,
-          "ctl_image_override": null
+          "acmesolver_image_name_override": null,
+          "acmesolver_image_tag_override": null,
+          "cainjector_image_name_override": null,
+          "cainjector_image_tag_override": null,
+          "controller_image_name_override": null,
+          "controller_image_tag_override": null,
+          "ctl_image_name_override": null,
+          "ctl_image_tag_override": null,
+          "webhook_image_name_override": null,
+          "webhook_image_tag_override": null
         },
         "group": "net_sec",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e4f78cabda6e4c0bfe95581",
+        "id": "batt_01919ae7df3c7a2695f0c6466a6964e0",
         "type": "battery_ca",
         "config": {
           "type": "battery_ca"
@@ -98,7 +104,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e4f7ef1a176a2b354c4eb49",
+        "id": "batt_01919ae7df3c7fbfb1833fb4e1d84bee",
         "type": "aws_load_balancer_controller",
         "config": {
           "type": "aws_load_balancer_controller",
@@ -106,52 +112,56 @@
           "service_role_arn": null,
           "subnets": null,
           "eip_allocations": null,
-          "image_override": null
+          "image_tag_override": null,
+          "image_name_override": null
         },
         "group": "magic",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e4f73089b39c9c2f72d2c1e",
+        "id": "batt_01919ae7df3c746e9c8dbc0568fb5e08",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
           "image": "ghcr.io/cloudnative-pg/cloudnative-pg:1.23.2",
-          "image_override": null
+          "image_tag_override": null,
+          "image_name_override": null
         },
         "group": "data",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e4f72b7abdbb82bffb072b4",
+        "id": "batt_01919ae7df3c7859a004ad5c6e745305",
         "type": "istio",
         "config": {
           "type": "istio",
           "namespace": "battery-istio",
           "pilot_image": "docker.io/istio/pilot:1.22.3-distroless",
           "namespace_override": null,
-          "pilot_image_override": null
+          "pilot_image_name_override": null,
+          "pilot_image_tag_override": null
         },
         "group": "net_sec",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e4f723fa1156429e3a84cdc",
+        "id": "batt_01919ae7df3c7167a98861ecc97af56c",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
           "proxy_image": "docker.io/istio/proxyv2:1.22.3-distroless",
-          "proxy_image_override": null
+          "proxy_image_name_override": null,
+          "proxy_image_tag_override": null
         },
         "group": "net_sec",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e4f779abe2c0ac210757414",
+        "id": "batt_01919ae7df3c766085b94bb73ac1e169",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -195,7 +205,7 @@
           {
             "version": 1,
             "username": "battery-control-user",
-            "password": "EWAS5NEDAA7IL5MBI23E2WD3"
+            "password": "JQU46R2N6E3NG7CKHKJKI2IH"
           }
         ],
         "cpu_requested": 500,
@@ -221,7 +231,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "3LNBXFGACSQMJKZCIFZOWZOUG2DO54NIYG5KXMWCMKKKTYYS3Q2Q===="
+          "battery/hash": "EMOLYBD4UOCK3BSYPMHOUF3ECFFVREXILEMB76RNOPLG3LZULPTA===="
         },
         "labels": {
           "app": "battery-core",
@@ -231,7 +241,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e4f76b98930f4a9bfa89d8c",
+          "battery/owner": "batt_01919ae7df3c77c2935dd4e7ac7db9e5",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -254,7 +264,7 @@
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "CFSQ3EFS33EZIMWE3V67YGSWYIXJ72BVN2L7XHWJDRQ3KCSM4R4A===="
+          "battery/hash": "JNY35SGMNQL7EBIPGS7YCE5774FAKT3DK6IC7CO6XW5WZZZ2R4CQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -264,7 +274,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e4f76b98930f4a9bfa89d8c",
+          "battery/owner": "batt_01919ae7df3c77c2935dd4e7ac7db9e5",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -288,7 +298,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_0191808e3e4f76b98930f4a9bfa89d8c",
+              "battery/owner": "batt_01919ae7df3c77c2935dd4e7ac7db9e5",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -301,7 +311,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "KYMSA2WO5T626LZZNI2VUYFP7RNEAAR52KPH3LWMBTT5Y4GNYZVCFWLG6L47ZNTO"
+                    "value": "2T7R3AZ5PLJ7PEIGD42MLBKN5MPPAYCHDPJ7M2FLKNPU4XHEMDY7PCMK2SVNXKF4"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -349,7 +359,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "DTJ5GT6JTO6NHBD3JVXMTWKDQJZBCVGDDXH5LS4K7FHCWJTA3ZOA===="
+          "battery/hash": "53XZYAD2RRORKUK4KDHHZMPHI74FA4PCHEJWU7AM4I3IX4B7TBZA===="
         },
         "labels": {
           "app": "battery-core",
@@ -359,7 +369,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e4f76b98930f4a9bfa89d8c",
+          "battery/owner": "batt_01919ae7df3c77c2935dd4e7ac7db9e5",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -371,7 +381,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "7MTZJCATCNCGZMC4IGP2BWCLKQG3RZLMEGOFTB7ABJAIP227ZG5A===="
+          "battery/hash": "CL7FYXPNP7SPCEYP3M7AC5XRMSIFFNVUP3MIC763YSWO7JFYON5A===="
         },
         "labels": {
           "app": "battery-core",
@@ -381,7 +391,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e4f76b98930f4a9bfa89d8c",
+          "battery/owner": "batt_01919ae7df3c77c2935dd4e7ac7db9e5",
           "version": "latest"
         },
         "name": "bootstrap",
@@ -394,7 +404,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "BAYJHNZXR4Y4646MVOCSVSNH4E4RPLBANEQJZHIKFDCALPDI7AMA====",
+          "battery/hash": "BH5VW6XWMLH4XAOM3ZKYVVDU2FKL5W54E3BZGFKOICONZJ4C55BQ====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -405,7 +415,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e4f76b98930f4a9bfa89d8c",
+          "battery/owner": "batt_01919ae7df3c77c2935dd4e7ac7db9e5",
           "version": "latest"
         },
         "name": "gp2"
@@ -420,7 +430,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "EZISVM2KW65WPR5LIQJQPXKAVFSM3YOGFD7IN7DV7JX3K2N7BFZQ====",
+          "battery/hash": "BXST5B6QUVA777NMVPGVLQAVSCFDTGJESPHMK4YSPKQN2OF4M6AA====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -431,7 +441,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e4f76b98930f4a9bfa89d8c",
+          "battery/owner": "batt_01919ae7df3c77c2935dd4e7ac7db9e5",
           "version": "latest"
         },
         "name": "gp2-90032408"
@@ -451,7 +461,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "C4SB6P42EEOAYALBF2HWPAT4SWZNORMWPLP2KSLGYLSEOICVUYOA====",
+          "battery/hash": "GZXPZT553QY7OEYUYY2KZBJ642WXRE56RIDCIWTX2QY2KICTBXTQ====",
           "storageclass.kubernetes.io/is-default-class": "true"
         },
         "labels": {
@@ -462,7 +472,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e4f76b98930f4a9bfa89d8c",
+          "battery/owner": "batt_01919ae7df3c77c2935dd4e7ac7db9e5",
           "version": "latest"
         },
         "name": "gp3-105457460"

--- a/bootstrap/local.install.json
+++ b/bootstrap/local.install.json
@@ -1,18 +1,18 @@
 {
-  "id": "batt_0191808e3e3f7837a713bb440fcfc8a2",
+  "id": "batt_01919ae7df30744d86050a32a7ae9274",
   "usage": "development",
   "default_size": "tiny",
   "control_jwk": {
     "crv": "Ed25519",
-    "d": "E9Dbpr4_Cx0c1sk4Hfa8wh-RQdgRZZeJ8qju0L4zGp0",
+    "d": "9Ih_BFfGzQb9XrQjo9Qp6-690u-MNE--EKYgR8A3T1U",
     "kty": "OKP",
-    "x": "ZrSliZtdwlh_IdU8tk0qOSyfu3-qWLlCKmPPOaY6RBg"
+    "x": "IXsClMYGV4ea8Vr587RMntpWJozkh56Q9yGqzDm7W5Q"
   },
   "inserted_at": null,
   "updated_at": null,
   "slug": "local",
   "kube_provider": "kind",
-  "team_id": "batt_0191808e3dee71769cb97e44ee965206",
+  "team_id": "batt_01919ae7dee477ae8b21960049e4c9bf",
   "kube_provider_config": {},
   "user_id": null
 }

--- a/bootstrap/local.spec.json
+++ b/bootstrap/local.spec.json
@@ -9,33 +9,35 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_0191808e3e4d7a47978fbb4c5182a401",
+        "id": "batt_01919ae7df3a7c65a96a9e82645f9ff0",
         "type": "istio",
         "config": {
           "type": "istio",
           "namespace": "battery-istio",
           "pilot_image": "docker.io/istio/pilot:1.22.3-distroless",
           "namespace_override": null,
-          "pilot_image_override": null
+          "pilot_image_name_override": null,
+          "pilot_image_tag_override": null
         },
         "group": "net_sec",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e4d7c929491c36c12479a07",
+        "id": "batt_01919ae7df3a7f9881e732a91fc86e54",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
           "proxy_image": "docker.io/istio/proxyv2:1.22.3-distroless",
-          "proxy_image_override": null
+          "proxy_image_name_override": null,
+          "proxy_image_tag_override": null
         },
         "group": "net_sec",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e4d792aa90e713e68cbbd0d",
+        "id": "batt_01919ae7df3a7f14bdfea4980cd72007",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -48,12 +50,12 @@
           "default_size": "tiny",
           "cluster_name": "local",
           "server_in_cluster": true,
-          "install_id": "batt_0191808e3e3f7837a713bb440fcfc8a2",
+          "install_id": "batt_01919ae7df30744d86050a32a7ae9274",
           "control_jwk": {
             "crv": "Ed25519",
-            "d": "E9Dbpr4_Cx0c1sk4Hfa8wh-RQdgRZZeJ8qju0L4zGp0",
+            "d": "9Ih_BFfGzQb9XrQjo9Qp6-690u-MNE--EKYgR8A3T1U",
             "kty": "OKP",
-            "x": "ZrSliZtdwlh_IdU8tk0qOSyfu3-qWLlCKmPPOaY6RBg"
+            "x": "IXsClMYGV4ea8Vr587RMntpWJozkh56Q9yGqzDm7W5Q"
           },
           "upgrade_days_of_week": [
             true,
@@ -78,7 +80,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e4d71e49de9001e63676a8a",
+        "id": "batt_01919ae7df3a7d1b9c72b3f6677c09e3",
         "type": "metallb",
         "config": {
           "type": "metallb",
@@ -86,28 +88,32 @@
           "speaker_image": "quay.io/metallb/speaker:v0.14.8",
           "frrouting_image": "quay.io/frrouting/frr:9.1.0",
           "enable_pod_monitor": false,
-          "speaker_image_override": null,
-          "controller_image_override": null,
-          "frrouting_image_override": null
+          "speaker_image_name_override": null,
+          "speaker_image_tag_override": null,
+          "controller_image_name_override": null,
+          "controller_image_tag_override": null,
+          "frrouting_image_name_override": null,
+          "frrouting_image_tag_override": null
         },
         "group": "net_sec",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e4d7695b63127030c663b26",
+        "id": "batt_01919ae7df3a7fbf91060ab70d8eb867",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
           "image": "ghcr.io/cloudnative-pg/cloudnative-pg:1.23.2",
-          "image_override": null
+          "image_tag_override": null,
+          "image_name_override": null
         },
         "group": "data",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e4d73c8a126518a0b2efe80",
+        "id": "batt_01919ae7df3a7487b2cbc0a832550729",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -151,7 +157,7 @@
           {
             "version": 1,
             "username": "battery-control-user",
-            "password": "S54S6DBAUQSK53L3TOAXVLKL"
+            "password": "42AO4TZXXFJ5G27RA36HOHGK"
           }
         ],
         "cpu_requested": 500,
@@ -177,7 +183,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "Z4XOGLUNFZJXODRI5HKTIL6Z45TMHUUCRT4323FTQSYHSIKAKR5A===="
+          "battery/hash": "2LUSAQA6C6KOSB3HJ5SLIWTYYDALBNLGGOJBFTWBQDPJTV7NG3VQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -187,7 +193,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e4d792aa90e713e68cbbd0d",
+          "battery/owner": "batt_01919ae7df3a7f14bdfea4980cd72007",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -210,7 +216,7 @@
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "7IA4GW6ZDK3DOB35TFEMDLMPFQWV72EW3SCRTPN47ZHUAUJQ7TKQ===="
+          "battery/hash": "XQKKT7VW5B2NTL3YD423QT2D3PH4YSJMNDXVFJ5WKVUP2YKQAQRQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -220,7 +226,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e4d792aa90e713e68cbbd0d",
+          "battery/owner": "batt_01919ae7df3a7f14bdfea4980cd72007",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -244,7 +250,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_0191808e3e4d792aa90e713e68cbbd0d",
+              "battery/owner": "batt_01919ae7df3a7f14bdfea4980cd72007",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -257,7 +263,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "W36O2FZR3765RFJBNIY6EOVIJOND24NY33G6HLI64QNSJXZG5TBEPP4QCG5Z6VHW"
+                    "value": "CJB7KYYMPPY7PIXMATL7ACSSVET76J6MCYVGMXW6KQYPJCE2P447NCHM6IJIS62Z"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -305,7 +311,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "7K53U34C33HWRQEK5DGNSEGKORMBDR5NFBXD5EEOQ7J3J27EWJDA===="
+          "battery/hash": "52WGZ3IFCZE2XA2JUICKVUHDWZSPSBXAY2PFIDHE26SKP7SEJ4FA===="
         },
         "labels": {
           "app": "battery-core",
@@ -315,7 +321,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e4d792aa90e713e68cbbd0d",
+          "battery/owner": "batt_01919ae7df3a7f14bdfea4980cd72007",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -327,7 +333,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "UEOJ334ERLC7GOYQ3B3YJCBI3WLTVPYVB4PWSWTNFRMQFCUDGAPQ===="
+          "battery/hash": "C7UNBK2U6QHTNNF22RHPKQ7TJL3TU3WEXWUR5ASGCXTBS75PKDCQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -337,7 +343,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e4d792aa90e713e68cbbd0d",
+          "battery/owner": "batt_01919ae7df3a7f14bdfea4980cd72007",
           "version": "latest"
         },
         "name": "bootstrap",

--- a/bootstrap/maurer.install.json
+++ b/bootstrap/maurer.install.json
@@ -1,18 +1,18 @@
 {
-  "id": "batt_0191808e3e3f7e418cb896523114c49c",
+  "id": "batt_01919ae7df30729fa562480604afecb1",
   "usage": "development",
   "default_size": "small",
   "control_jwk": {
     "crv": "Ed25519",
-    "d": "qhySDvyjQ0BxDXtCog27873ggsVDWp9ZzyT3YieQcFo",
+    "d": "WArmkusB1tatV7xQybv1PZlJmYh9BxfarYNkinZuqWQ",
     "kty": "OKP",
-    "x": "5yF4IY_NZixwex39RkwYcEeyZLe1Wfn8tpLMZ03B3-E"
+    "x": "OQ_sQ9Jrmdvm8cCUhPchh5u4PNUWQRqzbYt-GLTHja4"
   },
   "inserted_at": null,
   "updated_at": null,
   "slug": "maurer",
   "kube_provider": "aws",
-  "team_id": "batt_0191808e3dee71769cb97e44ee965206",
+  "team_id": "batt_01919ae7dee477ae8b21960049e4c9bf",
   "kube_provider_config": {},
   "user_id": null
 }

--- a/bootstrap/maurer.spec.json
+++ b/bootstrap/maurer.spec.json
@@ -9,7 +9,7 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_0191808e3e507822ae682631d8700a63",
+        "id": "batt_01919ae7df3d7665a9ab6110c0d8882c",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -22,12 +22,12 @@
           "default_size": "small",
           "cluster_name": "maurer",
           "server_in_cluster": true,
-          "install_id": "batt_0191808e3e3f7e418cb896523114c49c",
+          "install_id": "batt_01919ae7df30729fa562480604afecb1",
           "control_jwk": {
             "crv": "Ed25519",
-            "d": "qhySDvyjQ0BxDXtCog27873ggsVDWp9ZzyT3YieQcFo",
+            "d": "WArmkusB1tatV7xQybv1PZlJmYh9BxfarYNkinZuqWQ",
             "kty": "OKP",
-            "x": "5yF4IY_NZixwex39RkwYcEeyZLe1Wfn8tpLMZ03B3-E"
+            "x": "OQ_sQ9Jrmdvm8cCUhPchh5u4PNUWQRqzbYt-GLTHja4"
           },
           "upgrade_days_of_week": [
             true,
@@ -52,7 +52,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e50708f8ca488f6a74652be",
+        "id": "batt_01919ae7df3d7875b5cadce6d02b86f7",
         "type": "karpenter",
         "config": {
           "type": "karpenter",
@@ -60,14 +60,15 @@
           "service_role_arn": null,
           "queue_name": null,
           "node_role_name": null,
-          "image_override": null
+          "image_tag_override": null,
+          "image_name_override": null
         },
         "group": "magic",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e507df583cb11c887ee2ea6",
+        "id": "batt_01919ae7df3d7e35914ebdc394e80951",
         "type": "cert_manager",
         "config": {
           "type": "cert_manager",
@@ -77,18 +78,23 @@
           "controller_image": "quay.io/jetstack/cert-manager-controller:v1.15.1",
           "ctl_image": "quay.io/jetstack/cert-manager-ctl:v1.15.1",
           "webhook_image": "quay.io/jetstack/cert-manager-webhook:v1.15.1",
-          "controller_image_override": null,
-          "webhook_image_override": null,
-          "acmesolver_image_override": null,
-          "cainjector_image_override": null,
-          "ctl_image_override": null
+          "acmesolver_image_name_override": null,
+          "acmesolver_image_tag_override": null,
+          "cainjector_image_name_override": null,
+          "cainjector_image_tag_override": null,
+          "controller_image_name_override": null,
+          "controller_image_tag_override": null,
+          "ctl_image_name_override": null,
+          "ctl_image_tag_override": null,
+          "webhook_image_name_override": null,
+          "webhook_image_tag_override": null
         },
         "group": "net_sec",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e507c329c2fce8fa67990e1",
+        "id": "batt_01919ae7df3d79d59d275f66362faf3f",
         "type": "battery_ca",
         "config": {
           "type": "battery_ca"
@@ -98,7 +104,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e507ad191d783e527365dce",
+        "id": "batt_01919ae7df3d72708b35f5935da74807",
         "type": "aws_load_balancer_controller",
         "config": {
           "type": "aws_load_balancer_controller",
@@ -106,52 +112,56 @@
           "service_role_arn": null,
           "subnets": null,
           "eip_allocations": null,
-          "image_override": null
+          "image_tag_override": null,
+          "image_name_override": null
         },
         "group": "magic",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e5078349d376f321155c47c",
+        "id": "batt_01919ae7df3d71a1a9faae1fa4c5ee05",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
           "image": "ghcr.io/cloudnative-pg/cloudnative-pg:1.23.2",
-          "image_override": null
+          "image_tag_override": null,
+          "image_name_override": null
         },
         "group": "data",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e507aaba62f3059413ac708",
+        "id": "batt_01919ae7df3d7713847cf970d82d2986",
         "type": "istio",
         "config": {
           "type": "istio",
           "namespace": "battery-istio",
           "pilot_image": "docker.io/istio/pilot:1.22.3-distroless",
           "namespace_override": null,
-          "pilot_image_override": null
+          "pilot_image_name_override": null,
+          "pilot_image_tag_override": null
         },
         "group": "net_sec",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e5073308e5eb3558c93cab8",
+        "id": "batt_01919ae7df3d773fa68fd4e7c1471499",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
           "proxy_image": "docker.io/istio/proxyv2:1.22.3-distroless",
-          "proxy_image_override": null
+          "proxy_image_name_override": null,
+          "proxy_image_tag_override": null
         },
         "group": "net_sec",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0191808e3e507dd695e8a52e0436e0e3",
+        "id": "batt_01919ae7df3d7eb2ba7694c197ab17ce",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -195,7 +205,7 @@
           {
             "version": 1,
             "username": "battery-control-user",
-            "password": "DNU24TTY3VXZAC76OMOSM56R"
+            "password": "WYAVRYQPRY3J73DPFG7VEGML"
           }
         ],
         "cpu_requested": 500,
@@ -221,7 +231,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "ZHYOP5ANMPUUQEBDJYTS3FKXY2RNNZCPVMQ263NCWIAB3KZNBTFA===="
+          "battery/hash": "ZVGFCILPJSLPBJNSZ4QIIS5ZKCKFXUMVZ52OFFG7FIRWLURAI7UQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -231,7 +241,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e507822ae682631d8700a63",
+          "battery/owner": "batt_01919ae7df3d7665a9ab6110c0d8882c",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -254,7 +264,7 @@
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "5FRPIO3MAZDMRMMVWNFHB2GPMBMUMLPLKYI7SBJRGYGYOQZWTBNQ===="
+          "battery/hash": "ZBVQPV2XUWHIY7L73SXEZCXE2TJ2GCVQZKLT5PGBZRQSYWZ67PEQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -264,7 +274,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e507822ae682631d8700a63",
+          "battery/owner": "batt_01919ae7df3d7665a9ab6110c0d8882c",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -288,7 +298,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_0191808e3e507822ae682631d8700a63",
+              "battery/owner": "batt_01919ae7df3d7665a9ab6110c0d8882c",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -301,7 +311,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "5IBFXLHKYS4N4XX25YLZBMQFS5AYP2NM2JPSNMTQR7QNZNZRZ3CDGFYWO5OOIN2O"
+                    "value": "PIH7AKWIN6XPSPGZEUQFSKUSVC3LWRCAN3TJ3HFKOPZNPWDR4775NDTV5XDZVNNG"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -349,7 +359,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "56SCC2OD4XD3XRSICB4OKQH2GF5LLB2OUEQLVKTSONB45IN2SL6Q===="
+          "battery/hash": "BP7CFJYIEWDLER4LPK2QTQZSODLILWWNLGLYKFUKFPAUU5PLTJWQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -359,7 +369,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e507822ae682631d8700a63",
+          "battery/owner": "batt_01919ae7df3d7665a9ab6110c0d8882c",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -371,7 +381,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "UIHL6NVHYSQH5EIUA5ETOBHYVUA2DORCYVAGISDEUS7BOJHN3SAA===="
+          "battery/hash": "2RZJR4ZERM7ZC7ZK3FQQQBW2JPGYNYLNB3ZW7LKZ5SSLPWVNLGAQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -381,7 +391,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e507822ae682631d8700a63",
+          "battery/owner": "batt_01919ae7df3d7665a9ab6110c0d8882c",
           "version": "latest"
         },
         "name": "bootstrap",
@@ -394,7 +404,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "AFINJSYX3SRLE27PWNHUAGXBJAMQRGY7WFNLVGPO2UTY75FE2YPQ====",
+          "battery/hash": "SCAHXXTO3INUUJVYPPFJRTQGTDGO4WFQTXDES45GM3ZBYZSUILYA====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -405,7 +415,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e507822ae682631d8700a63",
+          "battery/owner": "batt_01919ae7df3d7665a9ab6110c0d8882c",
           "version": "latest"
         },
         "name": "gp2"
@@ -420,7 +430,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "2THVFEJOHXIFP2AGD6AZASJPAKQVEVRNIOEXSB5MSAP5W5PXW7AQ====",
+          "battery/hash": "5JJFOCFDAM4PGO2S5TAIMS55EHOO2HSZVB2U7V5BADHPASD3JZWA====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -431,7 +441,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e507822ae682631d8700a63",
+          "battery/owner": "batt_01919ae7df3d7665a9ab6110c0d8882c",
           "version": "latest"
         },
         "name": "gp2-90032408"
@@ -451,7 +461,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "35OC7TQ2NNEG4K6H3UH4L4GCJRMVZ6SFHT4SKOQ64TT4HBGCXPMQ====",
+          "battery/hash": "D4GFCCOEMAJDOEBYCDMMLYFLIMOAC4Z6ZWUDCWXEUOAIWCFZ3A7Q====",
           "storageclass.kubernetes.io/is-default-class": "true"
         },
         "labels": {
@@ -462,7 +472,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0191808e3e507822ae682631d8700a63",
+          "battery/owner": "batt_01919ae7df3d7665a9ab6110c0d8882c",
           "version": "latest"
         },
         "name": "gp3-105457460"

--- a/bootstrap/team.json
+++ b/bootstrap/team.json
@@ -1,5 +1,5 @@
 {
-  "id": "batt_0191808e3dee71769cb97e44ee965206",
+  "id": "batt_01919ae7dee477ae8b21960049e4c9bf",
   "name": "Batteries Included Team",
   "inserted_at": null,
   "updated_at": null,

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/aws_loadbalancer_controller_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/aws_loadbalancer_controller_config.ex
@@ -3,10 +3,8 @@ defmodule CommonCore.Batteries.AwsLoadBalancerControllerConfig do
 
   use CommonCore, :embedded_schema
 
-  alias CommonCore.Defaults
-
   batt_polymorphic_schema type: :aws_load_balancer_controller do
-    defaultable_field :image, :string, default: Defaults.Images.aws_load_balancer_controller_image()
+    defaultable_image_field :image, image_id: :aws_load_balancer_controller
     field :service_role_arn, :string
     field :subnets, {:array, :string}
     field :eip_allocations, {:array, :string}

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/cert_manager_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/cert_manager_config.ex
@@ -3,14 +3,12 @@ defmodule CommonCore.Batteries.CertManagerConfig do
 
   use CommonCore, :embedded_schema
 
-  alias CommonCore.Defaults
-
   batt_polymorphic_schema type: :cert_manager do
-    defaultable_field :acmesolver_image, :string, default: Defaults.Images.cert_manager_acmesolver_image()
-    defaultable_field :cainjector_image, :string, default: Defaults.Images.cert_manager_cainjector_image()
-    defaultable_field :controller_image, :string, default: Defaults.Images.cert_manager_controller_image()
-    defaultable_field :ctl_image, :string, default: Defaults.Images.cert_manager_ctl_image()
-    defaultable_field :webhook_image, :string, default: Defaults.Images.cert_manager_webhook_image()
+    defaultable_image_field :acmesolver_image, image_id: :cert_manager_acmesolver
+    defaultable_image_field :cainjector_image, image_id: :cert_manager_cainjector
+    defaultable_image_field :controller_image, image_id: :cert_manager_controller
+    defaultable_image_field :ctl_image, image_id: :cert_manager_ctl
+    defaultable_image_field :webhook_image, image_id: :cert_manager_webhook
 
     field :email, :string
   end

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/cloudnative_pg_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/cloudnative_pg_config.ex
@@ -3,9 +3,7 @@ defmodule CommonCore.Batteries.CloudnativePGConfig do
 
   use CommonCore, :embedded_schema
 
-  alias CommonCore.Defaults
-
   batt_polymorphic_schema type: :cloudnative_pg do
-    defaultable_field :image, :string, default: Defaults.Images.cloudnative_pg_image()
+    defaultable_image_field :image, image_id: :cloudnative_pg
   end
 end

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/ferretdb_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/ferretdb_config.ex
@@ -3,9 +3,7 @@ defmodule CommonCore.Batteries.FerretDBConfig do
 
   use CommonCore, :embedded_schema
 
-  alias CommonCore.Defaults
-
   batt_polymorphic_schema type: :ferretdb do
-    defaultable_field :ferretdb_image, :string, default: Defaults.Images.ferretdb_image()
+    defaultable_image_field :ferretdb_image, image_id: :ferretdb
   end
 end

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/forgejo_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/forgejo_config.ex
@@ -3,12 +3,10 @@ defmodule CommonCore.Batteries.ForgejoConfig do
 
   use CommonCore, {:embedded_schema, no_encode: [:admin_password]}
 
-  alias CommonCore.Defaults
-
   @required_fields ~w()a
 
   batt_polymorphic_schema type: :forgejo do
-    defaultable_field :image, :string, default: Defaults.Images.forgejo_image()
+    defaultable_image_field :image, image_id: :forgejo
     defaultable_field :admin_username, :string, default: "battery-forgejo-admin"
     secret_field :admin_password
   end

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/grafana_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/grafana_config.ex
@@ -3,13 +3,11 @@ defmodule CommonCore.Batteries.GrafanaConfig do
 
   use CommonCore, {:embedded_schema, no_encode: [:admin_password]}
 
-  alias CommonCore.Defaults
-
   @required_fields ~w()a
 
   batt_polymorphic_schema type: :grafana do
-    defaultable_field :image, :string, default: Defaults.Images.grafana_image()
-    defaultable_field :sidecar_image, :string, default: Defaults.Images.kiwigrid_sidecar_image()
+    defaultable_image_field :image, image_id: :grafana
+    defaultable_image_field :sidecar_image, image_id: :kiwigrid_sidecar
 
     secret_field :admin_password
   end

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/istio_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/istio_config.ex
@@ -7,6 +7,6 @@ defmodule CommonCore.Batteries.IstioConfig do
 
   batt_polymorphic_schema type: :istio do
     defaultable_field :namespace, :string, default: Defaults.Namespaces.istio()
-    defaultable_field :pilot_image, :string, default: Defaults.Images.istio_pilot_image()
+    defaultable_image_field :pilot_image, image_id: :istio_pilot
   end
 end

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/istio_gateway_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/istio_gateway_config.ex
@@ -3,9 +3,7 @@ defmodule CommonCore.Batteries.IstioGatewayConfig do
 
   use CommonCore, :embedded_schema
 
-  alias CommonCore.Defaults
-
   batt_polymorphic_schema type: :istio_gateway do
-    defaultable_field :proxy_image, :string, default: Defaults.Images.istio_proxy_image()
+    defaultable_image_field :proxy_image, image_id: :istio_proxy
   end
 end

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/karpenter_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/karpenter_config.ex
@@ -3,10 +3,8 @@ defmodule CommonCore.Batteries.KarpenterConfig do
 
   use CommonCore, :embedded_schema
 
-  alias CommonCore.Defaults
-
   batt_polymorphic_schema type: :karpenter do
-    defaultable_field :image, :string, default: Defaults.Images.karpenter_image()
+    defaultable_image_field :image, image_id: :karpenter
     field :queue_name, :string
     field :service_role_arn, :string
     field :node_role_name, :string

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/keycloak_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/keycloak_config.ex
@@ -3,12 +3,11 @@ defmodule CommonCore.Batteries.KeycloakConfig do
 
   use CommonCore, {:embedded_schema, no_encode: [:admin_password]}
 
-  alias CommonCore.Defaults
-
   @required_fields ~w()a
 
   batt_polymorphic_schema type: :keycloak do
-    defaultable_field :image, :string, default: Defaults.Images.keycloak_image()
+    defaultable_image_field :image, image_id: :keycloak
+
     defaultable_field :admin_username, :string, default: "batteryadmin"
     defaultable_field :log_level, :string, default: "info"
     defaultable_field :replicas, :integer, default: 1

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/kiali_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/kiali_config.ex
@@ -3,14 +3,20 @@ defmodule CommonCore.Batteries.KialiConfig do
 
   use CommonCore, {:embedded_schema, no_encode: [:login_signing_key]}
 
-  alias CommonCore.Defaults
+  alias CommonCore.Batteries.KialiConfig
 
   @required_fields ~w()a
 
   batt_polymorphic_schema type: :kiali do
-    defaultable_field :image, :string, default: Defaults.Images.kiali_image()
-    defaultable_field :version, :string, default: Defaults.Images.kiali_image_version()
+    defaultable_image_field :image, image_id: :kiali
 
     secret_field :login_signing_key, length: 32
+  end
+
+  @spec image_version(t()) :: String.t()
+  def image_version(%KialiConfig{image: image} = _config) do
+    image
+    |> String.split(":")
+    |> List.last()
   end
 end

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/knative_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/knative_config.ex
@@ -8,13 +8,13 @@ defmodule CommonCore.Batteries.KnativeConfig do
   batt_polymorphic_schema type: :knative do
     field :namespace, :string, default: Defaults.Namespaces.knative()
 
-    defaultable_field :queue_image, :string, default: Defaults.Images.knative_serving_queue_image()
-    defaultable_field :activator_image, :string, default: Defaults.Images.knative_serving_activator_image()
-    defaultable_field :autoscaler_image, :string, default: Defaults.Images.knative_serving_autoscaler_image()
-    defaultable_field :controller_image, :string, default: Defaults.Images.knative_serving_controller_image()
-    defaultable_field :webhook_image, :string, default: Defaults.Images.knative_serving_webhook_image()
+    defaultable_image_field :queue_image, image_id: :knative_serving_queue
+    defaultable_image_field :activator_image, image_id: :knative_serving_activator
+    defaultable_image_field :autoscaler_image, image_id: :knative_serving_autoscaler
+    defaultable_image_field :controller_image, image_id: :knative_serving_controller
+    defaultable_image_field :webhook_image, image_id: :knative_serving_webhook
 
-    defaultable_field :istio_controller_image, :string, default: Defaults.Images.knative_istio_controller_image()
-    defaultable_field :istio_webhook_image, :string, default: Defaults.Images.knative_istio_webhook_image()
+    defaultable_image_field :istio_controller_image, image_id: :knative_istio_controller
+    defaultable_image_field :istio_webhook_image, image_id: :knative_istio_webhook
   end
 end

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/kube_monitoring_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/kube_monitoring_config.ex
@@ -3,12 +3,10 @@ defmodule CommonCore.Batteries.KubeMonitoringConfig do
 
   use CommonCore, :embedded_schema
 
-  alias CommonCore.Defaults
-
   batt_polymorphic_schema type: :kube_monitoring do
-    defaultable_field :kube_state_metrics_image, :string, default: Defaults.Images.kube_state_metrics_image()
-    defaultable_field :node_exporter_image, :string, default: Defaults.Images.node_exporter_image()
-    defaultable_field :metrics_server_image, :string, default: Defaults.Images.metrics_server_image()
-    defaultable_field :addon_resizer_image, :string, default: Defaults.Images.addon_resizer_image()
+    defaultable_image_field :kube_state_metrics_image, image_id: :kube_state_metrics
+    defaultable_image_field :node_exporter_image, image_id: :node_exporter
+    defaultable_image_field :metrics_server_image, image_id: :metrics_server
+    defaultable_image_field :addon_resizer_image, image_id: :addon_resizer
   end
 end

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/loki_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/loki_config.ex
@@ -3,12 +3,10 @@ defmodule CommonCore.Batteries.LokiConfig do
 
   use CommonCore, :embedded_schema
 
-  alias CommonCore.Defaults
-
   @required_fields ~w()a
 
   batt_polymorphic_schema type: :loki do
-    defaultable_field :image, :string, default: Defaults.Images.loki_image()
+    defaultable_image_field :image, image_id: :loki
     defaultable_field :replication_factor, :integer, default: 1
     defaultable_field :replicas, :integer, default: 1
   end

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/metallb_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/metallb_config.ex
@@ -3,12 +3,10 @@ defmodule CommonCore.Batteries.MetalLBConfig do
 
   use CommonCore, :embedded_schema
 
-  alias CommonCore.Defaults
-
   batt_polymorphic_schema type: :metallb do
-    defaultable_field :speaker_image, :string, default: Defaults.Images.metallb_speaker_image()
-    defaultable_field :controller_image, :string, default: Defaults.Images.metallb_controller_image()
-    defaultable_field :frrouting_image, :string, default: Defaults.Images.frrouting_frr_image()
+    defaultable_image_field :speaker_image, image_id: :metallb_speaker
+    defaultable_image_field :controller_image, image_id: :metallb_controller
+    defaultable_image_field :frrouting_image, image_id: :frrouting_frr
 
     field :enable_pod_monitor, :boolean, default: false
   end

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/promtail_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/promtail_config.ex
@@ -3,9 +3,7 @@ defmodule CommonCore.Batteries.PromtailConfig do
 
   use CommonCore, :embedded_schema
 
-  alias CommonCore.Defaults
-
   batt_polymorphic_schema type: :promtail do
-    defaultable_field :image, :string, default: Defaults.Images.promtail_image()
+    defaultable_image_field :image, image_id: :promtail
   end
 end

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/redis_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/redis_config.ex
@@ -3,11 +3,9 @@ defmodule CommonCore.Batteries.RedisConfig do
 
   use CommonCore, :embedded_schema
 
-  alias CommonCore.Defaults
-
   batt_polymorphic_schema type: :redis do
-    defaultable_field :operator_image, :string, default: Defaults.Images.redis_operator_image()
-    defaultable_field :redis_image, :string, default: Defaults.Images.redis_image()
-    defaultable_field :exporter_image, :string, default: Defaults.Images.redis_exporter_image()
+    defaultable_image_field :operator_image, image_id: :redis_operator
+    defaultable_image_field :redis_image, image_id: :redis
+    defaultable_image_field :exporter_image, image_id: :redis_exporter
   end
 end

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/smtp4dev_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/smtp4dev_config.ex
@@ -8,7 +8,7 @@ defmodule CommonCore.Batteries.Smtp4devConfig do
   @required_fields ~w()a
 
   batt_polymorphic_schema type: :smtp4dev do
-    defaultable_field :image, :string, default: Defaults.Images.smtp4dev_image()
+    defaultable_image_field :image, image_id: :smtp4dev
 
     secret_field :cookie_secret, length: 32, func: &Defaults.urlsafe_random_key_string/1
   end

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/sso_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/sso_config.ex
@@ -5,5 +5,7 @@ defmodule CommonCore.Batteries.SSOConfig do
 
   batt_polymorphic_schema type: :sso do
     defaultable_field :dev, :boolean, default: true
+
+    defaultable_image_field :oauth2_proxy_image, image_id: :oauth2_proxy
   end
 end

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/text_generation_web_ui_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/text_generation_web_ui_config.ex
@@ -6,7 +6,7 @@ defmodule CommonCore.Batteries.TextGenerationWebUIConfig do
   alias CommonCore.Defaults
 
   batt_polymorphic_schema type: :text_generation_webui do
-    defaultable_field :image, :string, default: Defaults.Images.text_generation_webui_image()
+    defaultable_image_field :image, image_id: :text_generation_webui
     secret_field :cookie_secret, length: 32, func: &Defaults.urlsafe_random_key_string/1
   end
 end

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/trivy_operator_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/trivy_operator_config.ex
@@ -3,12 +3,11 @@ defmodule CommonCore.Batteries.TrivyOperatorConfig do
 
   use CommonCore, :embedded_schema
 
-  alias CommonCore.Defaults
-
   batt_polymorphic_schema type: :trivy_operator do
-    defaultable_field :image, :string, default: Defaults.Images.trivy_operator_image()
-    defaultable_field :node_colletor_image, :string, default: Defaults.Images.aqua_node_collector()
-    defaultable_field :trivy_checks_image, :string, default: Defaults.Images.aqua_trivy_checks()
+    defaultable_image_field :image, image_id: :trivy_operator
+    defaultable_image_field :node_colletor_image, image_id: :aqua_node_collector
+    defaultable_image_field :trivy_checks_image, image_id: :aqua_trivy_checks
+
     defaultable_field :version_tag, :string, default: "0.52.0"
   end
 end

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/trust_manager_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/trust_manager_config.ex
@@ -3,10 +3,8 @@ defmodule CommonCore.Batteries.TrustManagerConfig do
 
   use CommonCore, :embedded_schema
 
-  alias CommonCore.Defaults
-
   batt_polymorphic_schema type: :trust_manager do
-    defaultable_field :image, :string, default: Defaults.Images.trust_manager_image()
-    defaultable_field :init_image, :string, default: Defaults.Images.trust_manager_init_image()
+    defaultable_image_field :image, image_id: :trust_manager
+    defaultable_image_field :init_image, image_id: :trust_manager_init
   end
 end

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/victoria_metrics_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/victoria_metrics_config.ex
@@ -7,7 +7,8 @@ defmodule CommonCore.Batteries.VictoriaMetricsConfig do
 
   batt_polymorphic_schema type: :victoria_metrics do
     defaultable_field :cluster_image_tag, :string, default: Defaults.Images.vm_cluster_tag()
-    defaultable_field :vm_operator_image, :string, default: Defaults.Images.vm_operator_image()
+    defaultable_image_field :operator_image, image_id: :vm_operator
+
     secret_field :cookie_secret, length: 32, func: &Defaults.urlsafe_random_key_string/1
 
     field :replication_factor, :integer, default: 1

--- a/platform_umbrella/apps/common_core/lib/common_core/defaults/images.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/defaults/images.ex
@@ -4,17 +4,279 @@ defmodule CommonCore.Defaults.Images do
   alias CommonCore.Defaults.Image
 
   @batteries_included_base "#{CommonCore.Version.version()}-#{CommonCore.Version.hash()}"
-  @cert_manager_image_tag "v1.15.1"
-  @kiali_image_version "v1.87.0"
+
+  @cert_manager_allowed_tags ~w(v1.15.1)
+  @cert_manager_default_tag "v1.15.1"
+
+  @knative_allowed_tags ~w(v1.15.1)
+  @knative_default_tag "v1.15.1"
 
   @registry %{
+    addon_resizer:
+      Image.new!(%{
+        name: "registry.k8s.io/autoscaling/addon-resizer",
+        tags: ~w(1.8.22),
+        default_tag: "1.8.22"
+      }),
+    aws_load_balancer_controller:
+      Image.new!(%{
+        name: "public.ecr.aws/eks/aws-load-balancer-controller",
+        tags: ~w(v2.8.1),
+        default_tag: "v2.8.1"
+      }),
+    cert_manager_acmesolver:
+      Image.new!(%{
+        name: "quay.io/jetstack/cert-manager-acmesolver",
+        tags: @cert_manager_allowed_tags,
+        default_tag: @cert_manager_default_tag
+      }),
+    cert_manager_cainjector:
+      Image.new!(%{
+        name: "quay.io/jetstack/cert-manager-cainjector",
+        tags: @cert_manager_allowed_tags,
+        default_tag: @cert_manager_default_tag
+      }),
+    cert_manager_controller:
+      Image.new!(%{
+        name: "quay.io/jetstack/cert-manager-controller",
+        tags: @cert_manager_allowed_tags,
+        default_tag: @cert_manager_default_tag
+      }),
+    cert_manager_ctl:
+      Image.new!(%{
+        name: "quay.io/jetstack/cert-manager-ctl",
+        tags: @cert_manager_allowed_tags,
+        default_tag: @cert_manager_default_tag
+      }),
+    cert_manager_webhook:
+      Image.new!(%{
+        name: "quay.io/jetstack/cert-manager-webhook",
+        tags: @cert_manager_allowed_tags,
+        default_tag: @cert_manager_default_tag
+      }),
+    cloudnative_pg:
+      Image.new!(%{
+        name: "ghcr.io/cloudnative-pg/cloudnative-pg",
+        tags: ~w(1.23.2),
+        default_tag: "1.23.2"
+      }),
+    ferretdb:
+      Image.new!(%{
+        name: "ghcr.io/ferretdb/ferretdb",
+        tags: ~w(1.23.0),
+        default_tag: "1.23.0"
+      }),
+    forgejo:
+      Image.new!(%{
+        name: "codeberg.org/forgejo/forgejo",
+        tags: ~w(1.21.11-2),
+        default_tag: "1.21.11-2"
+      }),
+    grafana:
+      Image.new!(%{
+        name: "grafana/grafana",
+        tags: ~w(10.4.5),
+        default_tag: "10.4.5"
+      }),
     istio_pilot:
       Image.new!(%{
         name: "docker.io/istio/pilot",
         tags: ~w(1.22.3-distroless),
         default_tag: "1.22.3-distroless"
       }),
-    schema_test:
+    istio_proxy:
+      Image.new!(%{
+        name: "docker.io/istio/proxyv2",
+        tags: ~w(1.22.3-distroless),
+        default_tag: "1.22.3-distroless"
+      }),
+    karpenter:
+      Image.new!(%{
+        name: "public.ecr.aws/karpenter/controller",
+        tags: ~w(0.37.0),
+        default_tag: "0.37.0"
+      }),
+    keycloak:
+      Image.new!(%{
+        name: "quay.io/keycloak/keycloak",
+        tags: ~w(25.0.2),
+        default_tag: "25.0.2"
+      }),
+    kiali:
+      Image.new!(%{
+        name: "quay.io/kiali/kiali",
+        tags: ~w(v1.87.0),
+        default_tag: "v1.87.0"
+      }),
+    kiwigrid_sidecar:
+      Image.new!(%{
+        name: "quay.io/kiwigrid/k8s-sidecar",
+        tags: ~w(1.27.4),
+        default_tag: "1.27.4"
+      }),
+    kube_state_metrics:
+      Image.new!(%{
+        name: "registry.k8s.io/kube-state-metrics/kube-state-metrics",
+        tags: ~w(v2.12.0),
+        default_tag: "v2.12.0"
+      }),
+    loki:
+      Image.new!(%{
+        name: "grafana/loki",
+        tags: ~w(2.9.8),
+        default_tag: "2.9.8"
+      }),
+    metallb_controller:
+      Image.new!(%{
+        name: "quay.io/metallb/controller",
+        tags: ~w(v0.14.8),
+        default_tag: "v0.14.8"
+      }),
+    metallb_speaker:
+      Image.new!(%{
+        name: "quay.io/metallb/speaker",
+        tags: ~w(v0.14.8),
+        default_tag: "v0.14.8"
+      }),
+    frrouting_frr:
+      Image.new!(%{
+        name: "quay.io/frrouting/frr",
+        tags: ~w(9.1.0),
+        default_tag: "9.1.0"
+      }),
+    metrics_server:
+      Image.new!(%{
+        name: "registry.k8s.io/metrics-server/metrics-server",
+        tags: ~w(v0.7.1),
+        default_tag: "v0.7.1"
+      }),
+    node_exporter:
+      Image.new!(%{
+        name: "quay.io/prometheus/node-exporter",
+        tags: ~w(v1.8.1),
+        default_tag: "v1.8.1"
+      }),
+    oauth2_proxy:
+      Image.new!(%{
+        name: "quay.io/oauth2-proxy/oauth2-proxy",
+        tags: ~w(v7.6.0),
+        default_tag: "v7.6.0"
+      }),
+    promtail:
+      Image.new!(%{
+        name: "grafana/promtail",
+        tags: ~w(2.9.8),
+        default_tag: "2.9.8"
+      }),
+    redis:
+      Image.new!(%{
+        name: "quay.io/opstree/redis",
+        tags: ~w(v7.2.3),
+        default_tag: "v7.2.3"
+      }),
+    redis_exporter:
+      Image.new!(%{
+        name: "quay.io/opstree/redis-exporter",
+        tags: ~w(v1.45.0),
+        default_tag: "v1.45.0"
+      }),
+    redis_operator:
+      Image.new!(%{
+        name: "ghcr.io/ot-container-kit/redis-operator/redis-operator",
+        tags: ~w(v0.18.0),
+        default_tag: "v0.18.0"
+      }),
+    smtp4dev:
+      Image.new!(%{
+        name: "rnwood/smtp4dev",
+        tags: ~w(3.1.4),
+        default_tag: "3.1.4"
+      }),
+    text_generation_webui:
+      Image.new!(%{
+        name: "atinoda/text-generation-webui",
+        tags: ~w(default-cpu-2024.06.23),
+        default_tag: "default-cpu-2024.06.23"
+      }),
+    trivy_operator:
+      Image.new!(%{
+        name: "ghcr.io/aquasecurity/trivy-operator",
+        tags: ~w(0.22.0),
+        default_tag: "0.22.0"
+      }),
+    aqua_node_collector:
+      Image.new!(%{
+        name: "ghcr.io/aquasecurity/node-collector",
+        tags: ~w(0.3.1),
+        default_tag: "0.3.1"
+      }),
+    aqua_trivy_checks:
+      Image.new!(%{
+        name: "ghcr.io/aquasecurity/trivy-checks",
+        tags: ~w(0.13.0),
+        default_tag: "0.13.0"
+      }),
+    trust_manager:
+      Image.new!(%{
+        name: "quay.io/jetstack/trust-manager",
+        tags: ~w(v0.11.0),
+        default_tag: "v0.11.0"
+      }),
+    trust_manager_init:
+      Image.new!(%{
+        name: "quay.io/jetstack/cert-manager-package-debian",
+        tags: ~w(20210119.0),
+        default_tag: "20210119.0"
+      }),
+    vm_operator:
+      Image.new!(%{
+        name: "victoriametrics/operator",
+        tags: ~w(v0.44.0),
+        default_tag: "v0.44.0"
+      }),
+    knative_serving_activator:
+      Image.new!(%{
+        name: "gcr.io/knative-releases/knative.dev/serving/cmd/activator",
+        tags: @knative_allowed_tags,
+        default_tag: @knative_default_tag
+      }),
+    knative_serving_autoscaler:
+      Image.new!(%{
+        name: "gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler",
+        tags: @knative_allowed_tags,
+        default_tag: @knative_default_tag
+      }),
+    knative_serving_controller:
+      Image.new!(%{
+        name: "gcr.io/knative-releases/knative.dev/serving/cmd/controller",
+        tags: @knative_allowed_tags,
+        default_tag: @knative_default_tag
+      }),
+    knative_serving_queue:
+      Image.new!(%{
+        name: "gcr.io/knative-releases/knative.dev/serving/cmd/queue",
+        tags: @knative_allowed_tags,
+        default_tag: @knative_default_tag
+      }),
+    knative_serving_webhook:
+      Image.new!(%{
+        name: "gcr.io/knative-releases/knative.dev/serving/cmd/webhook",
+        tags: @knative_allowed_tags,
+        default_tag: @knative_default_tag
+      }),
+    knative_istio_controller:
+      Image.new!(%{
+        name: "gcr.io/knative-releases/knative.dev/net-istio/cmd/controller",
+        tags: @knative_allowed_tags,
+        default_tag: @knative_default_tag
+      }),
+    knative_istio_webhook:
+      Image.new!(%{
+        name: "gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook",
+        tags: @knative_allowed_tags,
+        default_tag: @knative_default_tag
+      }),
+    __schema_test:
       Image.new!(%{
         name: "ecto/schema/test",
         tags: ~w(1.2.3 1.2.4 latest),
@@ -41,17 +303,11 @@ defmodule CommonCore.Defaults.Images do
     end
   end
 
-  @spec cert_manager_image_version() :: String.t()
-  def cert_manager_image_version, do: @cert_manager_image_tag
-
   @spec vm_cluster_tag() :: String.t()
   def vm_cluster_tag, do: "v1.102.0-cluster"
 
   @spec vm_tag() :: String.t()
   def vm_tag, do: "v1.93.9"
-
-  @spec kiali_image_version() :: String.t()
-  def kiali_image_version, do: @kiali_image_version
 
   @spec batteries_included_version() :: String.t()
   def batteries_included_version do
@@ -73,148 +329,15 @@ defmodule CommonCore.Defaults.Images do
     "public.ecr.aws/batteries-included/control-server:#{ver}"
   end
 
-  @spec control_server_image() :: String.t()
+  @spec bootstrap_image() :: String.t()
   def bootstrap_image do
     ver = batteries_included_version()
     "public.ecr.aws/batteries-included/kube-bootstrap:#{ver}"
   end
-
-  @spec addon_resizer_image() :: String.t()
-  def addon_resizer_image, do: "registry.k8s.io/autoscaling/addon-resizer:1.8.22"
-
-  @spec alertmanager_image() :: String.t()
-  def alertmanager_image, do: "quay.io/prometheus/alertmanager:v0.27.0"
-
-  @spec aws_load_balancer_controller_image() :: String.t()
-  def aws_load_balancer_controller_image, do: "public.ecr.aws/eks/aws-load-balancer-controller:v2.8.1"
-
-  @spec cert_manager_acmesolver_image() :: String.t()
-  def cert_manager_acmesolver_image, do: "quay.io/jetstack/cert-manager-acmesolver:#{cert_manager_image_version()}"
-
-  @spec cert_manager_cainjector_image() :: String.t()
-  def cert_manager_cainjector_image, do: "quay.io/jetstack/cert-manager-cainjector:#{cert_manager_image_version()}"
-
-  @spec cert_manager_controller_image() :: String.t()
-  def cert_manager_controller_image, do: "quay.io/jetstack/cert-manager-controller:#{cert_manager_image_version()}"
-
-  @spec cert_manager_ctl_image() :: String.t()
-  def cert_manager_ctl_image, do: "quay.io/jetstack/cert-manager-ctl:#{cert_manager_image_version()}"
-
-  @spec cert_manager_webhook_image() :: String.t()
-  def cert_manager_webhook_image, do: "quay.io/jetstack/cert-manager-webhook:#{cert_manager_image_version()}"
-
-  @spec cloudnative_pg_image() :: String.t()
-  def cloudnative_pg_image, do: "ghcr.io/cloudnative-pg/cloudnative-pg:1.23.2"
-
-  @spec ferretdb_image() :: String.t()
-  def ferretdb_image, do: "ghcr.io/ferretdb/ferretdb:1.23.0"
-
-  @spec forgejo_image() :: String.t()
-  def forgejo_image, do: "codeberg.org/forgejo/forgejo:1.21.11-2"
-
-  @spec grafana_image() :: String.t()
-  def grafana_image, do: "grafana/grafana:10.4.5"
 
   @spec home_base_image() :: String.t()
   def home_base_image do
     ver = batteries_included_version()
     "public.ecr.aws/batteries-included/home-base:#{ver}"
   end
-
-  @spec istio_pilot_image() :: String.t()
-  def istio_pilot_image, do: "docker.io/istio/pilot:1.22.3-distroless"
-
-  @spec istio_proxy_image() :: String.t()
-  def istio_proxy_image, do: "docker.io/istio/proxyv2:1.22.3-distroless"
-
-  @spec karpenter_image() :: String.t()
-  def karpenter_image, do: "public.ecr.aws/karpenter/controller:0.37.0"
-
-  @spec keycloak_image() :: String.t()
-  def keycloak_image, do: "quay.io/keycloak/keycloak:25.0.2"
-
-  @spec kiali_image() :: String.t()
-  def kiali_image, do: "quay.io/kiali/kiali:#{kiali_image_version()}"
-
-  @spec kiwigrid_sidecar_image() :: String.t()
-  def kiwigrid_sidecar_image, do: "quay.io/kiwigrid/k8s-sidecar:1.27.4"
-
-  @spec kube_state_metrics_image() :: String.t()
-  def kube_state_metrics_image, do: "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0"
-
-  @spec loki_image() :: String.t()
-  def loki_image, do: "grafana/loki:2.9.8"
-
-  @spec metallb_controller_image() :: String.t()
-  def metallb_controller_image, do: "quay.io/metallb/controller:v0.14.8"
-
-  @spec metallb_speaker_image() :: String.t()
-  def metallb_speaker_image, do: "quay.io/metallb/speaker:v0.14.8"
-
-  @spec frrouting_frr_image() :: String.t()
-  def frrouting_frr_image, do: "quay.io/frrouting/frr:9.1.0"
-
-  @spec metrics_server_image() :: String.t()
-  def metrics_server_image, do: "registry.k8s.io/metrics-server/metrics-server:v0.7.1"
-
-  @spec node_exporter_image() :: String.t()
-  def node_exporter_image, do: "quay.io/prometheus/node-exporter:v1.8.1"
-
-  @spec oauth2_proxy_image() :: String.t()
-  def oauth2_proxy_image, do: "quay.io/oauth2-proxy/oauth2-proxy:v7.6.0"
-
-  @spec promtail_image() :: String.t()
-  def promtail_image, do: "grafana/promtail:2.9.8"
-
-  @spec redis_operator_image() :: String.t()
-  def redis_operator_image, do: "ghcr.io/ot-container-kit/redis-operator/redis-operator:v0.18.0"
-
-  @spec redis_exporter_image() :: String.t()
-  def redis_exporter_image, do: "quay.io/opstree/redis-exporter:v1.45.0"
-
-  @spec redis_image() :: String.t()
-  def redis_image, do: "quay.io/opstree/redis:v7.2.3"
-
-  @spec smtp4dev_image() :: String.t()
-  def smtp4dev_image, do: "rnwood/smtp4dev:3.1.4"
-
-  @spec text_generation_webui_image() :: String.t()
-  def text_generation_webui_image, do: "atinoda/text-generation-webui:default-cpu-2024.06.23"
-
-  @spec trivy_operator_image() :: String.t()
-  def trivy_operator_image, do: "ghcr.io/aquasecurity/trivy-operator:0.22.0"
-
-  @spec aqua_node_collector() :: String.t()
-  def aqua_node_collector, do: "ghcr.io/aquasecurity/node-collector:0.3.1"
-
-  @spec aqua_trivy_checks() :: String.t()
-  def aqua_trivy_checks, do: "ghcr.io/aquasecurity/trivy-checks:0.13.0"
-
-  @spec trust_manager_image() :: String.t()
-  def trust_manager_image, do: "quay.io/jetstack/trust-manager:v0.11.0"
-  def trust_manager_init_image, do: "quay.io/jetstack/cert-manager-package-debian:20210119.0"
-
-  @spec vm_operator_image() :: String.t()
-  def vm_operator_image, do: "victoriametrics/operator:v0.44.0"
-
-  @spec knative_serving_queue_image() :: String.t()
-  def knative_serving_queue_image, do: "gcr.io/knative-releases/knative.dev/serving/cmd/queue:v1.15.1"
-
-  @spec knative_serving_activator_image() :: String.t()
-  def knative_serving_activator_image, do: "gcr.io/knative-releases/knative.dev/serving/cmd/activator:v1.15.1"
-
-  @spec knative_serving_autoscaler_image() :: String.t()
-  def knative_serving_autoscaler_image, do: "gcr.io/knative-releases/knative.dev/serving/cmd/autoscaler:v1.15.1"
-
-  @spec knative_serving_controller_image() :: String.t()
-  def knative_serving_controller_image, do: "gcr.io/knative-releases/knative.dev/serving/cmd/controller:v1.15.1"
-
-  @spec knative_serving_webhook_image() :: String.t()
-  def knative_serving_webhook_image, do: "gcr.io/knative-releases/knative.dev/serving/cmd/webhook:v1.15.1"
-
-  @spec knative_istio_controller_image() :: String.t()
-  def knative_istio_controller_image, do: "gcr.io/knative-releases/knative.dev/net-istio/cmd/controller:v1.15.1"
-
-  @spec knative_istio_webhook_image() :: String.t()
-  def knative_istio_webhook_image, do: "gcr.io/knative-releases/knative.dev/net-istio/cmd/webhook:v1.15.1"
 end

--- a/platform_umbrella/apps/common_core/lib/common_core/resources/istio/kiali_config_generator.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/resources/istio/kiali_config_generator.ex
@@ -4,7 +4,7 @@ defmodule CommonCore.Resources.Istio.KialiConfigGenerator do
   import CommonCore.StateSummary.Namespaces
   import CommonCore.StateSummary.URLs
 
-  alias CommonCore.Defaults.Images
+  alias CommonCore.Batteries.KialiConfig
   alias CommonCore.StateSummary
   alias CommonCore.StateSummary.Batteries
   alias CommonCore.StateSummary.URLs
@@ -27,7 +27,7 @@ defmodule CommonCore.Resources.Istio.KialiConfigGenerator do
         "image_name" => "quay.io/kiali/kiali",
         "image_pull_policy" => "Always",
         "image_pull_secrets" => [],
-        "image_version" => Images.kiali_image_version(),
+        "image_version" => KialiConfig.image_version(battery.config),
         "ingress" => %{
           "additional_labels" => %{},
           "class_name" => "nginx",
@@ -55,7 +55,7 @@ defmodule CommonCore.Resources.Istio.KialiConfigGenerator do
         "service_annotations" => %{},
         "service_type" => "",
         "tolerations" => [],
-        "version_label" => Images.kiali_image_version(),
+        "version_label" => KialiConfig.image_version(battery.config),
         "view_only_mode" => false
       },
       "external_services" => %{

--- a/platform_umbrella/apps/common_core/lib/common_core/resources/monitoring/vm_operator.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/resources/monitoring/vm_operator.ex
@@ -281,7 +281,7 @@ defmodule CommonCore.Resources.VMOperator do
                 %{"name" => "VM_PSPAUTOCREATEENABLED", "value" => "false"},
                 %{"name" => "VM_ENABLEDPROMETHEUSCONVERTEROWNERREFERENCES", "value" => "true"}
               ],
-              "image" => battery.config.vm_operator_image,
+              "image" => battery.config.operator_image,
               "imagePullPolicy" => "IfNotPresent",
               "name" => "operator",
               "ports" => [

--- a/platform_umbrella/apps/common_core/lib/common_core/state_summary/core.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/state_summary/core.ex
@@ -35,17 +35,17 @@ defmodule CommonCore.StateSummary.Core do
 
   def controlserver_image(%StateSummary{} = summary) do
     if upgrade_time?(summary) do
-      stable_contol_image(summary)
+      stable_control_image(summary)
     else
       Defaults.Images.control_server_image()
     end
   end
 
-  defp stable_contol_image(%StateSummary{stable_versions_report: %StableVersionsReport{} = report} = _summary) do
+  defp stable_control_image(%StateSummary{stable_versions_report: %StableVersionsReport{} = report} = _summary) do
     report.control_server
   end
 
-  defp stable_contol_image(_summary) do
+  defp stable_control_image(_summary) do
     Defaults.Images.control_server_image()
   end
 

--- a/platform_umbrella/apps/common_core/test/support/example_schemas.ex
+++ b/platform_umbrella/apps/common_core/test/support/example_schemas.ex
@@ -33,7 +33,7 @@ defmodule CommonCore.ExampleSchemas do
         default_name: "mycontainer",
         default_tag: "latest"
 
-      defaultable_image_field :image_from_registry, image_id: :schema_test
+      defaultable_image_field :image_from_registry, image_id: :__schema_test
 
       embeds_one :meta, EmbeddedMetaSchema
     end

--- a/platform_umbrella/apps/control_server/test/control_server/batteries_test.exs
+++ b/platform_umbrella/apps/control_server/test/control_server/batteries_test.exs
@@ -36,9 +36,11 @@ defmodule ControlServer.BatteriesTest do
       assert {:ok, %SystemBattery{} = system_battery} =
                Batteries.create_system_battery(valid_attrs)
 
+      pilot_image = Defaults.Images.get_image!(:istio_pilot)
+
       assert system_battery.config == %IstioConfig{
                namespace: Defaults.Namespaces.istio(),
-               pilot_image: Defaults.Images.istio_pilot_image()
+               pilot_image: "#{pilot_image.name}:#{pilot_image.default_tag}"
              }
 
       assert system_battery.group == :net_sec


### PR DESCRIPTION

Test plan:
- [x] create a `:kitchen_sink` install and diff the static spec between master and this branch. No diff in images.
- [x] go through and make sure batteries install and pods start locally
- [x] compile time checks on the image struct that actually caught a bunch of things as I was migrating!