### PR TITLE
ci: bi release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+
+env:
+  GOCACHE: /home/runner/.cache/go-cache
+  GOMODCACHE: /home/runner/.cache/go-mod
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup ASDF
+        uses: asdf-vm/actions/setup@v3
+
+      - name: Cache ASDF
+        uses: actions/cache@v4
+        id: asdf-cache
+        with:
+          # https://github.com/asdf-vm/asdf/blob/master/.gitignore
+          path: |
+            ~/.asdf/installs
+            ~/.asdf/plugins
+            ~/.asdf/shims
+          key: ${{ runner.os }}-asdf-tools-${{ hashFiles('.tool-versions') }}
+          restore-keys: ${{ runner.os }}-asdf-tools-
+
+      - name: Install ASDF Tools
+        uses: asdf-vm/actions/install@v3
+        # See https://github.com/asdf-vm/actions/issues/445
+        if: ${{ steps.asdf-cache.outputs.cache-hit != 'true' }}
+        with:
+          asdf_branch: v0.14.0
+
+      - name: Reshim ASDF
+        shell: bash
+        run: asdf reshim
+
+      - name: Setup Go cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ env.GOCACHE }}
+            ${{ env.GOMODCACHE }}
+          key:
+            ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum',
+            '.tool-versions') }}
+          restore-keys: |
+            ${{ runner.os }}-go-build-
+
+      - name: Release
+        run: goreleaser release --clean --verbose
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,50 @@
+version: 2
+
+builds:
+  - binary: bi
+    dir: bi
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+
+    tags:
+      - netgo
+      - osusergo
+      - static_build
+
+    flags:
+      - -trimpath
+
+    ldflags:
+      - -w -s -X 'bi/pkg.Version={{.Version}}'
+
+archives:
+  - format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: >-
+      {{ .ProjectName }}_ {{- title .Os }}_ {{- if eq .Arch "amd64" }}x86_64 {{-
+      else if eq .Arch "386" }}i386 {{- else }}{{ .Arch }}{{ end }} {{- if .Arm
+      }}v{{ .Arm }}{{ end }}
+
+    # use zip for windows archives
+    format_overrides:
+      - goos: windows
+        format: zip
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+
+snapshot:
+  version_template: '{{ .Version }}-{{.ShortCommit}}'
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj

--- a/.tool-versions
+++ b/.tool-versions
@@ -2,6 +2,7 @@ awscli 2.17.44
 elixir 1.17.2-otp-27
 erlang 27.0.1
 golang 1.23.1
+goreleaser 2.3.2
 kind 0.24.0
 kubectl 1.31.0
 nodejs 22.8.0

--- a/bin/bix
+++ b/bin/bix
@@ -570,10 +570,7 @@ do_ex_dialyzer() {
 }
 
 do_go_build_bi() {
-    build_bi_final "linux" "amd64"
-    build_bi_final "linux" "arm64"
-    build_bi_final "windows" "amd64"
-    build_bi_final "darwin" "arm64"
+    goreleaser release --clean --snapshot ${TRACE:+--verbose}
 }
 
 do_bi_location() {


### PR DESCRIPTION
This consolidates the go build logic into a single tool that will also release to Github when we create a tag.