### PR TITLE
build: allow using the already built bi via bix

### DIFF
--- a/bin/bix
+++ b/bin/bix
@@ -78,6 +78,7 @@ Available commands:
 - set-version       Change the version of the project in mix.exs and bin/bix
 
 **Go Commands**
+- bi                Run the bi binary
 - go-build-bi       Build the bi binary
 - go-test           Run go tests
 - go-test-int       Run go integration tests
@@ -595,6 +596,13 @@ do_ensure_bi() {
     fi
 }
 
+do_bi() {
+    local args=("$@")
+    local bin_path
+    log "Running bi with args: ${args[*]}"
+    run_bi "${args[@]}"
+}
+
 parse_params() {
     while :; do
         case "${1-}" in
@@ -652,6 +660,9 @@ dev)
     ;;
 phx-server)
     do_phx_server
+    ;;
+bi)
+    do_bi "${args[@]}"
     ;;
 go-update-deps)
     do_go_update_deps


### PR DESCRIPTION
Summary:
Don't make developers go run to use the go code.

Test Plan:

```
➜  batteries-included git:(elliott/bix_bi) ✗ bix bi --help
[2024-09-12T14:06:52-0500]: Running bi with args: --help
An all in one cli for installing and
debugging Batteries Included infrastructure
on top of kubernetes

Usage:
  bi [command]

Available Commands:
  aws         Commands to AWS kubertnetes clusters
  completion  Generate the autocompletion script for the specified shell
  debug       Utilities for debugging
  help        Help about any command
  postgres    Tools to interact with postgres databases
  rage        Collect debug information when things go wrong
  start       Start a Batteries Included Installation
  stop        Stop the Batteries Included Installation
  vpn         Manage the WireGuard VPN for a batteries included environment

Flags:
  -c, --color              Use color in logs (default true)
      --config string      config file (default is $XDG_CONFIG_HOME/bi/bi.yaml)
  -h, --help               help for bi
  -v, --verbosity string   Log level (debug, info, warn, error (default "WARN")

Use "bi [command] --help" for more information about a command.
```
