### PR TITLE
feat: automatically add the admin role on master realm

### DIFF
--- a/platform_umbrella/apps/kube_services/lib/kube_services/keycloak/admin_client.ex
+++ b/platform_umbrella/apps/kube_services/lib/kube_services/keycloak/admin_client.ex
@@ -215,6 +215,12 @@ defmodule KubeServices.Keycloak.AdminClient do
     GenServer.call(target, {:add_client_roles, realm_name, user_id, client_id, roles_payload})
   end
 
+  @spec add_roles(atom() | pid() | {atom(), any()} | {:via, atom(), any()}, String.t(), binary(), list()) ::
+          {:ok, any()} | {:error, any()}
+  def add_roles(target \\ @me, realm_name, user_id, roles_payload) do
+    GenServer.call(target, {:add_roles, realm_name, user_id, roles_payload})
+  end
+
   #
   # Genserver Implementation
   #
@@ -317,6 +323,12 @@ defmodule KubeServices.Keycloak.AdminClient do
     |> to_result(&GroupRepresentation.new!/1)
   end
 
+  defp run({:roles, realm_name}, client) do
+    client
+    |> get("/admin/realms/#{realm_name}/roles")
+    |> to_result(&RoleRepresentation.new!/1)
+  end
+
   defp run({:client_roles, realm_name, client_id}, client) do
     client
     |> get("/admin/realms/#{realm_name}/clients/#{client_id}/roles")
@@ -326,6 +338,12 @@ defmodule KubeServices.Keycloak.AdminClient do
   defp run({:add_client_roles, realm_name, user_id, client_id, role}, client) do
     client
     |> post("/admin/realms/#{realm_name}/users/#{user_id}/role-mappings/clients/#{client_id}", role)
+    |> to_result(nil)
+  end
+
+  defp run({:add_roles, realm_name, user_id, role}, client) do
+    client
+    |> post("/admin/realms/#{realm_name}/users/#{user_id}/role-mappings/realm", role)
     |> to_result(nil)
   end
 


### PR DESCRIPTION
Summary:

The master realm doesn't have admin client's created that allow access
to the admin side (and the ui). Instead it has a realm role `admin`. So
this PR makes `UserManager` automatically choose the type of admin to
make a user When we make a user an admin, we're giving keycloak the
permission to treat this user as an admin for all things below
this secuirty. So this gives everything on master realm.

This should fix: #674

Test Plan:
- bix bootstrap
- bix dev
- start the keycloak battery
- wait a few mins for tokens to be created
- create a user on the master realm.
- make them admin
- reset their password
- they can log into the master realm console
- they can see/interact with other realms admin consoles
