### PR TITLE
add: ollama and traditional services

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/et/ollama_report.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/et/ollama_report.ex
@@ -1,0 +1,35 @@
+defmodule CommonCore.ET.OllamaReport do
+  @moduledoc false
+
+  use CommonCore, :embedded_schema
+
+  alias CommonCore.Ecto.Schema
+  alias CommonCore.StateSummary
+
+  batt_embedded_schema do
+    field :model_counts, :map
+    field :instance_counts, :map
+  end
+
+  def new(%StateSummary{model_instances: model_instances} = _state_summary) do
+    model_counts =
+      model_instances
+      |> Enum.map(fn instance -> instance.model end)
+      |> Enum.group_by(& &1)
+      |> Map.new(fn {model, instances} -> {model, Enum.count(instances)} end)
+
+    instance_counts =
+      Map.new(model_instances, fn instance ->
+        {instance.model, instance.num_instances}
+      end)
+
+    Schema.schema_new(__MODULE__,
+      model_counts: model_counts,
+      instance_counts: instance_counts
+    )
+  end
+
+  def new(opts) do
+    Schema.schema_new(__MODULE__, opts)
+  end
+end

--- a/platform_umbrella/apps/common_core/lib/common_core/et/traditional_services_report.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/et/traditional_services_report.ex
@@ -1,0 +1,25 @@
+defmodule CommonCore.ET.TraditionalServicesReport do
+  @moduledoc false
+
+  use CommonCore, :embedded_schema
+
+  alias CommonCore.Ecto.Schema
+  alias CommonCore.StateSummary
+
+  batt_embedded_schema do
+    field :instance_counts, :map
+  end
+
+  def new(%StateSummary{traditional_services: services} = _state_summary) do
+    instance_counts =
+      Map.new(services, fn service ->
+        {service.name, service.num_instances}
+      end)
+
+    Schema.schema_new(__MODULE__, instance_counts: instance_counts)
+  end
+
+  def new(opts) do
+    Schema.schema_new(__MODULE__, opts)
+  end
+end

--- a/platform_umbrella/apps/common_core/lib/common_core/et/usage_report.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/et/usage_report.ex
@@ -12,7 +12,7 @@ defmodule CommonCore.ET.UsageReport do
   alias CommonCore.ET.TraditionalServicesReport
   alias CommonCore.StateSummary
 
-  @required_fields ~w(node_report namespace_report postgres_report redis_report num_projects batteries knative_report traditional_services_report)a
+  @required_fields ~w(node_report namespace_report postgres_report redis_report num_projects batteries knative_report traditional_services_report ollama_report)a
 
   batt_embedded_schema do
     embeds_one :node_report, NodeReport

--- a/platform_umbrella/apps/common_core/lib/common_core/et/usage_report.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/et/usage_report.ex
@@ -6,11 +6,13 @@ defmodule CommonCore.ET.UsageReport do
   alias CommonCore.ET.KnativeReport
   alias CommonCore.ET.NamespaceReport
   alias CommonCore.ET.NodeReport
+  alias CommonCore.ET.OllamaReport
   alias CommonCore.ET.PostgresReport
   alias CommonCore.ET.RedisReport
+  alias CommonCore.ET.TraditionalServicesReport
   alias CommonCore.StateSummary
 
-  @required_fields ~w(node_report namespace_report postgres_report redis_report num_projects batteries knative_report)a
+  @required_fields ~w(node_report namespace_report postgres_report redis_report num_projects batteries knative_report traditional_services_report)a
 
   batt_embedded_schema do
     embeds_one :node_report, NodeReport
@@ -18,6 +20,8 @@ defmodule CommonCore.ET.UsageReport do
     embeds_one :postgres_report, PostgresReport
     embeds_one :redis_report, RedisReport
     embeds_one :knative_report, KnativeReport
+    embeds_one :traditional_services_report, TraditionalServicesReport
+    embeds_one :ollama_report, OllamaReport
 
     field :batteries, {:array, :string}
     field :num_projects, :integer
@@ -28,7 +32,9 @@ defmodule CommonCore.ET.UsageReport do
          {:ok, namespace_report} <- NamespaceReport.new(state_summary),
          {:ok, postgres_report} <- PostgresReport.new(state_summary),
          {:ok, redis_report} <- RedisReport.new(state_summary),
-         {:ok, knative_report} <- KnativeReport.new(state_summary) do
+         {:ok, knative_report} <- KnativeReport.new(state_summary),
+         {:ok, traditional_services_report} <- TraditionalServicesReport.new(state_summary),
+         {:ok, ollama_report} <- OllamaReport.new(state_summary) do
       battery_names = batteries(state_summary)
 
       Schema.schema_new(__MODULE__,
@@ -38,6 +44,8 @@ defmodule CommonCore.ET.UsageReport do
         redis_report: redis_report,
         num_projects: length(state_summary.projects || []),
         knative_report: knative_report,
+        traditional_services_report: traditional_services_report,
+        ollama_report: ollama_report,
         batteries: battery_names
       )
     end

--- a/platform_umbrella/apps/common_core/test/common_core/et/usage_report_test.exs
+++ b/platform_umbrella/apps/common_core/test/common_core/et/usage_report_test.exs
@@ -5,8 +5,10 @@ defmodule CommonCore.ET.UsageReportTest do
   alias CommonCore.ET.KnativeReport
   alias CommonCore.ET.NamespaceReport
   alias CommonCore.ET.NodeReport
+  alias CommonCore.ET.OllamaReport
   alias CommonCore.ET.PostgresReport
   alias CommonCore.ET.RedisReport
+  alias CommonCore.ET.TraditionalServicesReport
   alias CommonCore.ET.UsageReport
   alias CommonCore.Projects.Project
   alias CommonCore.StateSummary
@@ -41,6 +43,8 @@ defmodule CommonCore.ET.UsageReportTest do
       postgres_report: %PostgresReport{},
       redis_report: %RedisReport{},
       knative_report: %KnativeReport{},
+      traditional_services_report: %TraditionalServicesReport{},
+      ollama_report: %OllamaReport{},
       num_projects: 2,
       batteries: ["istio", "loki"]
     }

--- a/platform_umbrella/apps/common_core/test/support/factory.ex
+++ b/platform_umbrella/apps/common_core/test/support/factory.ex
@@ -89,6 +89,11 @@ defmodule CommonCore.Factory do
     redis_report = Map.get_lazy(attrs, :redis_report, fn -> redis_report_factory() end)
     knative_report = Map.get_lazy(attrs, :knative_report, fn -> knative_report_factory() end)
 
+    traditional_services_report =
+      Map.get_lazy(attrs, :traditional_services_report, fn -> traditional_services_report_factory() end)
+
+    ollama_report = Map.get_lazy(attrs, :ollama_report, fn -> ollama_report_factory() end)
+
     %CommonCore.ET.UsageReport{
       batteries: batteries,
       num_projects: 0,
@@ -96,7 +101,9 @@ defmodule CommonCore.Factory do
       namespace_report: namespace_report,
       postgres_report: postgres_report,
       redis_report: redis_report,
-      knative_report: knative_report
+      knative_report: knative_report,
+      traditional_services_report: traditional_services_report,
+      ollama_report: ollama_report
     }
   end
 
@@ -146,6 +153,22 @@ defmodule CommonCore.Factory do
         "service-one" => 1,
         "another" => 0
       }
+    }
+  end
+
+  def traditional_services_report_factory do
+    %CommonCore.ET.TraditionalServicesReport{
+      instance_counts: %{
+        "service-one" => 1,
+        "another" => 0
+      }
+    }
+  end
+
+  def ollama_report_factory do
+    %CommonCore.ET.OllamaReport{
+      instance_counts: %{"model-instance-one" => 1},
+      model_counts: %{"llama3.1" => 1}
     }
   end
 


### PR DESCRIPTION
Summary:
Add reports for Ollama and TraditionalServices

Test Plan:
`mix test`
