### PR TITLE
Move AdminTeams logic to Common Core

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/accounts/admin_teams.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/accounts/admin_teams.ex
@@ -1,12 +1,11 @@
-defmodule HomeBase.Accounts.AdminTeams do
+defmodule CommonCore.Accounts.AdminTeams do
   @moduledoc """
-  This module provides which teams are
-  considered admin teams for batteries
-  inclued home base.
-
+  This module provides which teams are considered admin teams for
+  Batteries Inclued home base.
 
   For prodution environment, the admin teams are defined by setting
-  the environment variable `BATTERY_TEAM_IDS` to a comma-separated list of team ids (battery uuids).
+  the environment variable `BATTERY_TEAM_IDS` to a comma-separated list
+  of team ids (battery uuids).
 
   For development and test environments, we assume that the team from
   the bootstrap'd team.json file is the admin. However we also
@@ -17,15 +16,16 @@ defmodule HomeBase.Accounts.AdminTeams do
   file since we don't want to police the chance that it's
   created nefaiously.
   """
+  alias CommonCore.Accounts.EnvFetcher
   alias CommonCore.Ecto.BatteryUUID
   alias CommonCore.Teams.Team
-  alias HomeBase.Accounts.AdminTeams.EnvFetcher
+  alias CommonCore.Teams.TeamRole
 
   require CommonCore.Env
 
   @relative_path "../../../../bootstrap/team.json"
 
-  @team_path :home_base
+  @team_path :common_core
              |> :code.priv_dir()
              |> Path.join(@relative_path)
 
@@ -34,9 +34,13 @@ defmodule HomeBase.Accounts.AdminTeams do
                 |> Jason.decode!()
                 |> Team.new!()
 
-  def bootstrap_team do
-    @file_content
+  def bootstrap_team, do: @file_content
+
+  def batteries_included_admin?(%TeamRole{team_id: team_id}) when not is_nil(team_id) do
+    Enum.member?(admin_team_ids(), team_id)
   end
+
+  def batteries_included_admin?(_role), do: false
 
   def admin_team_ids do
     admin_team_ids(CommonCore.Env.dev_env?())

--- a/platform_umbrella/apps/common_core/lib/common_core/accounts/default_env_fetcher.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/accounts/default_env_fetcher.ex
@@ -1,6 +1,6 @@
-defmodule HomeBase.Accounts.AdminTeams.DefaultEnvFetcher do
+defmodule CommonCore.Accounts.DefaultEnvFetcher do
   @moduledoc false
-  @behaviour HomeBase.Accounts.AdminTeams.EnvFetcher
+  @behaviour CommonCore.Accounts.EnvFetcher
 
   @key "BATTERY_TEAM_IDS"
   @spec get_env() :: String.t()

--- a/platform_umbrella/apps/common_core/lib/common_core/accounts/env_fetcher.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/accounts/env_fetcher.ex
@@ -1,13 +1,13 @@
-defmodule HomeBase.Accounts.AdminTeams.EnvFetcher do
+defmodule CommonCore.Accounts.EnvFetcher do
   @moduledoc false
-  alias HomeBase.Accounts.AdminTeams.DefaultEnvFetcher
+  alias CommonCore.Accounts.DefaultEnvFetcher
 
   @callback get_env() :: String.t()
   @callback key() :: String.t()
 
   def impl do
-    :home_base
-    |> Application.get_env(HomeBase.Accounts.AdminTeams, [])
+    :common_core
+    |> Application.get_env(CommonCore.Accounts.AdminTeams, [])
     |> Keyword.get(:env_fetcher, DefaultEnvFetcher)
   end
 

--- a/platform_umbrella/apps/common_core/lib/common_core/installs/options.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/installs/options.ex
@@ -1,7 +1,7 @@
 defmodule CommonCore.Installs.Options do
   @moduledoc false
 
-  alias CommonCore.Teams.TeamRole
+  alias CommonCore.Accounts.AdminTeams
 
   @sizes [:tiny, :small, :medium, :large, :xlarge, :huge]
   @providers [Kind: :kind, AWS: :aws, Provided: :provided]
@@ -14,17 +14,16 @@ defmodule CommonCore.Installs.Options do
     Production: :production
   ]
 
-  def usages do
-    @usages
-  end
+  def usages, do: @usages
 
-  # TODO: Add batteries included team ID that is allowed to create internal installations
-  def usage_options(%TeamRole{id: "INTERNAL_TEAM_ID"}), do: @usages
-
-  def usage_options(_role) do
-    Enum.reject(@usages, fn {key, _} ->
-      key |> Atom.to_string() |> String.starts_with?("Internal")
-    end)
+  def usage_options(role) do
+    if AdminTeams.batteries_included_admin?(role) do
+      @usages
+    else
+      Enum.reject(@usages, fn {key, _} ->
+        key |> Atom.to_string() |> String.starts_with?("Internal")
+      end)
+    end
   end
 
   def sizes do

--- a/platform_umbrella/apps/common_core/test/common_core/accounts/admin_team_test.exs
+++ b/platform_umbrella/apps/common_core/test/common_core/accounts/admin_team_test.exs
@@ -1,11 +1,11 @@
-defmodule HomeBase.AdminTeamTest do
+defmodule CommonCore.AdminTeamTest do
   use ExUnit.Case, async: false
 
   import Mox
 
+  alias CommonCore.Accounts.AdminTeams
+  alias CommonCore.Accounts.EnvFetcherMock
   alias CommonCore.Ecto.BatteryUUID
-  alias HomeBase.Accounts.AdminTeams
-  alias HomeBase.Accounts.AdminTeams.EnvFetcherMock
 
   describe "admin_team_ids/0" do
     test "returns the expected development admin team ids" do
@@ -17,11 +17,11 @@ defmodule HomeBase.AdminTeamTest do
     setup :verify_on_exit!
 
     setup do
-      old_env = Application.get_env(:home_base, HomeBase.Accounts.AdminTeams, [])
+      old_env = Application.get_env(:common_core, AdminTeams, [])
       new_env = Keyword.put(old_env, :env_fetcher, EnvFetcherMock)
 
-      Application.put_env(:home_base, HomeBase.Accounts.AdminTeams, new_env)
-      on_exit(fn -> Application.put_env(:home_base, HomeBase.Accounts.AdminTeams, old_env) end)
+      Application.put_env(:common_core, AdminTeams, new_env)
+      on_exit(fn -> Application.put_env(:common_core, AdminTeams, old_env) end)
     end
 
     test "includes the environment team ids" do

--- a/platform_umbrella/apps/common_core/test/support/mocks.ex
+++ b/platform_umbrella/apps/common_core/test/support/mocks.ex
@@ -2,3 +2,4 @@
 
 Mox.defmock(CommonCore.Keycloak.TeslaMock, for: Tesla.Adapter)
 Mox.defmock(CommonCore.JWK.LoaderMock, for: CommonCore.JWK.Loader)
+Mox.defmock(CommonCore.Accounts.EnvFetcherMock, for: CommonCore.Accounts.EnvFetcher)

--- a/platform_umbrella/apps/home_base/lib/mix/tasks/admin.ex
+++ b/platform_umbrella/apps/home_base/lib/mix/tasks/admin.ex
@@ -6,8 +6,8 @@ defmodule Mix.Tasks.HomeBase.Admin do
 
   use Mix.Task
 
+  alias CommonCore.Accounts.AdminTeams
   alias HomeBase.Accounts
-  alias HomeBase.Accounts.AdminTeams
   alias HomeBase.Teams
 
   @shutdown {:shutdown, 1}

--- a/platform_umbrella/apps/home_base/test/support/mocks.ex
+++ b/platform_umbrella/apps/home_base/test/support/mocks.ex
@@ -1,2 +1,1 @@
 {:ok, _} = Application.ensure_all_started(:mox)
-Mox.defmock(HomeBase.Accounts.AdminTeams.EnvFetcherMock, for: HomeBase.Accounts.AdminTeams.EnvFetcher)


### PR DESCRIPTION
This PR moves all the AdminTeams logic into common_core so it can be used with the Installation usage options (which return the internal options for BI admins).