### PR TITLE
refactor: only send pods that are in the battery- namespaces

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/et/namespace_report.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/et/namespace_report.ex
@@ -7,6 +7,7 @@ defmodule CommonCore.ET.NamespaceReport do
   alias CommonCore.Ecto.Schema
   alias CommonCore.Resources.FieldAccessors
   alias CommonCore.StateSummary
+  alias CommonCore.StateSummary.Namespaces
 
   batt_embedded_schema do
     field :pod_counts, :map
@@ -14,8 +15,9 @@ defmodule CommonCore.ET.NamespaceReport do
 
   def new(%StateSummary{} = state_summary) do
     pod_counts = count_pods_by(state_summary, &FieldAccessors.namespace/1)
+    battery_namespaces = Namespaces.all_namespaces(state_summary)
 
-    Schema.schema_new(__MODULE__, pod_counts: pod_counts)
+    Schema.schema_new(__MODULE__, pod_counts: Map.take(pod_counts, battery_namespaces))
   end
 
   def new(opts) do
@@ -23,8 +25,8 @@ defmodule CommonCore.ET.NamespaceReport do
   end
 
   def total_battery_pods(%__MODULE__{pod_counts: pod_counts}) do
-    Enum.reduce(pod_counts, 0, fn {namespace, count}, acc ->
-      if String.starts_with?(namespace, "battery-"), do: acc + count, else: acc
+    Enum.reduce(pod_counts, 0, fn {_namespace, count}, acc ->
+      acc + count
     end)
   end
 

--- a/platform_umbrella/apps/common_core/lib/common_core/et/node_report.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/et/node_report.ex
@@ -39,7 +39,12 @@ defmodule CommonCore.ET.NodeReport do
         host_ip = pod |> FieldAccessors.status() |> Map.get("hostIP")
 
         node = find_node(nodes, host_ip)
-        if node == nil, do: "unknown", else: FieldAccessors.name(node)
+
+        if node == nil do
+          "unknown"
+        else
+          FieldAccessors.name(node) || host_ip
+        end
       end)
 
     node_count = length(nodes)

--- a/platform_umbrella/apps/common_core/lib/common_core/state_summary/namespaces.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/state_summary/namespaces.ex
@@ -13,6 +13,21 @@ defmodule CommonCore.StateSummary.Namespaces do
   @spec istio_namespace(CommonCore.StateSummary.t()) :: binary() | nil
   def istio_namespace(%StateSummary{} = summary), do: battery_namespace(summary, :istio)
 
+  def all_namespaces(%StateSummary{} = summary) do
+    Enum.reject(
+      [
+        ai_namespace(summary),
+        data_namespace(summary),
+        knative_namespace(summary),
+        traditional_namespace(summary),
+        core_namespace(summary),
+        base_namespace(summary),
+        istio_namespace(summary)
+      ],
+      &is_nil/1
+    )
+  end
+
   #
   # User Namespaces
   # These namespaces exist to put stuff that users will


### PR DESCRIPTION
Summary:
Only configured namespaces are sent for pod reports

Test Plan:
Locally
![image](https://github.com/user-attachments/assets/6c596af0-0441-4b37-964d-8ee27ab41983)

