### PR TITLE
feat: UI changes for read only fields

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/victoria_metrics_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/victoria_metrics_config.ex
@@ -5,6 +5,8 @@ defmodule CommonCore.Batteries.VictoriaMetricsConfig do
 
   alias CommonCore.Defaults
 
+  @read_only_fields ~w(cookie_secret)a
+
   batt_polymorphic_schema type: :victoria_metrics do
     defaultable_field :cluster_image_tag, :string, default: Defaults.Images.vm_cluster_tag()
     defaultable_image_field :operator_image, image_id: :vm_operator

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/vm_agent_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/vm_agent_config.ex
@@ -5,6 +5,8 @@ defmodule CommonCore.Batteries.VMAgentConfig do
 
   alias CommonCore.Defaults
 
+  @read_only_fields ~w(cookie_secret)a
+
   batt_polymorphic_schema type: :vm_agent do
     defaultable_field :image_tag, :string, default: Defaults.Images.vm_tag()
     secret_field :cookie_secret, length: 32, func: &Defaults.urlsafe_random_key_string/1

--- a/platform_umbrella/apps/common_ui/lib/common_ui/components/input.ex
+++ b/platform_umbrella/apps/common_ui/lib/common_ui/components/input.ex
@@ -9,6 +9,7 @@ defmodule CommonUI.Components.Input do
   import Phoenix.HTML.Form
 
   alias CommonUI.IDHelpers
+  alias CommonUI.TextHelpers
   alias Phoenix.HTML.FormField
 
   attr :name, :any
@@ -403,6 +404,22 @@ defmodule CommonUI.Components.Input do
       class={[input_class(@errors), @class]}
       {@rest}
     />
+    """
+  end
+
+  def input(%{type: "password", rest: %{disabled: true}} = assigns) do
+    assigns = IDHelpers.provide_id(assigns)
+
+    ~H"""
+    <label phx-feedback-for={@name}>
+      <div :if={@label} class="flex items-center justify-between mb-2">
+        <.label id={@id} label={@label} help={@help} class="mb-0" />
+      </div>
+
+      <div class="font-mono font-bold text-sm">
+        <%= TextHelpers.obfuscate(@value, keep: 1, char_limit: 12) %>
+      </div>
+    </label>
     """
   end
 

--- a/platform_umbrella/apps/common_ui/lib/common_ui/helpers/text_helpers.ex
+++ b/platform_umbrella/apps/common_ui/lib/common_ui/helpers/text_helpers.ex
@@ -28,7 +28,13 @@ defmodule CommonUI.TextHelpers do
   @doc """
   This is a method to obfuscate a string by replacing a chunk in the middle with asterisks.
   """
-  def obfuscate(text, opts \\ []) do
+  def obfuscate(text, opts \\ [])
+
+  def obfuscate(nil, _opts) do
+    ""
+  end
+
+  def obfuscate(text, opts) do
     keep = Keyword.get(opts, :keep, 4)
     char = Keyword.get(opts, :char, "*")
     char_limit = Keyword.get(opts, :char_limit, 30)

--- a/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/input_test/test_disabled_password_component.heyya_snap
+++ b/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/input_test/test_disabled_password_component.heyya_snap
@@ -1,0 +1,13 @@
+<label phx-feedback-for="foo">
+  <div class="flex items-center justify-between mb-2">
+    <div class="flex items-center gap-2 text-sm text-gray-darkest dark:text-gray-lighter mb-0">
+  <span>Foobar</span>
+
+  
+</div>
+  </div>
+
+  <div class="font-mono font-bold text-sm">
+    s************y
+  </div>
+</label>

--- a/platform_umbrella/apps/common_ui/test/common_ui/components/input_test.exs
+++ b/platform_umbrella/apps/common_ui/test/common_ui/components/input_test.exs
@@ -279,4 +279,18 @@ defmodule CommonUI.Components.InputTest do
     <.input type="hidden" name="foo" value="bar" />
     """
   end
+
+  component_snapshot_test "disabled password component" do
+    assigns = %{}
+
+    ~H"""
+    <.input
+      type="password"
+      name="foo"
+      label="Foobar"
+      value="somereallylongpasswordthatwedontwanttoshowforsecurity"
+      disabled
+    />
+    """
+  end
 end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/batteries/battery_core_form.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/batteries/battery_core_form.ex
@@ -16,13 +16,14 @@ defmodule ControlServerWeb.Batteries.BatteryCoreForm do
 
       <.panel title="Configuration">
         <.simple_form variant="nested">
-          <.input field={@form[:cluster_name]} label="Cluster Name" />
+          <.input field={@form[:cluster_name]} label="Cluster Name" disabled={@action != :new} />
 
           <.input
             field={@form[:cluster_type]}
             type="select"
             label="Cluster Type"
             options={Options.provider_options()}
+            disabled={@action != :new}
           />
 
           <.input
@@ -32,16 +33,22 @@ defmodule ControlServerWeb.Batteries.BatteryCoreForm do
             options={Options.size_options()}
           />
 
-          <.input field={@form[:usage]} type="select" label="Usage" options={Options.usages()} />
+          <.input
+            field={@form[:usage]}
+            type="select"
+            label="Usage"
+            options={Options.usages()}
+            disabled={@action != :new}
+          />
         </.simple_form>
       </.panel>
 
       <.panel title="Namespaces">
         <.simple_form variant="nested">
-          <.input field={@form[:core_namespace]} label="Core Namespace" />
-          <.input field={@form[:base_namespace]} label="Base Namespace" />
-          <.input field={@form[:data_namespace]} label="Data Namespace" />
-          <.input field={@form[:ai_namespace]} label="AI Namespace" />
+          <.input field={@form[:core_namespace]} label="Core Namespace" disabled={@action != :new} />
+          <.input field={@form[:base_namespace]} label="Base Namespace" disabled={@action != :new} />
+          <.input field={@form[:data_namespace]} label="Data Namespace" disabled={@action != :new} />
+          <.input field={@form[:ai_namespace]} label="AI Namespace" disabled={@action != :new} />
         </.simple_form>
       </.panel>
 
@@ -79,7 +86,7 @@ defmodule ControlServerWeb.Batteries.BatteryCoreForm do
             <div class="flex-1 text-sm">Secret Key</div>
 
             <div class="font-mono font-bold text-sm">
-              <%= TextHelpers.obfuscate(@form[:secret_key].value, char_limit: 4) %>
+              <%= TextHelpers.obfuscate(@form[:secret_key].value, keep: 2, char_limit: 6) %>
             </div>
           </div>
         </.simple_form>

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/batteries/forgejo_form.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/batteries/forgejo_form.ex
@@ -14,8 +14,13 @@ defmodule ControlServerWeb.Batteries.ForgejoForm do
 
       <.panel title="Configuration">
         <.simple_form variant="nested">
-          <.input field={@form[:admin_username]} label="Admin Username" />
-          <.input field={@form[:admin_password]} type="password" label="Admin Password" />
+          <.input field={@form[:admin_username]} label="Admin Username" disabled={@action != :new} />
+          <.input
+            field={@form[:admin_password]}
+            type="password"
+            label="Admin Password"
+            disabled={@action != :new}
+          />
         </.simple_form>
       </.panel>
 

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/batteries/grafana_form.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/batteries/grafana_form.ex
@@ -14,7 +14,12 @@ defmodule ControlServerWeb.Batteries.GrafanaForm do
 
       <.panel title="Configuration">
         <.simple_form variant="nested">
-          <.input field={@form[:admin_password]} type="password" label="Admin Password" />
+          <.input
+            field={@form[:admin_password]}
+            type="password"
+            label="Admin Password"
+            disabled={@action != :new}
+          />
         </.simple_form>
       </.panel>
 

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/batteries/keycloak_form.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/batteries/keycloak_form.ex
@@ -21,8 +21,15 @@ defmodule ControlServerWeb.Batteries.KeycloakForm do
 
       <.panel title="Configuration">
         <.simple_form variant="nested">
-          <.input field={@form[:admin_username]} label="Admin Username" />
-          <.input field={@form[:admin_password]} type="password" label="Admin Password" />
+          <.input field={@form[:admin_username]} label="Admin Username" disabled={@action != :new} />
+
+          <.input
+            disabled={@action != :new}
+            field={@form[:admin_password]}
+            type="password"
+            label="Admin Password"
+          />
+
           <.input field={@form[:log_level]} label="Log Level" />
           <.input field={@form[:replicas]} type="number" label="Replicas" />
         </.simple_form>

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/batteries/knative_form.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/batteries/knative_form.ex
@@ -14,7 +14,7 @@ defmodule ControlServerWeb.Batteries.KnativeForm do
 
       <.panel title="Configuration">
         <.simple_form variant="nested">
-          <.input field={@form[:namespace]} label="Namespace" />
+          <.input field={@form[:namespace]} label="Namespace" disabled={@action != :new} />
         </.simple_form>
       </.panel>
 

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/batteries/notebooks_form.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/batteries/notebooks_form.ex
@@ -12,7 +12,12 @@ defmodule ControlServerWeb.Batteries.NotebooksForm do
 
       <.panel title="Configuration">
         <.simple_form variant="nested">
-          <.input field={@form[:cookie_secret]} type="password" label="Cookie Secret" />
+          <.input
+            field={@form[:cookie_secret]}
+            type="password"
+            label="Cookie Secret"
+            disabled={@action != :new}
+          />
         </.simple_form>
       </.panel>
     </div>

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/batteries/smtp4dev_form.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/batteries/smtp4dev_form.ex
@@ -14,7 +14,12 @@ defmodule ControlServerWeb.Batteries.Smtp4devForm do
 
       <.panel title="Configuration">
         <.simple_form variant="nested">
-          <.input field={@form[:cookie_secret]} type="password" label="Cookie Secret" />
+          <.input
+            field={@form[:cookie_secret]}
+            type="password"
+            label="Cookie Secret"
+            disabled={@action != :new}
+          />
         </.simple_form>
       </.panel>
 

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/batteries/victoria_metrics_form.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/batteries/victoria_metrics_form.ex
@@ -26,7 +26,12 @@ defmodule ControlServerWeb.Batteries.VictoriaMetricsForm do
 
       <.panel title="Configuration">
         <.simple_form variant="nested">
-          <.input field={@form[:cookie_secret]} type="password" label="Cookie Secret" />
+          <.input
+            field={@form[:cookie_secret]}
+            type="password"
+            label="Cookie Secret"
+            disabled={@action != :new}
+          />
           <.input field={@form[:replication_factor]} type="number" label="Replication Factor" />
           <.input field={@form[:vminsert_replicas]} type="number" label="Insert Replicas" />
           <.input field={@form[:vmselect_replicas]} type="number" label="Select Replicas" />

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/batteries/vm_agent_form.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/batteries/vm_agent_form.ex
@@ -12,7 +12,12 @@ defmodule ControlServerWeb.Batteries.VMAgentForm do
 
       <.panel title="Configuration">
         <.simple_form variant="nested">
-          <.input field={@form[:cookie_secret]} type="password" label="Cookie Secret" />
+          <.input
+            field={@form[:cookie_secret]}
+            type="password"
+            label="Cookie Secret"
+            disabled={@action != :new}
+          />
         </.simple_form>
       </.panel>
     </div>

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/notebooks/form_component.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/notebooks/form_component.ex
@@ -170,7 +170,7 @@ defmodule ControlServerWeb.Live.Notebooks.FormComponent do
         <.grid columns={[sm: 1, lg: 2]}>
           <.panel class="col-span-2">
             <.grid columns={[sm: 1, lg: 2]} class="items-center">
-              <.input field={@form[:name]} label="Name" />
+              <.input field={@form[:name]} label="Name" disabled={@action != :new} />
 
               <.input
                 field={@form[:virtual_size]}

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/postgres/form_component.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/postgres/form_component.ex
@@ -244,6 +244,7 @@ defmodule ControlServerWeb.Live.PostgresFormComponent do
             <PostgresFormSubcomponents.size_form
               form={@form}
               phx_target={@myself}
+              action={@action}
               ticks={Cluster.storage_range_ticks()}
             />
 

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/postgres/postgres_form_subcomponents.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/postgres/postgres_form_subcomponents.ex
@@ -188,6 +188,7 @@ defmodule ControlServerWeb.PostgresFormSubcomponents do
 
   attr :phx_target, :any
   attr :class, :any, default: nil
+  attr :action, :atom, default: nil
   attr :with_divider, :boolean, default: true
   attr :form, Phoenix.HTML.Form, required: true
   attr :ticks, :list, required: true
@@ -196,7 +197,12 @@ defmodule ControlServerWeb.PostgresFormSubcomponents do
     ~H"""
     <div class={["contents", @class]}>
       <.grid columns={[sm: 1, xl: 2]}>
-        <.input field={@form[:name]} label="Name" autofocus />
+        <.input
+          field={@form[:name]}
+          label="Name"
+          autofocus={@action == :new}
+          disabled={@action != :new}
+        />
 
         <.input
           field={@form[:virtual_size]}

--- a/platform_umbrella/apps/control_server_web/test/live/postgres_live_test.exs
+++ b/platform_umbrella/apps/control_server_web/test/live/postgres_live_test.exs
@@ -225,7 +225,7 @@ defmodule ControlServerWeb.PostgresLiveTest do
       |> start(~p"/postgres/#{cluster.id}/edit")
       |> click("#edit_user_#{valid_user_params["username"]}")
       |> submit_form("#user-form", %{"pg_user" => updated_user_params})
-      |> submit_form("#cluster-form", @valid_attrs)
+      |> submit_form("#cluster-form", Map.update(@valid_attrs, :cluster, %{}, fn attrs -> Map.delete(attrs, :name) end))
 
       updated_cluster = Repo.get(Cluster, cluster.id)
 


### PR DESCRIPTION
Summary:
- For passwords we don't want to send them to the user at all after they
  are created. So this adds a new input for disabled passwords that uses
  the obfusacte method.
- Add some read only fields tags for secret values.
-

Test Plan:
- Test added for input with disabled password.
