### PR TITLE
feat: use the current request host, port, and scheme for starting

### DIFF
--- a/platform_umbrella/apps/home_base_web/lib/home_base_web/live/installation/show_live.ex
+++ b/platform_umbrella/apps/home_base_web/lib/home_base_web/live/installation/show_live.ex
@@ -7,6 +7,8 @@ defmodule HomeBaseWeb.InstallationShowLive do
   alias HomeBaseWeb.InstallationNewLive
   alias HomeBaseWeb.UserAuth
 
+  on_mount {HomeBaseWeb.RequestURL, :default}
+
   def mount(%{"id" => id}, _session, socket) do
     owner = UserAuth.current_team_or_user(socket)
     installation = CustomerInstalls.get_installation!(id, owner)
@@ -72,7 +74,10 @@ defmodule HomeBaseWeb.InstallationShowLive do
           To download and install the Batteries Included control server in <%= @provider %>, run the script below.
         </p>
         <!-- TODO: update script src to actual installation script -->
-        <.script src="https://install.example.com/8ej3l" class="mt-4 mb-8" />
+        <.script
+          src={"#{@request_scheme}://#{@request_authority}/installations/#{@installation.id}/script"}
+          class="mt-4 mb-8"
+        />
         <.markdown content={explanation(@installation)} />
       </.panel>
 
@@ -106,7 +111,10 @@ defmodule HomeBaseWeb.InstallationShowLive do
           We havn't heard from your installation yet! To download and install the Batteries Included control server in <%= @provider %>, run the script below.
         </p>
         <!-- TODO: update script src to actual installation script -->
-        <.script src="https://install.example.com/8ej3l" class="mb-8" />
+        <.script
+          src={"#{@request_scheme}://#{@request_authority}/installations/#{@installation.id}/script"}
+          class="mb-8"
+        />
         <.markdown content={explanation(@installation)} />
       </.panel>
 

--- a/platform_umbrella/apps/home_base_web/lib/home_base_web/request_host.ex
+++ b/platform_umbrella/apps/home_base_web/lib/home_base_web/request_host.ex
@@ -1,0 +1,35 @@
+defmodule HomeBaseWeb.RequestURL do
+  @moduledoc false
+
+  import Plug.Conn
+
+  def assign_request_info(conn, _) do
+    url =
+      conn
+      |> request_url()
+      |> URI.new!()
+
+    scheme =
+      conn
+      |> get_req_header("x-forwarded-proto")
+      |> List.first(url.scheme)
+
+    authority =
+      if url.port == 80 or url.port == 443 do
+        url.host
+      else
+        "#{url.host}:#{url.port}"
+      end
+
+    conn
+    |> put_session(:request_authority, authority)
+    |> put_session(:request_scheme, scheme)
+  end
+
+  def on_mount(:default, _params, %{"request_authority" => authority, "request_scheme" => scheme}, socket) do
+    {:cont,
+     socket
+     |> Phoenix.Component.assign_new(:request_authority, fn -> authority end)
+     |> Phoenix.Component.assign_new(:request_scheme, fn _ -> scheme end)}
+  end
+end

--- a/platform_umbrella/apps/home_base_web/lib/home_base_web/router.ex
+++ b/platform_umbrella/apps/home_base_web/lib/home_base_web/router.ex
@@ -1,6 +1,7 @@
 defmodule HomeBaseWeb.Router do
   use HomeBaseWeb, :router
 
+  import HomeBaseWeb.RequestURL
   import HomeBaseWeb.UserAuth
 
   @redirect_authenticated_user {HomeBaseWeb.UserAuth, :redirect_authenticated_user}
@@ -27,6 +28,10 @@ defmodule HomeBaseWeb.Router do
 
   pipeline :api do
     plug :accepts, ["json"]
+  end
+
+  pipeline :add_request_info do
+    plug :assign_request_info
   end
 
   # Enable LiveDashboard and Swoosh mailbox preview in development
@@ -74,7 +79,7 @@ defmodule HomeBaseWeb.Router do
   end
 
   scope "/", HomeBaseWeb do
-    pipe_through [:browser, :app_layout, :require_authenticated_user]
+    pipe_through [:browser, :app_layout, :require_authenticated_user, :add_request_info]
 
     live_session :app, layout: @app_layout, on_mount: [@ensure_authenticated_user] do
       live "/", DashboardLive


### PR DESCRIPTION
Summary:
When coming to home base, we can have a lot of hostnames. So figure that
out at run time. However live view doesn't really offer that since the
socket persists. Instead we use the last on we saw before leaving
Plug.Conn goodbye.

Test Plan:
```
/bin/bash -c "$(curl -fsSL http://home.127-0-0-1.batrsinc.co:4100/installations/batt_01922808981a728a95959a2488018987/script)"
```
