### PR TITLE
feat: use postmark to deliver on prod

### DIFF
--- a/platform_umbrella/apps/home_base_web/config/runtime.exs
+++ b/platform_umbrella/apps/home_base_web/config/runtime.exs
@@ -37,6 +37,11 @@ config :common_core, CommonCore.JWK,
   sign_key: :environment,
   verify_keys: [:home_a_pub, :home_b_pub]
 
+config :home_base, HomeBase.Mailer,
+  adapter: Swoosh.Adapters.Postmark,
+  # Fall back to the black hole postmark server if no key is provided
+  api_key: System.get_env("POSTMARK_KEY") || "d382f183-4b4b-417f-82db-3f9635a05c8b"
+
 config :home_base, HomeBase.Repo,
   database: postgres_database,
   hostname: postgres_host,

--- a/platform_umbrella/config/config.exs
+++ b/platform_umbrella/config/config.exs
@@ -123,7 +123,7 @@ config :oauth2,
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
 
-config :swoosh, :api_client, Swoosh.ApiClient.Finch
+config :swoosh, api_client: Swoosh.ApiClient.Finch, finch_name: CommonCore.Finch
 
 config :tesla, adapter: {Tesla.Adapter.Finch, [timeout: 30_000, name: CommonCore.Finch]}
 


### PR DESCRIPTION
Summary:
Set up swoosh to use the correct finch pool
Set up swoosh to use postmark for home base web prod
Set up a black hole server for home base

Test Plan:
Get a prod server up and running again.
