### PR TITLE
fix(bix): don't remove team.json when gen'ing specs

### DIFF
--- a/bin/bix
+++ b/bin/bix
@@ -358,7 +358,7 @@ do_check_fmt() {
 }
 
 do_gen_static_specs() {
-    rm -rf "${ROOT_DIR}/bootstrap"
+    rm -rf "${ROOT_DIR}/bootstrap/*.{spec,install}.json"
     # VERSION_OVERRIDE generates different bytecode for
     # the current version. We don't want that to be left
     # around for developers. It makes tests fail.


### PR DESCRIPTION
```
== Compilation error in file lib/home_base/accounts/admin_teams/admin_teams.ex ==
** (File.Error) could not read file "/home/jason/Development/bi/batteries-included/platform_umbrella/_build/dev/lib/home_base/priv/../../../../bootstrap/team.json": no such file or directory
    (elixir 1.17.2) lib/file.ex:385: File.read!/1
    lib/home_base/accounts/admin_teams/admin_teams.ex:33: (module)
```