### PR TITLE
chore: iterate on build and locale

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/env.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/env.ex
@@ -1,0 +1,9 @@
+defmodule CommonCore.Env do
+  @moduledoc false
+
+  defmacro dev_env? do
+    quote do
+      Enum.member?([:dev, :test], Mix.env())
+    end
+  end
+end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/endpoint.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/endpoint.ex
@@ -1,6 +1,8 @@
 defmodule ControlServerWeb.Endpoint do
   use Phoenix.Endpoint, otp_app: :control_server_web
 
+  require CommonCore.Env
+
   # The session will be stored in the cookie and signed,
   # this means its contents can be read but not tampered with.
   # Set :encryption_salt if you would also like to encrypt it.
@@ -13,13 +15,10 @@ defmodule ControlServerWeb.Endpoint do
   socket "/live", Phoenix.LiveView.Socket, websocket: [connect_info: [session: @session_options]]
 
   # Serve at "/" the static files from "priv/static" directory.
-  #
-  # You should set gzip to true if you are running phx.digest
-  # when deploying your static files in production.
   plug Plug.Static,
     at: "/",
     from: :control_server_web,
-    gzip: false,
+    gzip: !CommonCore.Env.dev_env?(),
     only: ~w(assets fonts images favicon.ico robots.txt)
 
   # Code reloading can be explicitly enabled under the
@@ -31,9 +30,11 @@ defmodule ControlServerWeb.Endpoint do
     plug Phoenix.Ecto.CheckRepoStatus, otp_app: :control_server_web
   end
 
-  plug Phoenix.LiveDashboard.RequestLogger,
-    param_key: "request_logger",
-    cookie_key: "request_logger"
+  if CommonCore.Env.dev_env?() do
+    plug Phoenix.LiveDashboard.RequestLogger,
+      param_key: "request_logger",
+      cookie_key: "request_logger"
+  end
 
   plug Plug.RequestId
   plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint]

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/router.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/router.ex
@@ -3,6 +3,8 @@ defmodule ControlServerWeb.Router do
 
   import Phoenix.LiveDashboard.Router
 
+  require CommonCore.Env
+
   pipeline :browser do
     plug :accepts, ["html"]
     plug :fetch_session
@@ -236,7 +238,7 @@ defmodule ControlServerWeb.Router do
     resources "/notebooks/jupyter_lab_notebooks", JupyterLabNotebookController, except: [:new, :edit]
   end
 
-  if Enum.member?([:dev, :test], Mix.env()) do
+  if CommonCore.Env.dev_env?() do
     # Enables LiveDashboard only for development
     scope "/dev" do
       pipe_through :browser

--- a/platform_umbrella/apps/home_base_web/lib/home_base_web/endpoint.ex
+++ b/platform_umbrella/apps/home_base_web/lib/home_base_web/endpoint.ex
@@ -1,6 +1,8 @@
 defmodule HomeBaseWeb.Endpoint do
   use Phoenix.Endpoint, otp_app: :home_base_web
 
+  require CommonCore.Env
+
   # The session will be stored in the cookie and signed,
   # this means its contents can be read but not tampered with.
   # Set :encryption_salt if you would also like to encrypt it.
@@ -14,13 +16,10 @@ defmodule HomeBaseWeb.Endpoint do
   socket "/live", Phoenix.LiveView.Socket, websocket: [connect_info: [session: @session_options]]
 
   # Serve at "/" the static files from "priv/static" directory.
-  #
-  # You should set gzip to true if you are running phx.digest
-  # when deploying your static files in production.
   plug Plug.Static,
     at: "/",
     from: :home_base_web,
-    gzip: false,
+    gzip: !CommonCore.Env.dev_env?(),
     only: HomeBaseWeb.static_paths()
 
   # Code reloading can be explicitly enabled under the
@@ -32,9 +31,11 @@ defmodule HomeBaseWeb.Endpoint do
     plug Phoenix.Ecto.CheckRepoStatus, otp_app: :home_base_web
   end
 
-  plug Phoenix.LiveDashboard.RequestLogger,
-    param_key: "request_logger",
-    cookie_key: "request_logger"
+  if CommonCore.Env.dev_env?() do
+    plug Phoenix.LiveDashboard.RequestLogger,
+      param_key: "request_logger",
+      cookie_key: "request_logger"
+  end
 
   plug Plug.RequestId
   plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint]


### PR DESCRIPTION
Summary:

Right now if we try and tail the logs of the control server on
kubernetes it errors out asking about encoding. That log message is a
debug log about phoenix request time to open up the live view socket. So
this is an attempt to remedy that.

- Don't include some plugs in non-dev endpoints
- Set LANG ang LC_ALL early in the process. Don't do that over and over
  again. Simplufy and share it everywhere
- localedev and update-local in addition.

Test Plan:
`bix build-image` for control-server and others
Then let CI take it
