### PR TITLE
docs: add the needed asdf plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ asdf plugin add erlang
 asdf plugin add elixir
 asdf plugin add nodejs
 asdf plugin add golang
+asdf plugin add goreleaser
 asdf plugin add kubectl
 asdf plugin add shfmt
 asdf plugin add awscli


### PR DESCRIPTION
Summary:
We user goreleaser for building the go binary `bi`

Test Plan:
asdf install
