### PR TITLE
fix: correctly require batteries inlcluded team for /admin

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/accounts/admin_teams.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/accounts/admin_teams.ex
@@ -17,6 +17,7 @@ defmodule CommonCore.Accounts.AdminTeams do
   created nefaiously.
   """
   alias CommonCore.Accounts.EnvFetcher
+  alias CommonCore.Accounts.User
   alias CommonCore.Ecto.BatteryUUID
   alias CommonCore.Teams.Team
   alias CommonCore.Teams.TeamRole
@@ -35,6 +36,10 @@ defmodule CommonCore.Accounts.AdminTeams do
                 |> Team.new!()
 
   def bootstrap_team, do: @file_content
+
+  def batteries_included_admin?(%User{roles: roles}) when is_list(roles) do
+    Enum.any?(roles, &batteries_included_admin?/1)
+  end
 
   def batteries_included_admin?(%TeamRole{team_id: team_id}) when not is_nil(team_id) do
     Enum.member?(admin_team_ids(), team_id)

--- a/platform_umbrella/apps/home_base_web/lib/home_base_web/router.ex
+++ b/platform_umbrella/apps/home_base_web/lib/home_base_web/router.ex
@@ -108,7 +108,7 @@ defmodule HomeBaseWeb.Router do
   end
 
   scope "/admin/", HomeBaseWeb do
-    pipe_through [:browser, :app_layout, :require_authenticated_user]
+    pipe_through [:browser, :app_layout, :require_authenticated_user, :require_admin_user]
 
     # TODO: Change this to ensure_admin_team_user
     live_session :admin, layout: @app_layout, on_mount: [@ensure_authenticated_user] do

--- a/platform_umbrella/apps/home_base_web/lib/home_base_web/user_auth.ex
+++ b/platform_umbrella/apps/home_base_web/lib/home_base_web/user_auth.ex
@@ -5,6 +5,7 @@ defmodule HomeBaseWeb.UserAuth do
   import Phoenix.Controller
   import Plug.Conn
 
+  alias CommonCore.Accounts.AdminTeams
   alias HomeBase.Accounts
 
   # Make the remember me cookie valid for 60 days.
@@ -231,6 +232,19 @@ defmodule HomeBaseWeb.UserAuth do
       |> put_flash(:error, "You must log in to access this page")
       |> maybe_store_return_to()
       |> redirect(to: ~p"/login")
+      |> halt()
+    end
+  end
+
+  def require_admin_user(conn, _opts) do
+    current_user = conn.assigns[:current_user]
+
+    if current_user && AdminTeams.batteries_included_admin?(current_user) do
+      conn
+    else
+      conn
+      |> put_flash(:error, "You must be an admin to access this page")
+      |> redirect(to: ~p"/")
       |> halt()
     end
   end


### PR DESCRIPTION
Summary:
- Add a check if a user is a batteriesincl team member
- Use that check to require that users are batteriesincl for /admin

Test Plan:
visited before adding myself, got a redirect
visited after got there.
