### PR TITLE
fix(knative): use released version(s)

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/defaults/images.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/defaults/images.ex
@@ -8,8 +8,8 @@ defmodule CommonCore.Defaults.Images do
   @cert_manager_allowed_tags ~w(v1.15.1)
   @cert_manager_default_tag "v1.15.1"
 
-  @knative_allowed_tags ~w(v1.15.1 v1.15.2 v1.15.3)
-  @knative_default_tag "v1.15.3"
+  @knative_allowed_tags ~w(v1.15.1 v1.15.2)
+  @knative_default_tag "v1.15.2"
 
   @knative_istio_allowed_tags ~w(v1.15.1)
   @knative_istio_default_tag "v1.15.1"


### PR DESCRIPTION
v1.15.3 isn't released yet so roll back to 1.15.2.