### PR TITLE
feat: add a way to specify a batteries included admin team

### DIFF
--- a/platform_umbrella/apps/common_core/test/support/mocks.ex
+++ b/platform_umbrella/apps/common_core/test/support/mocks.ex
@@ -1,0 +1,4 @@
+{:ok, _} = Application.ensure_all_started(:mox)
+
+Mox.defmock(CommonCore.Keycloak.TeslaMock, for: Tesla.Adapter)
+Mox.defmock(CommonCore.JWK.LoaderMock, for: CommonCore.JWK.Loader)

--- a/platform_umbrella/apps/common_core/test/test_helper.exs
+++ b/platform_umbrella/apps/common_core/test/test_helper.exs
@@ -1,5 +1,5 @@
-Application.ensure_all_started(:mox)
-Mox.defmock(CommonCore.Keycloak.TeslaMock, for: Tesla.Adapter)
-Mox.defmock(CommonCore.JWK.LoaderMock, for: CommonCore.JWK.Loader)
+{:ok, _} = Application.ensure_all_started(:mox)
+{:ok, _} = Application.ensure_all_started(:ex_machina)
+
 ExUnit.configure(formatters: [JUnitFormatter, ExUnit.CLIFormatter])
 ExUnit.start()

--- a/platform_umbrella/apps/home_base/lib/home_base/accounts/admin_teams/admin_teams.ex
+++ b/platform_umbrella/apps/home_base/lib/home_base/accounts/admin_teams/admin_teams.ex
@@ -1,0 +1,64 @@
+defmodule HomeBase.Accounts.AdminTeams do
+  @moduledoc """
+  This module provides which teams are
+  considered admin teams for batteries
+  inclued home base.
+
+
+  For prodution environment, the admin teams are defined by setting
+  the environment variable `BATTERY_TEAM_IDS` to a comma-separated list of team ids (battery uuids).
+
+  For development and test environments, we assume that the team from
+  the bootstrap'd team.json file is the admin. However we also
+  include the team ids from the `BATTERY_TEAM_IDS` environment
+  variable. This should allows test teams in development.
+
+  It is important however that production never uses the team.json
+  file since we don't want to police the chance that it's
+  created nefaiously.
+  """
+  alias CommonCore.Ecto.BatteryUUID
+  alias CommonCore.Teams.Team
+  alias HomeBase.Accounts.AdminTeams.EnvFetcher
+
+  require CommonCore.Env
+
+  @relative_path "../../../../bootstrap/team.json"
+
+  @team_path :home_base
+             |> :code.priv_dir()
+             |> Path.join(@relative_path)
+
+  @file_content @team_path
+                |> File.read!()
+                |> Jason.decode!()
+                |> Team.new!()
+
+  def bootstrap_team do
+    @file_content
+  end
+
+  def admin_team_ids do
+    admin_team_ids(CommonCore.Env.dev_env?())
+  end
+
+  defp admin_team_ids(true = _is_dev) do
+    environment_team_ids() ++ [bootstrap_team().id]
+  end
+
+  defp admin_team_ids(_is_dev) do
+    environment_team_ids()
+  end
+
+  defp environment_team_ids do
+    # Take the environment variable and split it by commas
+    # then cast each value to a BatteryUUID
+    # keep only the {:ok, _} values
+    EnvFetcher.get_env()
+    |> String.split(",")
+    |> Enum.map(&BatteryUUID.cast/1)
+    |> Enum.filter(&match?({:ok, _}, &1))
+    |> Enum.map(fn {:ok, id} -> id end)
+    |> Enum.filter(&(is_nil(&1) == false))
+  end
+end

--- a/platform_umbrella/apps/home_base/lib/home_base/accounts/admin_teams/default_env_fetcher.ex
+++ b/platform_umbrella/apps/home_base/lib/home_base/accounts/admin_teams/default_env_fetcher.ex
@@ -1,0 +1,11 @@
+defmodule HomeBase.Accounts.AdminTeams.DefaultEnvFetcher do
+  @moduledoc false
+  @behaviour HomeBase.Accounts.AdminTeams.EnvFetcher
+
+  @key "BATTERY_TEAM_IDS"
+  @spec get_env() :: String.t()
+  def get_env, do: System.get_env(key(), "")
+
+  @spec key() :: String.t()
+  def key, do: @key
+end

--- a/platform_umbrella/apps/home_base/lib/home_base/accounts/admin_teams/env_fetcher.ex
+++ b/platform_umbrella/apps/home_base/lib/home_base/accounts/admin_teams/env_fetcher.ex
@@ -1,0 +1,21 @@
+defmodule HomeBase.Accounts.AdminTeams.EnvFetcher do
+  @moduledoc false
+  alias HomeBase.Accounts.AdminTeams.DefaultEnvFetcher
+
+  @callback get_env() :: String.t()
+  @callback key() :: String.t()
+
+  def impl do
+    :home_base
+    |> Application.get_env(HomeBase.Accounts.AdminTeams, [])
+    |> Keyword.get(:env_fetcher, DefaultEnvFetcher)
+  end
+
+  def get_env do
+    impl().get_env()
+  end
+
+  def key do
+    impl().key()
+  end
+end

--- a/platform_umbrella/apps/home_base/mix.exs
+++ b/platform_umbrella/apps/home_base/mix.exs
@@ -29,7 +29,7 @@ defmodule HomeBase.MixProject do
   end
 
   # Specifies which paths to compile per environment.
-  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(:test), do: ["test/support", "lib"]
   defp elixirc_paths(_), do: ["lib"]
 
   defp test_paths(:test), do: ["test"]
@@ -44,6 +44,7 @@ defmodule HomeBase.MixProject do
       {:ecto_sql, "~> 3.11"},
       {:ex_audit, "~> 0.10"},
       {:ex_machina, "~> 2.7", only: [:dev, :test]},
+      {:mox, "~> 1.0", only: [:dev, :test], runtime: false},
       {:jason, "~> 1.4"},
       {:mnemonic_slugs, "~> 0.0.3"},
       {:phoenix_ecto, "~> 4.6"},

--- a/platform_umbrella/apps/home_base/test/home_base/admin_team_test.exs
+++ b/platform_umbrella/apps/home_base/test/home_base/admin_team_test.exs
@@ -1,0 +1,34 @@
+defmodule HomeBase.AdminTeamTest do
+  use ExUnit.Case, async: false
+
+  import Mox
+
+  alias CommonCore.Ecto.BatteryUUID
+  alias HomeBase.Accounts.AdminTeams
+  alias HomeBase.Accounts.AdminTeams.EnvFetcherMock
+
+  describe "admin_team_ids/0" do
+    test "returns the expected development admin team ids" do
+      assert AdminTeams.admin_team_ids() == [AdminTeams.bootstrap_team().id]
+    end
+  end
+
+  describe "using env" do
+    setup :verify_on_exit!
+
+    setup do
+      old_env = Application.get_env(:home_base, HomeBase.Accounts.AdminTeams, [])
+      new_env = Keyword.put(old_env, :env_fetcher, EnvFetcherMock)
+
+      Application.put_env(:home_base, HomeBase.Accounts.AdminTeams, new_env)
+      on_exit(fn -> Application.put_env(:home_base, HomeBase.Accounts.AdminTeams, old_env) end)
+    end
+
+    test "includes the environment team ids" do
+      id = "batt_ca695f31d27c44159d9e079ccb37d9f7"
+      {:ok, battery_id} = BatteryUUID.cast(id)
+      expect(EnvFetcherMock, :get_env, fn -> id end)
+      assert AdminTeams.admin_team_ids() == [battery_id, AdminTeams.bootstrap_team().id]
+    end
+  end
+end

--- a/platform_umbrella/apps/home_base/test/support/mocks.ex
+++ b/platform_umbrella/apps/home_base/test/support/mocks.ex
@@ -1,0 +1,2 @@
+{:ok, _} = Application.ensure_all_started(:mox)
+Mox.defmock(HomeBase.Accounts.AdminTeams.EnvFetcherMock, for: HomeBase.Accounts.AdminTeams.EnvFetcher)

--- a/platform_umbrella/apps/home_base/test/test_helper.exs
+++ b/platform_umbrella/apps/home_base/test/test_helper.exs
@@ -1,3 +1,4 @@
+{:ok, _} = Application.ensure_all_started(:mox)
 {:ok, _} = Application.ensure_all_started(:ex_machina)
 
 ExUnit.configure(formatters: [JUnitFormatter, ExUnit.CLIFormatter])


### PR DESCRIPTION
Summary:
Since we can pick a team per session we can then use a comparison of if
the users's current team id is inside the admin team ids list

Test Plan:
Use it later to create an admin UI
Tests added
