### PR TITLE
fix: don't error out if kubesnapshot is in progress for

### DIFF
--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/home.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/home.ex
@@ -102,7 +102,7 @@ defmodule ControlServerWeb.Live.Home do
       </div>
 
       <.button
-        :if={@latest_snapshot}
+        :if={@latest_snapshot && @latest_snapshot.kube_snapshot}
         variant="minimal"
         link={~p"/deploy"}
         icon={snapshot_icon(@latest_snapshot.kube_snapshot.status)}


### PR DESCRIPTION
For the home page we relied on the kubesnapshot having a status when it could be nil.
