### PR TITLE
chore: switch to key allowlist

### DIFF
--- a/platform_umbrella/apps/common_core/priv/keys/.gitignore
+++ b/platform_umbrella/apps/common_core/priv/keys/.gitignore
@@ -1,2 +1,7 @@
-home_a.pem
-home_b.pem
+*
+!home_a.pub.pem
+!home_b.pub.pem
+!test.pub.pem
+
+# this should be the only private key in here!
+!test.pem


### PR DESCRIPTION
I think, by preventing all files in the keys directory and explicitly allowing specific public keys, we're less likely to accidently commit something?