### PR TITLE
feat: add read_only_fields to CommonCore.Ecto.Schema

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/aws_loadbalancer_controller_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/aws_loadbalancer_controller_config.ex
@@ -3,6 +3,8 @@ defmodule CommonCore.Batteries.AwsLoadBalancerControllerConfig do
 
   use CommonCore, :embedded_schema
 
+  @read_only_fields ~w(service_role_arn subnets eip_allocations)a
+
   batt_polymorphic_schema type: :aws_load_balancer_controller do
     defaultable_image_field :image, image_id: :aws_load_balancer_controller
     field :service_role_arn, :string

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/battery_core_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/battery_core_config.ex
@@ -9,6 +9,7 @@ defmodule CommonCore.Batteries.BatteryCoreConfig do
   alias CommonCore.Util.Time
 
   @required_fields ~w(cluster_type)a
+  @read_only_fields ~w(install_id core_namespace base_namespace data_namespace ai_namespace usage)a
 
   batt_polymorphic_schema type: :battery_core do
     field :core_namespace, :string, default: Defaults.Namespaces.core()
@@ -46,9 +47,9 @@ defmodule CommonCore.Batteries.BatteryCoreConfig do
     field :upgrade_end_hour, :integer, default: 23
   end
 
-  def changeset(%__MODULE__{} = config, attrs) do
+  def changeset(%__MODULE__{} = config, attrs, opts \\ []) do
     config
-    |> Schema.schema_changeset(attrs)
+    |> Schema.schema_changeset(attrs, opts)
     |> put_upgrade_days_of_week_from_virtual()
   end
 

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/catalog_battery.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/catalog_battery.ex
@@ -29,7 +29,7 @@ defmodule CommonCore.Batteries.CatalogBattery do
       |> Map.put(:id, BatteryUUID.autogenerate())
 
     %SystemBattery{}
-    |> SystemBattery.changeset(args)
-    |> Ecto.Changeset.apply_action!(:create)
+    |> SystemBattery.changeset(args, action: :insert)
+    |> Ecto.Changeset.apply_action!(:insert)
   end
 end

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/forgejo_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/forgejo_config.ex
@@ -4,6 +4,7 @@ defmodule CommonCore.Batteries.ForgejoConfig do
   use CommonCore, {:embedded_schema, no_encode: [:admin_password]}
 
   @required_fields ~w()a
+  @read_only_fields ~w(admin_username admin_password)a
 
   batt_polymorphic_schema type: :forgejo do
     defaultable_image_field :image, image_id: :forgejo

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/grafana_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/grafana_config.ex
@@ -4,6 +4,7 @@ defmodule CommonCore.Batteries.GrafanaConfig do
   use CommonCore, {:embedded_schema, no_encode: [:admin_password]}
 
   @required_fields ~w()a
+  @read_only_fields ~w(admin_password)a
 
   batt_polymorphic_schema type: :grafana do
     defaultable_image_field :image, image_id: :grafana

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/karpenter_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/karpenter_config.ex
@@ -3,6 +3,8 @@ defmodule CommonCore.Batteries.KarpenterConfig do
 
   use CommonCore, :embedded_schema
 
+  @read_only_fields ~w(queue_name service_role_arn node_role_name)a
+
   batt_polymorphic_schema type: :karpenter do
     defaultable_image_field :image, image_id: :karpenter
     field :queue_name, :string

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/keycloak_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/keycloak_config.ex
@@ -4,11 +4,12 @@ defmodule CommonCore.Batteries.KeycloakConfig do
   use CommonCore, {:embedded_schema, no_encode: [:admin_password]}
 
   @required_fields ~w()a
+  @read_only_fields ~w(admin_username admin_password)a
 
   batt_polymorphic_schema type: :keycloak do
     defaultable_image_field :image, image_id: :keycloak
 
-    defaultable_field :admin_username, :string, default: "batteryadmin"
+    field :admin_username, :string, default: "batteryadmin"
     defaultable_field :log_level, :string, default: "info"
     defaultable_field :replicas, :integer, default: 1
     secret_field :admin_password

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/loki_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/loki_config.ex
@@ -11,9 +11,9 @@ defmodule CommonCore.Batteries.LokiConfig do
     defaultable_field :replicas, :integer, default: 1
   end
 
-  def changeset(struct, params \\ %{}) do
+  def changeset(struct, params \\ %{}, opts \\ []) do
     struct
-    |> CommonCore.Ecto.Schema.schema_changeset(params)
+    |> CommonCore.Ecto.Schema.schema_changeset(params, opts)
     |> validate_number(:replication_factor, greater_than: 0, less_than: 99)
     |> validate_number(:replicas, greater_than: 0, less_than: 99)
   end

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/traditional_services_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/traditional_services_config.ex
@@ -5,7 +5,9 @@ defmodule CommonCore.Batteries.TraditionalServicesConfig do
 
   alias CommonCore.Defaults
 
+  @read_only_fields ~w(namespace)a
+
   batt_polymorphic_schema type: :traditional_services do
-    defaultable_field :namespace, :string, default: Defaults.Namespaces.traditional()
+    field :namespace, :string, default: Defaults.Namespaces.traditional()
   end
 end

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/victoria_metrics_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/victoria_metrics_config.ex
@@ -21,9 +21,9 @@ defmodule CommonCore.Batteries.VictoriaMetricsConfig do
     field :vmstorage_volume_size, :string, default: "5Gi"
   end
 
-  def changeset(base_struct, args) do
+  def changeset(base_struct, args, opts \\ []) do
     base_struct
-    |> CommonCore.Ecto.Schema.schema_changeset(args)
+    |> CommonCore.Ecto.Schema.schema_changeset(args, opts)
     |> validate_number(:replication_factor, greater_than: 0, less_than: 99)
     |> validate_number(:vmstorage_replicas, greater_than: 0, less_than: 99)
     |> validate_number(:vminsert_replicas, greater_than: 0, less_than: 99)

--- a/platform_umbrella/apps/common_core/lib/common_core/containers/container.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/containers/container.ex
@@ -17,9 +17,9 @@ defmodule CommonCore.Containers.Container do
     embeds_many(:mounts, CommonCore.Containers.Mount, on_replace: :delete)
   end
 
-  def changeset(struct, params \\ %{}) do
+  def changeset(struct, params \\ %{}, opts \\ []) do
     struct
-    |> CommonCore.Ecto.Schema.schema_changeset(params)
+    |> CommonCore.Ecto.Schema.schema_changeset(params, opts)
     |> downcase_fields([:name])
   end
 end

--- a/platform_umbrella/apps/common_core/lib/common_core/containers/env_value.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/containers/env_value.ex
@@ -15,9 +15,9 @@ defmodule CommonCore.Containers.EnvValue do
     field :source_optional, :boolean, default: false
   end
 
-  def changeset(struct, params \\ %{}) do
+  def changeset(struct, params \\ %{}, opts \\ []) do
     struct
-    |> CommonCore.Ecto.Schema.schema_changeset(params)
+    |> CommonCore.Ecto.Schema.schema_changeset(params, opts)
     |> validate_length(:name, min: 3, max: 256)
   end
 

--- a/platform_umbrella/apps/common_core/lib/common_core/defaults/image.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/defaults/image.ex
@@ -11,9 +11,9 @@ defmodule CommonCore.Defaults.Image do
   end
 
   @doc false
-  def changeset(image, attrs) do
+  def changeset(image, attrs, opts \\ []) do
     image
-    |> CommonCore.Ecto.Schema.schema_changeset(attrs)
+    |> CommonCore.Ecto.Schema.schema_changeset(attrs, opts)
     |> default_tag_in_tags()
   end
 

--- a/platform_umbrella/apps/common_core/lib/common_core/ferretdb/ferret_service.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/ferretdb/ferret_service.ex
@@ -12,6 +12,7 @@ defmodule CommonCore.FerretDB.FerretService do
   }
 
   @required_fields ~w(instances postgres_cluster_id)a
+  @read_only_fields ~w(name)a
 
   @presets [
     %{
@@ -71,9 +72,9 @@ defmodule CommonCore.FerretDB.FerretService do
   def preset_options_for_select, do: Enum.map(@presets, &{String.capitalize(&1.name), &1.name}) ++ [{"Custom", "custom"}]
 
   @doc false
-  def changeset(ferret_service, attrs) do
+  def changeset(ferret_service, attrs, opts \\ []) do
     ferret_service
-    |> CommonCore.Ecto.Schema.schema_changeset(attrs)
+    |> CommonCore.Ecto.Schema.schema_changeset(attrs, opts)
     |> maybe_set_virtual_size(@presets)
     |> foreign_key_constraint(:project_id)
   end

--- a/platform_umbrella/apps/common_core/lib/common_core/installs/installation.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/installs/installation.ex
@@ -37,9 +37,9 @@ defmodule CommonCore.Installation do
   end
 
   @doc false
-  def changeset(installation, attrs \\ %{}) do
+  def changeset(installation, attrs \\ %{}, opts \\ []) do
     installation
-    |> CommonCore.Ecto.Schema.schema_changeset(attrs)
+    |> CommonCore.Ecto.Schema.schema_changeset(attrs, opts)
     |> maybe_add_control_jwk()
     |> foreign_key_constraint(:slug)
   end

--- a/platform_umbrella/apps/common_core/lib/common_core/knative/service.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/knative/service.ex
@@ -30,9 +30,9 @@ defmodule CommonCore.Knative.Service do
   end
 
   @doc false
-  def changeset(struct, attrs) do
+  def changeset(struct, attrs, opts \\ []) do
     struct
-    |> CommonCore.Ecto.Schema.schema_changeset(attrs)
+    |> CommonCore.Ecto.Schema.schema_changeset(attrs, opts)
     |> unique_constraint(:name)
     |> validate_realm()
   end

--- a/platform_umbrella/apps/common_core/lib/common_core/metal_lb/ip_address_pool.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/metal_lb/ip_address_pool.ex
@@ -9,6 +9,7 @@ defmodule CommonCore.MetalLB.IPAddressPool do
   }
 
   @required_fields [:name, :subnet]
+  @read_only_fields ~w(name)a
 
   batt_schema "ip_address_pools" do
     slug_field :name
@@ -18,9 +19,9 @@ defmodule CommonCore.MetalLB.IPAddressPool do
   end
 
   @doc false
-  def changeset(ip_address_pool, attrs \\ %{}) do
+  def changeset(ip_address_pool, attrs \\ %{}, opts \\ []) do
     ip_address_pool
-    |> CommonCore.Ecto.Schema.schema_changeset(attrs)
+    |> CommonCore.Ecto.Schema.schema_changeset(attrs, opts)
     |> unique_constraint(:name)
   end
 

--- a/platform_umbrella/apps/common_core/lib/common_core/notebooks/jupyter_lab_notebook.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/notebooks/jupyter_lab_notebook.ex
@@ -64,6 +64,7 @@ defmodule CommonCore.Notebooks.JupyterLabNotebook do
   ]
 
   @required_fields ~w(name image)a
+  @read_only_fields ~w(name)a
 
   batt_schema "jupyter_lab_notebooks" do
     slug_field :name
@@ -86,9 +87,9 @@ defmodule CommonCore.Notebooks.JupyterLabNotebook do
   end
 
   @doc false
-  def changeset(jupyter_lab_notebook, attrs) do
+  def changeset(jupyter_lab_notebook, attrs, opts \\ []) do
     jupyter_lab_notebook
-    |> CommonCore.Ecto.Schema.schema_changeset(attrs)
+    |> CommonCore.Ecto.Schema.schema_changeset(attrs, opts)
     |> maybe_set_virtual_size(@presets)
     |> validate_number(:cpu_requested, greater_than: 0, less_than: 100_000)
     |> validate_number(:cpu_limits, greater_than: 0, less_than: 100_000)

--- a/platform_umbrella/apps/common_core/lib/common_core/ollama/model_instance.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/ollama/model_instance.ex
@@ -64,9 +64,9 @@ defmodule CommonCore.Ollama.ModelInstance do
     timestamps()
   end
 
-  def changeset(model_instance, attrs) do
+  def changeset(model_instance, attrs, opts \\ []) do
     model_instance
-    |> CommonCore.Ecto.Schema.schema_changeset(attrs)
+    |> CommonCore.Ecto.Schema.schema_changeset(attrs, opts)
     |> maybe_set_virtual_size(@presets)
     |> validate_number(:cpu_requested, greater_than: 0, less_than: 100_000)
     |> validate_number(:cpu_limits, greater_than: 0, less_than: 100_000)

--- a/platform_umbrella/apps/common_core/lib/common_core/port.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/port.ex
@@ -20,9 +20,9 @@ defmodule CommonCore.Port do
     field :protocol, Ecto.Enum, values: Keyword.values(@protocols), default: :http2
   end
 
-  def changeset(struct, params \\ %{}) do
+  def changeset(struct, params \\ %{}, opts \\ []) do
     struct
-    |> Schema.schema_changeset(params)
+    |> Schema.schema_changeset(params, opts)
     |> downcase_fields([:name])
   end
 

--- a/platform_umbrella/apps/common_core/lib/common_core/postgres/pg_user.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/postgres/pg_user.ex
@@ -14,9 +14,9 @@ defmodule CommonCore.Postgres.PGUser do
     field :position, :integer, virtual: true
   end
 
-  def changeset(struct, params \\ %{}) do
+  def changeset(struct, params \\ %{}, opts \\ []) do
     struct
-    |> CommonCore.Ecto.Schema.schema_changeset(params)
+    |> CommonCore.Ecto.Schema.schema_changeset(params, opts)
     |> validate_pg_rolelist(:roles)
   end
 end

--- a/platform_umbrella/apps/common_core/lib/common_core/projects/project.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/projects/project.ex
@@ -26,9 +26,9 @@ defmodule CommonCore.Projects.Project do
     timestamps()
   end
 
-  def changeset(project, attrs) do
+  def changeset(project, attrs, opts \\ []) do
     project
-    |> CommonCore.Ecto.Schema.schema_changeset(attrs)
+    |> CommonCore.Ecto.Schema.schema_changeset(attrs, opts)
     |> validate_length(:description, max: 1000)
     |> no_assoc_constraint(:postgres_clusters, name: :pg_clusters_project_id_fkey)
     |> no_assoc_constraint(:redis_instances, name: :redis_instances_project_id_fkey)

--- a/platform_umbrella/apps/common_core/lib/common_core/redis/redis_instance.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/redis/redis_instance.ex
@@ -36,6 +36,7 @@ defmodule CommonCore.Redis.RedisInstance do
   ]
 
   @required_fields ~w(type name)a
+  @read_only_fields ~w(name type)a
 
   batt_schema "redis_instances" do
     slug_field :name
@@ -91,9 +92,9 @@ defmodule CommonCore.Redis.RedisInstance do
     do: Enum.map([:standalone, :replication, :cluster], &{String.capitalize(to_string(&1)), &1})
 
   @doc false
-  def changeset(redis_instance, attrs) do
+  def changeset(redis_instance, attrs, opts \\ []) do
     redis_instance
-    |> CommonCore.Ecto.Schema.schema_changeset(attrs)
+    |> CommonCore.Ecto.Schema.schema_changeset(attrs, opts)
     |> maybe_set_virtual_size(@presets)
     |> unique_constraint([:type, :name])
     |> foreign_key_constraint(:project_id)

--- a/platform_umbrella/apps/common_core/lib/common_core/state_summary/state_summary.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/state_summary/state_summary.ex
@@ -51,16 +51,21 @@ defmodule CommonCore.StateSummary do
     home_base_init_data = Keyword.get(opts, :home_base_init_data, %HomeBaseInitData{})
     batteries = CommonCore.Installs.Batteries.default_batteries(installation)
 
+    cluster_args = CommonCore.Installs.Postgres.cluster_arg_list(batteries, installation)
+
     %__MODULE__{}
-    |> changeset(%{
-      batteries: Enum.map(batteries, fn b -> %{Map.from_struct(b) | config: Map.from_struct(b.config)} end),
-      postgres_clusters: CommonCore.Installs.Postgres.cluster_arg_list(batteries, installation),
-      traditional_services: CommonCore.Installs.TraditionalServices.services(installation),
-      home_base_init_data: Map.from_struct(home_base_init_data),
-      # For now we don't have projects to add to the target summary
-      # once we work out inter-cluster project sharing we can add this
-      projects: []
-    })
+    |> changeset(
+      %{
+        batteries: Enum.map(batteries, fn b -> %{Map.from_struct(b) | config: Map.from_struct(b.config)} end),
+        postgres_clusters: cluster_args,
+        traditional_services: CommonCore.Installs.TraditionalServices.services(installation),
+        home_base_init_data: Map.from_struct(home_base_init_data),
+        # For now we don't have projects to add to the target summary
+        # once we work out inter-cluster project sharing we can add this
+        projects: []
+      },
+      action: :insert
+    )
     |> apply_action(:insert)
   end
 end

--- a/platform_umbrella/apps/common_core/lib/common_core/teams/team.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/teams/team.ex
@@ -19,9 +19,9 @@ defmodule CommonCore.Teams.Team do
     timestamps()
   end
 
-  def changeset(team, attrs \\ %{}) do
+  def changeset(team, attrs \\ %{}, opts \\ []) do
     team
-    |> CommonCore.Ecto.Schema.schema_changeset(attrs)
+    |> CommonCore.Ecto.Schema.schema_changeset(attrs, opts)
     |> cast_assoc(:roles, with: &TeamRole.changeset/2, sort_param: :sort_roles, drop_param: :drop_roles)
     |> validate_length(:name, max: 255)
     |> validate_email_address(:op_email)

--- a/platform_umbrella/apps/common_core/lib/common_core/teams/team_role.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/teams/team_role.ex
@@ -18,9 +18,9 @@ defmodule CommonCore.Teams.TeamRole do
     timestamps()
   end
 
-  def changeset(team_role, attrs \\ %{}) do
+  def changeset(team_role, attrs \\ %{}, opts \\ []) do
     team_role
-    |> CommonCore.Ecto.Schema.schema_changeset(attrs)
+    |> CommonCore.Ecto.Schema.schema_changeset(attrs, opts)
     |> validate_email_address(:invited_email)
     |> unique_constraint([:user, :team],
       name: "teams_roles_user_id_team_id_index",

--- a/platform_umbrella/apps/common_core/lib/common_core/traditional_services/service.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/traditional_services/service.ex
@@ -86,9 +86,9 @@ defmodule CommonCore.TraditionalServices.Service do
   end
 
   @doc false
-  def changeset(service, attrs) do
+  def changeset(service, attrs, opts) do
     service
-    |> CommonCore.Ecto.Schema.schema_changeset(attrs)
+    |> CommonCore.Ecto.Schema.schema_changeset(attrs, opts)
     |> maybe_set_virtual_size(@service_size_preset)
     |> unique_constraint(:name)
   end

--- a/platform_umbrella/apps/common_core/lib/common_core/traditional_services/volume.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/traditional_services/volume.ex
@@ -21,9 +21,9 @@ defmodule CommonCore.TraditionalServices.Volume do
     field :config, PolymorphicType, mappings: @config_types
   end
 
-  def changeset(struct, params \\ %{}) do
+  def changeset(struct, params \\ %{}, opts \\ []) do
     struct
-    |> CommonCore.Ecto.Schema.schema_changeset(params)
+    |> CommonCore.Ecto.Schema.schema_changeset(params, opts)
     |> validate_length(:name, min: 3, max: 256)
   end
 

--- a/platform_umbrella/apps/common_core/test/common_core/postgres/cluster_test.exs
+++ b/platform_umbrella/apps/common_core/test/common_core/postgres/cluster_test.exs
@@ -54,7 +54,9 @@ defmodule CommonCore.Postgres.ClusterTest do
 
     test "should put a storage size into the changeset with ticks" do
       assert %Cluster{}
-             |> Cluster.changeset(%{storage_size: Memory.to_bytes(50, :GB)}, Cluster.compact_storage_range_ticks())
+             |> Cluster.changeset(%{storage_size: Memory.to_bytes(50, :GB)},
+               range_ticks: Cluster.compact_storage_range_ticks()
+             )
              |> Changeset.get_change(:virtual_storage_size_range_value) == Memory.to_bytes(0.3, :TB)
     end
 

--- a/platform_umbrella/apps/common_core/test/support/example_schemas.ex
+++ b/platform_umbrella/apps/common_core/test/support/example_schemas.ex
@@ -12,9 +12,9 @@ defmodule CommonCore.ExampleSchemas do
       secret_field :password
     end
 
-    def changeset(struct, attrs) do
+    def changeset(struct, attrs, opts \\ []) do
       struct
-      |> CommonCore.Ecto.Schema.schema_changeset(attrs)
+      |> CommonCore.Ecto.Schema.schema_changeset(attrs, opts)
       |> validate_exclusion(:name, ["admin"])
     end
   end
@@ -22,6 +22,8 @@ defmodule CommonCore.ExampleSchemas do
   defmodule TodoSchema do
     @moduledoc false
     use CommonCore, :schema
+
+    @read_only_fields ~w(name)a
 
     batt_schema "todos" do
       slug_field :name

--- a/platform_umbrella/apps/control_server/lib/control_server/postgres.ex
+++ b/platform_umbrella/apps/control_server/lib/control_server/postgres.ex
@@ -161,7 +161,7 @@ defmodule ControlServer.Postgres do
 
   defp maybe_insert(nil = _selected, repo, attrs) do
     %Cluster{}
-    |> Cluster.changeset(attrs)
+    |> Cluster.changeset(attrs, action: :insert)
     |> repo.insert()
     |> broadcast(:insert)
   end

--- a/platform_umbrella/apps/control_server/lib/control_server/snapshot_apply/actions.ex
+++ b/platform_umbrella/apps/control_server/lib/control_server/snapshot_apply/actions.ex
@@ -66,7 +66,7 @@ defmodule ControlServer.SnapshotApply.Actions do
   """
   def update_keycloak_action(%KeycloakAction{} = keycloak_action, attrs) do
     keycloak_action
-    |> KeycloakAction.changeset(attrs)
+    |> KeycloakAction.changeset(attrs, action: :update)
     |> Repo.update()
   end
 

--- a/platform_umbrella/apps/control_server/lib/control_server/snapshot_apply/keycloak_action.ex
+++ b/platform_umbrella/apps/control_server/lib/control_server/snapshot_apply/keycloak_action.ex
@@ -34,9 +34,9 @@ defmodule ControlServer.SnapshotApply.KeycloakAction do
     timestamps()
   end
 
-  def changeset(keycloak_action, attrs) do
+  def changeset(keycloak_action, attrs, opts \\ []) do
     keycloak_action
-    |> CommonCore.Ecto.Schema.schema_changeset(attrs)
+    |> CommonCore.Ecto.Schema.schema_changeset(attrs, opts)
     |> validate_realm_present_if_needed()
     |> validate_ping_only_for_realm()
   end

--- a/platform_umbrella/apps/control_server/test/control_server/metal_lb_test.exs
+++ b/platform_umbrella/apps/control_server/test/control_server/metal_lb_test.exs
@@ -43,12 +43,11 @@ defmodule ControlServer.MetalLBTest do
 
     test "update_ip_address_pool/2 with valid data updates the ip_address_pool" do
       ip_address_pool = ip_address_pool_fixture()
-      update_attrs = %{name: "some-updated-name", subnet: "some updated subnet"}
+      update_attrs = %{subnet: "some updated subnet"}
 
       assert {:ok, %IPAddressPool{} = ip_address_pool} =
                MetalLB.update_ip_address_pool(ip_address_pool, update_attrs)
 
-      assert ip_address_pool.name == "some-updated-name"
       assert ip_address_pool.subnet == "some updated subnet"
     end
 

--- a/platform_umbrella/apps/control_server/test/control_server/notebooks_test.exs
+++ b/platform_umbrella/apps/control_server/test/control_server/notebooks_test.exs
@@ -6,7 +6,7 @@ defmodule ControlServer.NotebooksTest do
 
   describe "jupyter_lab_notebooks" do
     @valid_attrs %{image: "some-image", name: "some-name", storage_size: 524_288_000}
-    @update_attrs %{image: "some-updated-image", name: "some-updated-name", storage_size: 209_715_200}
+    @update_attrs %{image: "some-updated-image", storage_size: 209_715_200}
     @invalid_attrs %{image: nil, name: nil, storage_size: nil}
 
     def jupyter_lab_notebook_fixture(attrs \\ %{}) do
@@ -56,7 +56,6 @@ defmodule ControlServer.NotebooksTest do
                Notebooks.update_jupyter_lab_notebook(jupyter_lab_notebook, @update_attrs)
 
       assert jupyter_lab_notebook.image == "some-updated-image"
-      assert jupyter_lab_notebook.name == "some-updated-name"
       assert jupyter_lab_notebook.storage_size == 209_715_200
     end
 

--- a/platform_umbrella/apps/control_server/test/control_server/postgres_test.exs
+++ b/platform_umbrella/apps/control_server/test/control_server/postgres_test.exs
@@ -14,7 +14,6 @@ defmodule ControlServer.PostgresTest do
       database: %{name: "maindata", owner: "userone"}
     }
     @update_attrs %{
-      name: "some-updated-name",
       num_instances: 3,
       storage_size: 524_288_000,
       users: [
@@ -69,7 +68,6 @@ defmodule ControlServer.PostgresTest do
     test "update_cluster/2 with valid data updates the cluster" do
       cluster = cluster_fixture()
       assert {:ok, %Cluster{} = cluster} = Postgres.update_cluster(cluster, @update_attrs)
-      assert cluster.name == "some-updated-name"
       assert cluster.num_instances == 3
       assert cluster.storage_size == 524_288_000
     end

--- a/platform_umbrella/apps/control_server/test/control_server/redis_test.exs
+++ b/platform_umbrella/apps/control_server/test/control_server/redis_test.exs
@@ -51,13 +51,11 @@ defmodule ControlServer.RedisTest do
       redis_instance = redis_instance_fixture()
 
       update_attrs = %{
-        name: "some-updated-name",
         num_instances: 43
       }
 
       assert {:ok, %RedisInstance{} = redis_instance} = Redis.update_redis_instance(redis_instance, update_attrs)
 
-      assert redis_instance.name == "some-updated-name"
       assert redis_instance.num_instances == 43
     end
 

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/batteries/form_component.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/batteries/form_component.ex
@@ -226,6 +226,7 @@ defmodule ControlServerWeb.BatteriesFormComponent do
             module={@form_module}
             battery={@catalog_battery}
             form={f}
+            action={@action}
             id="battery-subform"
           />
         </.grid>

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/ai_form.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/ai_form.ex
@@ -26,7 +26,7 @@ defmodule ControlServerWeb.Projects.AIForm do
       PGCluster.changeset(
         KubeServices.SmartBuilder.new_postgres(),
         Map.get(form_data, "postgres", %{name: resource_name}),
-        PGCluster.compact_storage_range_ticks()
+        range_ticks: PGCluster.compact_storage_range_ticks()
       )
 
     form =
@@ -56,7 +56,7 @@ defmodule ControlServerWeb.Projects.AIForm do
 
     postgres_changeset =
       %PGCluster{}
-      |> PGCluster.changeset(params["postgres"], PGCluster.compact_storage_range_ticks())
+      |> PGCluster.changeset(params["postgres"], range_ticks: PGCluster.compact_storage_range_ticks())
       |> Map.put(:action, :validate)
 
     form =
@@ -107,7 +107,7 @@ defmodule ControlServerWeb.Projects.AIForm do
 
     if Validations.subforms_valid?(params, %{
          "jupyter" => &JupyterLabNotebook.changeset(%JupyterLabNotebook{}, &1),
-         "postgres" => &PGCluster.changeset(%PGCluster{}, &1, PGCluster.compact_storage_range_ticks())
+         "postgres" => &PGCluster.changeset(%PGCluster{}, &1, range_ticks: PGCluster.compact_storage_range_ticks())
        }) do
       # Don't create the resources yet, send data to parent liveview
       send(self(), {:next, {__MODULE__, params}})

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/database_form.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/database_form.ex
@@ -21,7 +21,7 @@ defmodule ControlServerWeb.Projects.DatabaseForm do
       PGCluster.changeset(
         KubeServices.SmartBuilder.new_postgres(),
         Map.get(form_data, "postgres", %{name: resource_name}),
-        PGCluster.compact_storage_range_ticks()
+        range_ticks: PGCluster.compact_storage_range_ticks()
       )
 
     redis_changeset =
@@ -56,7 +56,7 @@ defmodule ControlServerWeb.Projects.DatabaseForm do
   def handle_event("validate", params, socket) do
     postgres_changeset =
       %PGCluster{}
-      |> PGCluster.changeset(params["postgres"], PGCluster.compact_storage_range_ticks())
+      |> PGCluster.changeset(params["postgres"], range_ticks: PGCluster.compact_storage_range_ticks())
       |> Map.put(:action, :validate)
 
     redis_changeset =
@@ -126,7 +126,7 @@ defmodule ControlServerWeb.Projects.DatabaseForm do
       ])
 
     if Validations.subforms_valid?(params, %{
-         "postgres" => &PGCluster.changeset(%PGCluster{}, &1, PGCluster.compact_storage_range_ticks()),
+         "postgres" => &PGCluster.changeset(%PGCluster{}, &1, range_ticks: PGCluster.compact_storage_range_ticks()),
          "redis" => &RedisCluster.changeset(%RedisCluster{}, &1),
          "ferret" => &FerretService.changeset(%FerretService{}, &1)
        }) do

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/web_form.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/web_form.ex
@@ -36,7 +36,7 @@ defmodule ControlServerWeb.Projects.WebForm do
       PGCluster.changeset(
         KubeServices.SmartBuilder.new_postgres(),
         Map.get(form_data, "postgres", %{name: resource_name}),
-        PGCluster.compact_storage_range_ticks()
+        range_ticks: PGCluster.compact_storage_range_ticks()
       )
 
     redis_changeset =
@@ -85,7 +85,7 @@ defmodule ControlServerWeb.Projects.WebForm do
 
     postgres_changeset =
       %PGCluster{}
-      |> PGCluster.changeset(params["postgres"], PGCluster.compact_storage_range_ticks())
+      |> PGCluster.changeset(params["postgres"], range_ticks: PGCluster.compact_storage_range_ticks())
       |> Map.put(:action, :validate)
 
     redis_changeset =
@@ -148,7 +148,7 @@ defmodule ControlServerWeb.Projects.WebForm do
     if Validations.subforms_valid?(params, %{
          "knative" => &KnativeService.changeset(%KnativeService{}, &1),
          "traditional" => &TraditionalService.changeset(%TraditionalService{}, &1),
-         "postgres" => &PGCluster.changeset(%PGCluster{}, &1, PGCluster.compact_storage_range_ticks()),
+         "postgres" => &PGCluster.changeset(%PGCluster{}, &1, range_ticks: PGCluster.compact_storage_range_ticks()),
          "redis" => &RedisCluster.changeset(%RedisCluster{}, &1)
        }) do
       # Don't create the resources yet, send data to parent liveview

--- a/platform_umbrella/apps/control_server_web/test/controllers/cluster_controller_test.exs
+++ b/platform_umbrella/apps/control_server_web/test/controllers/cluster_controller_test.exs
@@ -57,19 +57,21 @@ defmodule ControlServerWeb.ClusterControllerTest do
     setup [:create_cluster]
 
     test "renders cluster when data is valid", %{conn: conn, cluster: %Cluster{id: id} = cluster} do
-      update_attrs = params_for(:postgres_cluster, name: "some-updated-name")
+      update_attrs = params_for(:postgres_cluster, name: cluster.name)
       conn = put(conn, ~p"/api/postgres/clusters/#{cluster}", cluster: update_attrs)
       assert %{"id" => ^id} = json_response(conn, 200)["data"]
 
       conn = get(conn, ~p"/api/postgres/clusters/#{id}")
       resp = json_response(conn, 200)["data"]
 
+      name = cluster.name
+
       assert %{
                "id" => ^id,
                "cpu_limits" => _,
                "cpu_requested" => _,
                "memory_limits" => _,
-               "name" => "some-updated-name",
+               "name" => ^name,
                "num_instances" => _,
                "storage_size" => _,
                "type" => _
@@ -77,7 +79,7 @@ defmodule ControlServerWeb.ClusterControllerTest do
     end
 
     test "renders errors when data is invalid", %{conn: conn, cluster: %Cluster{id: id} = cluster} do
-      update_attrs = params_for(:postgres_cluster, name: "another-updated-name")
+      update_attrs = params_for(:postgres_cluster, name: cluster.name, type: cluster.type)
       conn = put(conn, ~p"/api/postgres/clusters/#{cluster}", cluster: update_attrs)
       assert %{"id" => ^id} = json_response(conn, 200)["data"]
 

--- a/platform_umbrella/apps/control_server_web/test/controllers/jupyter_lab_notebook_controller_test.exs
+++ b/platform_umbrella/apps/control_server_web/test/controllers/jupyter_lab_notebook_controller_test.exs
@@ -46,7 +46,8 @@ defmodule ControlServerWeb.JupyterLabNotebookControllerTest do
       conn: conn,
       jupyter_lab_notebook: %JupyterLabNotebook{id: id} = jupyter_lab_notebook
     } do
-      update_attrs = params_for(:jupyter_lab_notebook, name: "some-updated-name", image: "some-updated-image:latest")
+      update_attrs =
+        params_for(:jupyter_lab_notebook, image: "some-updated-image:latest", name: jupyter_lab_notebook.name)
 
       conn =
         put(conn, ~p"/api/notebooks/jupyter_lab_notebooks/#{jupyter_lab_notebook}", jupyter_lab_notebook: update_attrs)
@@ -57,8 +58,7 @@ defmodule ControlServerWeb.JupyterLabNotebookControllerTest do
 
       assert %{
                "id" => ^id,
-               "image" => "some-updated-image:latest",
-               "name" => "some-updated-name"
+               "image" => "some-updated-image:latest"
              } = json_response(conn, 200)["data"]
     end
 

--- a/platform_umbrella/apps/control_server_web/test/controllers/redis_instance_controller_test.exs
+++ b/platform_umbrella/apps/control_server_web/test/controllers/redis_instance_controller_test.exs
@@ -24,7 +24,7 @@ defmodule ControlServerWeb.RedisInstanceControllerTest do
 
   describe "create redis_instance" do
     test "renders redis_instance when data is valid", %{conn: conn} do
-      attrs = params_for(:redis_cluster, name: "some-name")
+      attrs = params_for(:redis_cluster, name: "some-name", type: :standard)
       conn = post(conn, ~p"/api/redis/clusters", redis_instance: attrs)
 
       assert %{"id" => id} = json_response(conn, 201)["data"]
@@ -55,7 +55,7 @@ defmodule ControlServerWeb.RedisInstanceControllerTest do
       conn: conn,
       redis_instance: %RedisInstance{id: id} = redis_instance
     } do
-      update_attrs = params_for(:redis_cluster, name: "some-updated-name")
+      update_attrs = params_for(:redis_cluster, name: redis_instance.name, type: redis_instance.type)
       conn = put(conn, ~p"/api/redis/clusters/#{redis_instance}", redis_instance: update_attrs)
       assert %{"id" => ^id} = json_response(conn, 200)["data"]
 
@@ -66,7 +66,6 @@ defmodule ControlServerWeb.RedisInstanceControllerTest do
                "cpu_requested" => _,
                "memory_limits" => _,
                "memory_requested" => _,
-               "name" => "some-updated-name",
                "num_instances" => _,
                "type" => _
              } = json_response(conn, 200)["data"]

--- a/platform_umbrella/apps/control_server_web/test/live/postgres_live_test.exs
+++ b/platform_umbrella/apps/control_server_web/test/live/postgres_live_test.exs
@@ -19,7 +19,6 @@ defmodule ControlServerWeb.PostgresLiveTest do
   }
   @update_attrs %{
     cluster: %{
-      name: "postgres-live-test",
       virtual_size: "medium",
       num_instances: 3
     }
@@ -190,7 +189,7 @@ defmodule ControlServerWeb.PostgresLiveTest do
       |> submit_form("#cluster-form", @update_attrs)
 
       updated_cluster = Repo.get(Cluster, cluster.id)
-      assert updated_cluster.name == @update_attrs.cluster.name
+      assert updated_cluster.num_instances == @update_attrs.cluster.num_instances
     end
 
     test "changing the virtual size field to custom exposes storage fields and defaults to the existing storage size", %{


### PR DESCRIPTION
Summary:
- Add an annotation `@read_only_fields` that will all the field to be set
  once on insert, but not after that.
- Add that annotation to lots of secret fields in battery configs
- Apply that annotation to name fields of things that create storage. We
  can't rename a database since that will change the mount name where
  data is.
- Change `CommonCore.Ecto.Schema` new, load, and cast behavior to pass
  the action to changeset.

Note there's a big giant hack in this thing. Ecto uses a new changeset
for each relation. They don't pass the action down into the the
dependent changeset. So we rely on the private metadata field to see if
this record was loaded from the database (in which case we continue on)
or built in memory. In the latter case we assue that read only doesn't
apply. Yes I know it's a hack.

Test Plan:
- Many tests changed
- Updated tests where name can't be changed anymore
