### PR TITLE
security: remove all traces of the private key as early as possible

### DIFF
--- a/platform_umbrella/apps/home_base/lib/home_base/customer_installs.ex
+++ b/platform_umbrella/apps/home_base/lib/home_base/customer_installs.ex
@@ -89,6 +89,7 @@ defmodule HomeBase.CustomerInstalls do
     |> Repo.insert()
   end
 
+  @spec update_installation(CommonCore.Installation.t(), any()) :: {:ok, CommonCore.Installation.t()} | {:error, any()}
   @doc """
   Updates a installation.
 
@@ -105,6 +106,12 @@ defmodule HomeBase.CustomerInstalls do
     installation
     |> Installation.changeset(attrs)
     |> Repo.update()
+  end
+
+  @spec remove_control_jwk(CommonCore.Installation.t()) ::
+          {:ok, CommonCore.Installation.t()} | {:error, any()}
+  def remove_control_jwk(%Installation{control_jwk: jwk} = installation) do
+    update_installation(installation, %{control_jwk: CommonCore.JWK.public_key(jwk)})
   end
 
   @doc """

--- a/platform_umbrella/apps/home_base_web/config/runtime.exs
+++ b/platform_umbrella/apps/home_base_web/config/runtime.exs
@@ -54,9 +54,7 @@ config :home_base, HomeBase.Repo,
   username: postgres_username
 
 config :home_base_web, HomeBaseWeb.Endpoint,
-  http: [
-    port: String.to_integer(port)
-  ],
+  http: [port: String.to_integer(port)],
   check_origin: false,
   secret_key_base: secret_key_base,
   server: true

--- a/platform_umbrella/apps/home_base_web/lib/home_base_web/controllers/stored_host_report_controller.ex
+++ b/platform_umbrella/apps/home_base_web/lib/home_base_web/controllers/stored_host_report_controller.ex
@@ -6,11 +6,23 @@ defmodule HomeBaseWeb.StoredHostReportController do
   alias HomeBase.ET
   alias HomeBase.ET.StoredHostReport
 
+  require Logger
+
   action_fallback HomeBaseWeb.FallbackController
 
   def create(conn, %{"installation_id" => install_id, "jwt" => jwt}) do
     installation = CustomerInstalls.get_installation!(install_id)
     report = Installation.verify_message!(installation, jwt)
+
+    # This will rarely happen. It will only happen for the first
+    # report of the installation.
+    #
+    # Once the installation reported back, we no longer want the
+    # private key. Delete it. They showed proof of life.
+    if CommonCore.JWK.has_private_key?(installation.control_jwk) do
+      {:ok, _} = CustomerInstalls.remove_control_jwk(installation)
+      Logger.info("Removed private key for installation #{install_id} this was the first report")
+    end
 
     with {:ok, %StoredHostReport{} = stored_host_report} <-
            ET.create_stored_host_report(%{report: report, installation_id: install_id}) do

--- a/platform_umbrella/apps/home_base_web/lib/home_base_web/controllers/stored_usage_report_controller.ex
+++ b/platform_umbrella/apps/home_base_web/lib/home_base_web/controllers/stored_usage_report_controller.ex
@@ -6,12 +6,26 @@ defmodule HomeBaseWeb.StoredUsageReportController do
   alias HomeBase.ET
   alias HomeBase.ET.StoredUsageReport
 
+  require Logger
+
   action_fallback HomeBaseWeb.FallbackController
 
   def create(conn, %{"jwt" => jwt, "installation_id" => install_id}) do
     installation = CustomerInstalls.get_installation!(install_id)
     report = Installation.verify_message!(installation, jwt)
 
+    # This will rarely happen. It will only happen for the first
+    # report of the installation.
+    #
+    # Once the installation reported back, we no longer want the
+    # private key. Delete it. They showed proof of life.
+    if CommonCore.JWK.has_private_key?(installation.control_jwk) do
+      {:ok, _} = CustomerInstalls.remove_control_jwk(installation)
+      Logger.info("Removed private key for installation #{install_id} this was the first report")
+    end
+
+    # At this point we at guaranteed that we don't know thw private key
+    # So all reports must be signed from the installation.
     with {:ok, %StoredUsageReport{} = stored_usage_report} <-
            ET.create_stored_usage_report(%{report: report, installation_id: install_id}) do
       conn

--- a/platform_umbrella/apps/home_base_web/lib/home_base_web/live/installation/show_live.ex
+++ b/platform_umbrella/apps/home_base_web/lib/home_base_web/live/installation/show_live.ex
@@ -19,7 +19,7 @@ defmodule HomeBaseWeb.InstallationShowLive do
      |> assign(:page_title, installation.slug)
      |> assign(:installation, installation)
      |> assign(:provider, provider)
-     |> assign(:installed?, false)
+     |> assign(:installed?, !CommonCore.JWK.has_private_key?(installation.control_jwk))
      |> assign(:form, to_form(changeset))}
   end
 

--- a/platform_umbrella/apps/home_base_web/test/home_base_web/controllers/jwk_delete_test.exs
+++ b/platform_umbrella/apps/home_base_web/test/home_base_web/controllers/jwk_delete_test.exs
@@ -54,4 +54,25 @@ defmodule HomeBaseWeb.JwkDeleteTest do
              "Private key should not exist after report is created"
     end
   end
+
+  describe "Install spec  won't render without a private key" do
+    test "renders errors when key is gone", %{conn: conn, installation: install} do
+      # This assumes that the private key has been removed on usage report.
+      report = params_for(:usage_report)
+      conn = post(conn, ~p"/api/v1/installations/#{install.id}/usage_reports", jwt: sign(install.control_jwk, report))
+      assert %{"id" => _} = json_response(conn, 201)["data"]
+
+      conn = get(conn, ~p"/api/v1/installations/#{install.id}/spec")
+      assert json_response(conn, 400)["errors"] != %{}
+    end
+
+    # This shows that there was some change from the test above
+    test "Will render a spec before", %{conn: conn, installation: install} do
+      conn = get(conn, ~p"/api/v1/installations/#{install.id}/spec")
+
+      result = json_response(conn, 200)
+
+      assert Map.has_key?(result, "jwt") == true
+    end
+  end
 end

--- a/platform_umbrella/apps/home_base_web/test/home_base_web/controllers/jwk_delete_test.exs
+++ b/platform_umbrella/apps/home_base_web/test/home_base_web/controllers/jwk_delete_test.exs
@@ -1,0 +1,57 @@
+defmodule HomeBaseWeb.JwkDeleteTest do
+  use HomeBaseWeb.ConnCase
+
+  import HomeBase.Factory
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json"), installation: insert(:installation)}
+  end
+
+  defp sign(jwk, data) do
+    jwk |> JOSE.JWT.sign(JOSE.JWT.from(data)) |> elem(1)
+  end
+
+  describe "Host reports remove private key" do
+    test "removes private key when creating stored host report", %{conn: conn, installation: install} do
+      report = params_for(:host_report)
+
+      install_one = HomeBase.CustomerInstalls.get_installation!(install.id)
+
+      assert CommonCore.JWK.has_private_key?(install_one.control_jwk) == true,
+             "Private key should exist before report is created"
+
+      conn = post(conn, ~p"/api/v1/installations/#{install.id}/host_reports", jwt: sign(install.control_jwk, report))
+      assert %{"id" => id} = json_response(conn, 201)["data"]
+
+      report = HomeBase.ET.get_stored_host_report!(id)
+      assert report != nil
+
+      install_two = HomeBase.CustomerInstalls.get_installation!(install.id)
+
+      assert CommonCore.JWK.has_private_key?(install_two.control_jwk) == false,
+             "Private key should not exist after report is created"
+    end
+  end
+
+  describe "Usage reports remove the private keys" do
+    test "removes private key when creating stored usage report", %{conn: conn, installation: install} do
+      report = params_for(:usage_report)
+
+      install_one = HomeBase.CustomerInstalls.get_installation!(install.id)
+
+      assert CommonCore.JWK.has_private_key?(install_one.control_jwk) == true,
+             "Private key should exist before report is created"
+
+      conn = post(conn, ~p"/api/v1/installations/#{install.id}/usage_reports", jwt: sign(install.control_jwk, report))
+      assert %{"id" => id} = json_response(conn, 201)["data"]
+
+      report = HomeBase.ET.get_stored_usage_report!(id)
+      assert report != nil
+
+      install_two = HomeBase.CustomerInstalls.get_installation!(install.id)
+
+      assert CommonCore.JWK.has_private_key?(install_two.control_jwk) == false,
+             "Private key should not exist after report is created"
+    end
+  end
+end


### PR DESCRIPTION
Summary:
For every install we generate a curve pair. Home base will verify all
messages for usage and hosts with that key. We don't want others to get
it. So this makes the first report to remove the key.

This also adds some palces where we assert that the keys are using our
curve. That's becuase I made assumptions about how the keys are
structured based upon this key type.

Test Plan:
- Tests Added
