### PR TITLE
feat: print message about vpn configuration

### DIFF
--- a/bi/cmd/vpn/config.go
+++ b/bi/cmd/vpn/config.go
@@ -1,4 +1,4 @@
-package debug
+package vpn
 
 import (
 	"bi/pkg/installs"
@@ -11,8 +11,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var wireGuardConfigCmd = &cobra.Command{
-	Use:   "wireguard-config [install-slug|install-spec-url|install-spec-file]",
+var vpnConfigCmd = &cobra.Command{
+	Use:   "config [install-slug|install-spec-url|install-spec-file]",
 	Short: "Get the wireguard config for a batteries included environment",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -67,7 +67,7 @@ var wireGuardConfigCmd = &cobra.Command{
 }
 
 func init() {
-	wireGuardConfigCmd.Flags().StringP("output", "o", "-", "Path to write the wireguard config to")
+	vpnConfigCmd.Flags().StringP("output", "o", "-", "Path to write the wireguard config to")
 
-	debugCmd.AddCommand(wireGuardConfigCmd)
+	vpnCmd.AddCommand(vpnConfigCmd)
 }

--- a/bi/cmd/vpn/vpn.go
+++ b/bi/cmd/vpn/vpn.go
@@ -1,0 +1,16 @@
+package vpn
+
+import (
+	"bi/cmd"
+
+	"github.com/spf13/cobra"
+)
+
+var vpnCmd = &cobra.Command{
+	Use:   "vpn",
+	Short: "Manage the WireGuard VPN for a batteries included environment",
+}
+
+func init() {
+	cmd.RootCmd.AddCommand(vpnCmd)
+}

--- a/bi/main.go
+++ b/bi/main.go
@@ -8,6 +8,7 @@ import (
 	_ "bi/cmd/aws"
 	_ "bi/cmd/debug"
 	_ "bi/cmd/postgres"
+	_ "bi/cmd/vpn"
 )
 
 func main() {

--- a/bi/pkg/start/start.go
+++ b/bi/pkg/start/start.go
@@ -58,7 +58,7 @@ func StartInstall(ctx context.Context, env *installs.InstallEnv) error {
 	}
 
 	slog.Info("Displaying access information")
-	if err := env.Spec.PrintAccessInfo(ctx, kubeClient); err != nil {
+	if err := env.Spec.PrintAccessInfo(ctx, kubeClient, env.Slug); err != nil {
 		return fmt.Errorf("failed get and display access info: %w", err)
 	}
 


### PR DESCRIPTION
Move the `vpn config` command out of the debug group (now that we want end users to use it).

Add a message to the end of the bootstrap process (if we detect docker desktop) explaining how to obtain the vpn configuration.

The message text is kind of a place holder, please let me know what to replace it with.