### PR TITLE
fix: don't error about podman missing

### DIFF
--- a/bi/pkg/specs/print.go
+++ b/bi/pkg/specs/print.go
@@ -54,10 +54,7 @@ func (spec *InstallSpec) PrintAccessInfo(ctx context.Context, kubeClient kube.Ku
 		return err
 	}
 
-	podman, err := kind.IsPodmanAvailable()
-	if err != nil {
-		return err
-	}
+	podman, _ := kind.IsPodmanAvailable()
 
 	if dockerDesktop || podman {
 		fmt.Printf(


### PR DESCRIPTION
Summary:
If podman is missing don't error out. We assume false for
`IsPodmanAvailable` if podman info doesn't return success

Test Plan:
Tried it
