### PR TITLE
Support path and arguments for containers

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/containers/container.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/containers/container.ex
@@ -5,7 +5,10 @@ defmodule CommonCore.Containers.Container do
   @required_fields ~w(image name)a
 
   batt_embedded_schema do
+    field :path, :string, virtual: true
     field :args, {:array, :string}, default: nil
+
+    # Should never be set directly, it gets constructed using path and args
     field :command, {:array, :string}, default: nil
 
     # TODO: validate that we can reach whatever registry/image/version is set
@@ -21,5 +24,20 @@ defmodule CommonCore.Containers.Container do
     struct
     |> CommonCore.Ecto.Schema.schema_changeset(params)
     |> downcase_fields([:name])
+    |> put_command_from_path()
+  end
+
+  defp put_command_from_path(%{changes: %{path: path}} = changeset) do
+    put_change(changeset, :command, [path])
+  end
+
+  defp put_command_from_path(changeset) do
+    path =
+      changeset
+      |> get_field(:command)
+      |> Kernel.||([])
+      |> List.first()
+
+    put_change(changeset, :path, path)
   end
 end

--- a/platform_umbrella/apps/common_core/lib/common_core/ecto/schema.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/ecto/schema.ex
@@ -459,10 +459,11 @@ defmodule CommonCore.Ecto.Schema do
 
     to_cast = Enum.concat(fields, virtual_fields) -- embeds
     cast_opts = Keyword.get(opts, :cast_opts, [])
+    cast_embed_opts = Keyword.get(opts, :cast_embed_opts, [])
 
     base
     |> Ecto.Changeset.cast(sanitize_opts(params), to_cast, cast_opts)
-    |> add_embeds(struct)
+    |> add_embeds(struct, cast_embed_opts)
     |> add_polymorphic_fields(struct)
     |> add_defaultable_fields(struct)
     |> add_defaultable_image_fields(struct)
@@ -472,10 +473,12 @@ defmodule CommonCore.Ecto.Schema do
     |> add_required_fields(struct)
   end
 
-  defp add_embeds(changeset, struct) do
+  defp add_embeds(changeset, struct, opts) do
     embeds = struct.__schema__(:embeds)
 
-    Enum.reduce(embeds, changeset, fn embed_field, chg -> Ecto.Changeset.cast_embed(chg, embed_field) end)
+    Enum.reduce(embeds, changeset, fn embed_field, chg ->
+      Ecto.Changeset.cast_embed(chg, embed_field, opts)
+    end)
   end
 
   defp add_polymorphic_fields(changeset, struct) do

--- a/platform_umbrella/apps/common_ui/lib/common_ui/components/input_list.ex
+++ b/platform_umbrella/apps/common_ui/lib/common_ui/components/input_list.ex
@@ -107,28 +107,24 @@ defmodule CommonUI.Components.InputList do
     <div>
       <div :if={@label} class={label_class()}><%= @label %></div>
 
-      <%= if @field.value == [] do %>
-        <input type="hidden" name={"#{@field.name}[]"} />
-      <% else %>
-        <%= for {value, index} <- Enum.with_index(@field.value) do %>
-          <div class={wrapper_class()}>
-            <div class="flex-1">
-              <%= render_slot(
-                @inner_block,
-                Map.merge(@field, %{name: @field.name <> "[]", value: value})
-              ) %>
-            </div>
-
-            <.button
-              variant="minimal"
-              icon={:x_mark}
-              phx-value-index={index}
-              phx-click={@remove_click}
-              phx-target={@phx_target}
-            />
+      <.list :let={{value, index}} field={@field}>
+        <div class={wrapper_class()}>
+          <div class="flex-1">
+            <%= render_slot(
+              @inner_block,
+              Map.merge(@field, %{name: @field.name <> "[]", value: value})
+            ) %>
           </div>
-        <% end %>
-      <% end %>
+
+          <.button
+            variant="minimal"
+            icon={:x_mark}
+            phx-value-index={index}
+            phx-click={@remove_click}
+            phx-target={@phx_target}
+          />
+        </div>
+      </.list>
 
       <.button
         variant="minimal"
@@ -140,6 +136,25 @@ defmodule CommonUI.Components.InputList do
         <%= @add_label %>
       </.button>
     </div>
+    """
+  end
+
+  defp list(%{field: %{value: nil}} = assigns) do
+    ~H"""
+    """
+  end
+
+  defp list(%{field: %{value: []}} = assigns) do
+    ~H"""
+    <input type="hidden" name={"#{@field.name}[]"} />
+    """
+  end
+
+  defp list(assigns) do
+    ~H"""
+    <%= for {value, index} <- Enum.with_index(@field.value) do %>
+      <%= render_slot(@inner_block, {value, index}) %>
+    <% end %>
     """
   end
 

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/containers/container_modal.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/containers/container_modal.ex
@@ -4,6 +4,7 @@ defmodule ControlServerWeb.Containers.ContainerModal do
   use ControlServerWeb, :live_component
 
   alias CommonCore.Containers.Container
+  alias CommonCore.Ecto.Validations
   alias Ecto.Changeset
 
   @impl Phoenix.LiveComponent
@@ -87,6 +88,16 @@ defmodule ControlServerWeb.Containers.ContainerModal do
     {:noreply, assign_changeset(socket, changeset)}
   end
 
+  def handle_event("add_arg", _params, socket) do
+    changeset = Validations.add_item_to_list(socket.assigns.form.source, :args)
+    {:noreply, assign_changeset(socket, changeset)}
+  end
+
+  def handle_event("remove_arg", %{"index" => index}, socket) do
+    changeset = Validations.remove_item_from_list(socket.assigns.form.source, :args, index)
+    {:noreply, assign_changeset(socket, changeset)}
+  end
+
   @impl Phoenix.LiveComponent
   def render(assigns) do
     ~H"""
@@ -104,12 +115,19 @@ defmodule ControlServerWeb.Containers.ContainerModal do
           <.flex column>
             <.input label="Name" field={@form[:name]} autofocus placeholder="Name" />
             <.input label="Image" field={@form[:image]} placeholder="Image" />
-            <.input
-              label="Command (optional)"
-              name="container[command][]"
-              value={(@form.data.command || []) |> List.first(nil)}
-              placeholder="/bin/true"
-            />
+            <.input label="Path (optional)" field={@form[:path]} placeholder="/bin/true" />
+
+            <.input_list
+              :let={field}
+              field={@form[:args]}
+              label="Arguments"
+              add_label="Add argument"
+              add_click="add_arg"
+              remove_click="remove_arg"
+              phx_target={@myself}
+            >
+              <.input field={field} />
+            </.input_list>
           </.flex>
 
           <:actions cancel="Cancel">

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/containers/containers_panel.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/containers/containers_panel.ex
@@ -16,7 +16,7 @@ defmodule ControlServerWeb.Containers.ContainersPanel do
           Add Container
         </.button>
       </:menu>
-      <.table id="containers-table" rows={Enum.with_index(@containers ++ @init_containers)}>
+      <.table id={"containers-table-#{@id}"} rows={Enum.with_index(@containers ++ @init_containers)}>
         <:col :let={{c, _idx}} label="Name"><%= c.name %></:col>
         <:col :let={{c, _idx}} label="Image"><%= c.image %></:col>
 

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/containers/hidden_forms.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/containers/hidden_forms.ex
@@ -27,8 +27,17 @@ defmodule ControlServerWeb.Containers.HiddenForms do
     <.inputs_for :let={f_nested} field={@field}>
       <.input type="hidden" field={f_nested[:name]} />
       <.input type="hidden" field={f_nested[:image]} />
-      <.input type="hidden" field={f_nested[:command]} multiple={true} />
-      <.input type="hidden" field={f_nested[:args]} multiple={true} />
+      <.input type="hidden" field={f_nested[:path]} />
+
+      <%= if f_nested[:args].value do %>
+        <.input
+          :for={cmd <- f_nested[:args].value}
+          type="hidden"
+          name={f_nested[:args].name <> "[]"}
+          value={cmd}
+        />
+      <% end %>
+
       <.inputs_for :let={env_nested} field={f_nested[:env_values]}>
         <.single_env_value_hidden form={env_nested} />
       </.inputs_for>


### PR DESCRIPTION
Addresses #425 by replacing the `command` field in the container form with a virtual `path` field, and adds an input list for container arguments.

<img width="782" alt="Screenshot 2024-09-23 at 16 42 16" src="https://github.com/user-attachments/assets/cf45374f-09fb-400f-b7a1-58a1946e1d83">
<img width="780" alt="Screenshot 2024-09-23 at 16 43 17" src="https://github.com/user-attachments/assets/b6bd2355-60a4-441c-959b-712dbe2170d4">
