### PR TITLE
feat: add nvidia device plugin battery

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/catalog.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/catalog.ex
@@ -177,6 +177,13 @@ defmodule CommonCore.Batteries.Catalog do
       name: "Notebooks",
       description: "Jupyter Notebooks for AI, ML, and Data Science."
     },
+    %CatalogBattery{
+      group: :ai,
+      type: :nvidia_device_plugin,
+      dependencies: [:battery_core],
+      name: "Nvidia Device Plugin",
+      description: "The Nvidia Device Plugin for Kubernetes. This exposes the nvidia device details to kubernetes."
+    },
     # Monitoring
     %CatalogBattery{
       group: :monitoring,

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/nvidia_device_plugin_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/nvidia_device_plugin_config.ex
@@ -1,0 +1,11 @@
+defmodule CommonCore.Batteries.NvidiaDevicePluginConfig do
+  @moduledoc false
+
+  use CommonCore, :embedded_schema
+
+  @required_fields ~w()a
+
+  batt_polymorphic_schema type: :nvidia_device_plugin do
+    defaultable_image_field :image, image_id: :nvidia_device_plugin
+  end
+end

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/system_battery.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/system_battery.ex
@@ -22,6 +22,7 @@ defmodule CommonCore.Batteries.SystemBattery do
   alias CommonCore.Batteries.LokiConfig
   alias CommonCore.Batteries.MetalLBConfig
   alias CommonCore.Batteries.NotebooksConfig
+  alias CommonCore.Batteries.NvidiaDevicePluginConfig
   alias CommonCore.Batteries.PromtailConfig
   alias CommonCore.Batteries.RedisConfig
   alias CommonCore.Batteries.Smtp4devConfig
@@ -67,6 +68,7 @@ defmodule CommonCore.Batteries.SystemBattery do
     loki: LokiConfig,
     metallb: MetalLBConfig,
     notebooks: NotebooksConfig,
+    nvidia_device_plugin: NvidiaDevicePluginConfig,
     promtail: PromtailConfig,
     redis: RedisConfig,
     stale_resource_cleaner: StaleResourceCleanerConfig,

--- a/platform_umbrella/apps/common_core/lib/common_core/defaults/images.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/defaults/images.ex
@@ -156,6 +156,12 @@ defmodule CommonCore.Defaults.Images do
         tags: ~w(v1.8.1),
         default_tag: "v1.8.1"
       }),
+    nvidia_device_plugin:
+      Image.new!(%{
+        name: "nvcr.io/nvidia/k8s-device-plugin",
+        tags: ~w(v0.16.2),
+        default_tag: "v0.16.2"
+      }),
     oauth2_proxy:
       Image.new!(%{
         name: "quay.io/oauth2-proxy/oauth2-proxy",

--- a/platform_umbrella/apps/common_core/lib/common_core/resources/ml/nvidia_device_plugin.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/resources/ml/nvidia_device_plugin.ex
@@ -1,0 +1,199 @@
+defmodule CommonCore.Resources.NvidiaDevicePlugin do
+  @moduledoc false
+  use CommonCore.Resources.ResourceGenerator, app_name: "nvidia-device-plugin"
+
+  import CommonCore.StateSummary.Namespaces
+
+  alias CommonCore.Resources.Builder, as: B
+
+  resource(:nvidia_device_plugin, battery, state) do
+    namespace = core_namespace(state)
+
+    template =
+      %{}
+      |> Map.put("metadata", %{"labels" => %{"battery/managed" => "true"}})
+      |> Map.put(
+        "spec",
+        %{
+          "affinity" => %{
+            "nodeAffinity" => %{
+              "requiredDuringSchedulingIgnoredDuringExecution" => %{
+                "nodeSelectorTerms" => [
+                  %{
+                    "matchExpressions" => [
+                      %{"key" => "feature.node.kubernetes.io/pci-10de.present", "operator" => "In", "values" => ["true"]}
+                    ]
+                  },
+                  %{
+                    "matchExpressions" => [
+                      %{
+                        "key" => "feature.node.kubernetes.io/cpu-model.vendor_id",
+                        "operator" => "In",
+                        "values" => ["NVIDIA"]
+                      }
+                    ]
+                  },
+                  %{
+                    "matchExpressions" => [%{"key" => "nvidia.com/gpu.present", "operator" => "In", "values" => ["true"]}]
+                  }
+                ]
+              }
+            }
+          },
+          "containers" => [
+            %{
+              "command" => ["nvidia-device-plugin"],
+              "env" => [
+                %{"name" => "MPS_ROOT", "value" => "/run/nvidia/mps"},
+                %{"name" => "NVIDIA_VISIBLE_DEVICES", "value" => "all"},
+                %{"name" => "NVIDIA_DRIVER_CAPABILITIES", "value" => "compute,utility"}
+              ],
+              "image" => battery.config.image,
+              "name" => "nvidia-device-plugin-ctr",
+              "securityContext" => %{"allowPrivilegeEscalation" => false, "capabilities" => %{"drop" => ["ALL"]}},
+              "volumeMounts" => [
+                %{"mountPath" => "/var/lib/kubelet/device-plugins", "name" => "device-plugin"},
+                %{"mountPath" => "/dev/shm", "name" => "mps-shm"},
+                %{"mountPath" => "/mps", "name" => "mps-root"},
+                %{"mountPath" => "/var/run/cdi", "name" => "cdi-root"}
+              ]
+            }
+          ],
+          "tolerations" => [
+            %{"key" => "CriticalAddonsOnly", "operator" => "Exists"},
+            %{"effect" => "NoSchedule", "key" => "nvidia.com/gpu", "operator" => "Exists"}
+          ],
+          "volumes" => [
+            %{"hostPath" => %{"path" => "/var/lib/kubelet/device-plugins"}, "name" => "device-plugin"},
+            %{"hostPath" => %{"path" => "/run/nvidia/mps", "type" => "DirectoryOrCreate"}, "name" => "mps-root"},
+            %{"hostPath" => %{"path" => "/run/nvidia/mps/shm"}, "name" => "mps-shm"},
+            %{"hostPath" => %{"path" => "/var/run/cdi", "type" => "DirectoryOrCreate"}, "name" => "cdi-root"}
+          ]
+        }
+      )
+      |> B.app_labels(@app_name)
+      |> B.add_owner(battery)
+      |> B.component_labels("nvidia-device-plugin")
+
+    spec =
+      %{}
+      |> Map.put(
+        "selector",
+        %{"matchLabels" => %{"battery/app" => @app_name, "battery/component" => "nvidia-device-plugin"}}
+      )
+      |> Map.put("updateStrategy", %{"type" => "RollingUpdate"})
+      |> B.template(template)
+
+    :daemon_set
+    |> B.build_resource()
+    |> B.name("nvdp-nvidia-device-plugin")
+    |> B.component_labels("nvidia-device-plugin")
+    |> B.namespace(namespace)
+    |> B.spec(spec)
+  end
+
+  resource(:mps_control, battery, state) do
+    namespace = core_namespace(state)
+
+    template =
+      %{}
+      |> Map.put(
+        "metadata",
+        %{
+          "annotations" => %{},
+          "labels" => %{
+            "battery/managed" => "true"
+          }
+        }
+      )
+      |> Map.put(
+        "spec",
+        %{
+          "affinity" => %{
+            "nodeAffinity" => %{
+              "requiredDuringSchedulingIgnoredDuringExecution" => %{
+                "nodeSelectorTerms" => [
+                  %{
+                    "matchExpressions" => [
+                      %{"key" => "feature.node.kubernetes.io/pci-10de.present", "operator" => "In", "values" => ["true"]}
+                    ]
+                  },
+                  %{
+                    "matchExpressions" => [
+                      %{
+                        "key" => "feature.node.kubernetes.io/cpu-model.vendor_id",
+                        "operator" => "In",
+                        "values" => ["NVIDIA"]
+                      }
+                    ]
+                  },
+                  %{
+                    "matchExpressions" => [%{"key" => "nvidia.com/gpu.present", "operator" => "In", "values" => ["true"]}]
+                  }
+                ]
+              }
+            }
+          },
+          "containers" => [
+            %{
+              "command" => ["mps-control-daemon"],
+              "env" => [
+                %{
+                  "name" => "NODE_NAME",
+                  "valueFrom" => %{"fieldRef" => %{"apiVersion" => "v1", "fieldPath" => "spec.nodeName"}}
+                },
+                %{"name" => "NVIDIA_VISIBLE_DEVICES", "value" => "all"},
+                %{"name" => "NVIDIA_DRIVER_CAPABILITIES", "value" => "compute,utility"}
+              ],
+              "image" => battery.config.image,
+              "name" => "mps-control-daemon-ctr",
+              "securityContext" => %{"privileged" => true},
+              "volumeMounts" => [
+                %{"mountPath" => "/dev/shm", "name" => "mps-shm"},
+                %{"mountPath" => "/mps", "name" => "mps-root"}
+              ]
+            }
+          ],
+          "initContainers" => [
+            %{
+              "command" => ["mps-control-daemon", "mount-shm"],
+              "image" => battery.config.image,
+              "name" => "mps-control-daemon-mounts",
+              "securityContext" => %{"privileged" => true},
+              "volumeMounts" => [%{"mountPath" => "/mps", "mountPropagation" => "Bidirectional", "name" => "mps-root"}]
+            }
+          ],
+          "nodeSelector" => %{"nvidia.com/mps.capable" => "true"},
+          "priorityClassName" => "system-node-critical",
+          "securityContext" => %{},
+          "tolerations" => [
+            %{"key" => "CriticalAddonsOnly", "operator" => "Exists"},
+            %{"effect" => "NoSchedule", "key" => "nvidia.com/gpu", "operator" => "Exists"}
+          ],
+          "volumes" => [
+            %{"hostPath" => %{"path" => "/run/nvidia/mps", "type" => "DirectoryOrCreate"}, "name" => "mps-root"},
+            %{"hostPath" => %{"path" => "/run/nvidia/mps/shm"}, "name" => "mps-shm"}
+          ]
+        }
+      )
+      |> B.app_labels(@app_name)
+      |> B.add_owner(battery)
+      |> B.component_labels("mps-control-daemon")
+
+    spec =
+      %{}
+      |> Map.put(
+        "selector",
+        %{"matchLabels" => %{"battery/app" => @app_name, "battery/component" => "mps-control-daemon"}}
+      )
+      |> Map.put("updateStrategy", %{"type" => "RollingUpdate"})
+      |> B.template(template)
+
+    :daemon_set
+    |> B.build_resource()
+    |> B.name("nvdp-mps-control-daemon")
+    |> B.component_labels("mps-control-daemon")
+    |> B.namespace(namespace)
+    |> B.spec(spec)
+  end
+end

--- a/platform_umbrella/apps/common_core/lib/common_core/resources/root.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/resources/root.ex
@@ -42,6 +42,7 @@ defmodule CommonCore.Resources.RootResourceGenerator do
   alias CommonCore.Resources.MetricsServer
   alias CommonCore.Resources.NodeExporter
   alias CommonCore.Resources.Notebooks
+  alias CommonCore.Resources.NvidiaDevicePlugin
   alias CommonCore.Resources.Promtail
   alias CommonCore.Resources.Redis
   alias CommonCore.Resources.RedisOperator
@@ -76,6 +77,7 @@ defmodule CommonCore.Resources.RootResourceGenerator do
     loki: [Loki],
     metallb: [MetalLB, MetalLBMonitoring, MetalLBPools],
     notebooks: [Notebooks],
+    nvidia_device_plugin: [NvidiaDevicePlugin],
     promtail: [Promtail],
     redis: [Redis, RedisOperator],
     smtp4dev: [Smtp4Dev],

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/batteries/form_component.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/batteries/form_component.ex
@@ -27,6 +27,7 @@ defmodule ControlServerWeb.BatteriesFormComponent do
   alias ControlServerWeb.Batteries.LokiForm
   alias ControlServerWeb.Batteries.MetalLBForm
   alias ControlServerWeb.Batteries.NotebooksForm
+  alias ControlServerWeb.Batteries.NvidiaDevicePluginForm
   alias ControlServerWeb.Batteries.PromtailForm
   alias ControlServerWeb.Batteries.RedisForm
   alias ControlServerWeb.Batteries.Smtp4devForm
@@ -61,6 +62,7 @@ defmodule ControlServerWeb.BatteriesFormComponent do
     loki: LokiForm,
     metallb: MetalLBForm,
     notebooks: NotebooksForm,
+    nvidia_device_plugin: NvidiaDevicePluginForm,
     promtail: PromtailForm,
     redis: RedisForm,
     smtp4dev: Smtp4devForm,

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/batteries/nvida_device_plugin_form.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/batteries/nvida_device_plugin_form.ex
@@ -1,0 +1,29 @@
+defmodule ControlServerWeb.Batteries.NvidiaDevicePluginForm do
+  @moduledoc false
+
+  use ControlServerWeb, :live_component
+
+  import ControlServerWeb.BatteriesFormSubcomponents
+
+  def render(assigns) do
+    ~H"""
+    <div class="contents">
+      <.panel title="Description">
+        <%= @battery.description %>
+      </.panel>
+
+      <.panel title="Image">
+        <.simple_form variant="nested">
+          <.image><%= @form[:image].value %></.image>
+
+          <.image_version
+            field={@form[:image_tag_override]}
+            image_id={:nvidia_device_plugin}
+            label="Version"
+          />
+        </.simple_form>
+      </.panel>
+    </div>
+    """
+  end
+end


### PR DESCRIPTION
If we want to schedule on nodes that have a gpu we need to know where they are and ensure that the devices are ready.
