### PR TITLE
feat: add api to get installation's spec

### DIFF
--- a/platform_umbrella/apps/home_base_web/lib/home_base_web/controllers/install_spec_controller.ex
+++ b/platform_umbrella/apps/home_base_web/lib/home_base_web/controllers/install_spec_controller.ex
@@ -1,0 +1,17 @@
+defmodule HomeBaseWeb.InstallSpecController do
+  use HomeBaseWeb, :controller
+
+  alias HomeBase.CustomerInstalls
+
+  action_fallback HomeBaseWeb.FallbackController
+
+  def show(conn, %{"installation_id" => install_id}) do
+    installation = CustomerInstalls.get_installation!(install_id)
+    {:ok, report} = CommonCore.InstallSpec.new(installation)
+
+    conn
+    |> put_status(:ok)
+    |> put_view(json: HomeBaseWeb.JwtJSON)
+    |> render(:show, jwt: CommonCore.JWK.sign(report))
+  end
+end

--- a/platform_umbrella/apps/home_base_web/lib/home_base_web/controllers/installation_status_controller.ex
+++ b/platform_umbrella/apps/home_base_web/lib/home_base_web/controllers/installation_status_controller.ex
@@ -13,7 +13,10 @@ defmodule HomeBaseWeb.InstallationStatusContoller do
     installation = CustomerInstalls.get_installation!(install_id)
     # One hour when everyone comes back in 9 minutes seems good
     # Adjust when needed
-    exp = DateTime.utc_now() |> DateTime.add(1, :hour) |> DateTime.to_unix()
+    exp =
+      DateTime.utc_now()
+      |> DateTime.add(1, :hour)
+      |> DateTime.to_unix()
 
     # Everything is ok
     status = :ok

--- a/platform_umbrella/apps/home_base_web/lib/home_base_web/router.ex
+++ b/platform_umbrella/apps/home_base_web/lib/home_base_web/router.ex
@@ -103,6 +103,7 @@ defmodule HomeBaseWeb.Router do
       resources "/usage_reports", StoredUsageReportController, only: [:create]
       resources "/host_reports", StoredHostReportController, only: [:create]
       get "/status", InstallationStatusContoller, :show
+      get "/spec", InstallSpecController, :show
     end
   end
 


### PR DESCRIPTION
Summary:
Get this from http

Test Plan:
curl http://home.127-0-0-1.batrsinc.co:4100/api/v1/installations/batt_0191f28be0a478c592c5aee6e35dff3e/spec
