### PR TITLE
fix(keycloak): prevent flapping on client update

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/state_summary/keycloak_summary.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/state_summary/keycloak_summary.ex
@@ -109,7 +109,8 @@ defmodule CommonCore.StateSummary.KeycloakSummary do
 
   defp scrub_client(client, _fields) when is_nil(client), do: nil
 
-  defp scrub_client(client, fields) do
-    Map.take(client, fields)
-  end
+  defp scrub_client(client, fields), do: client |> Map.take(fields) |> Map.new(fn f -> normalize_field(f) end)
+
+  defp normalize_field({key, val}) when is_list(val), do: {key, Enum.sort(val)}
+  defp normalize_field({_key, _val} = field), do: field
 end


### PR DESCRIPTION
We're flapping with multiple hosts as we have a different ordering of the redirect URIs than keycloak. Functionally, there's no difference but we try to update the client every time. Fix this by ordering client list fields.