### PR TITLE
fix: don't assume podman just because it's on the path

### DIFF
--- a/bi/pkg/cluster/kind/podman.go
+++ b/bi/pkg/cluster/kind/podman.go
@@ -6,9 +6,8 @@ import (
 )
 
 func IsPodmanAvailable() (bool, error) {
-	cmd := exec.Command("command", "-v", "podman")
+	cmd := exec.Command("podman", "info")
 	err := cmd.Run()
-
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
This changes it to get the info of podman. If the server isn't running podman we won't get anything back and will get a non-zero exit code.
