### PR TITLE
chore: bump the stable bi version now that 0.19.0 has been released

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/defaults/versions.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/defaults/versions.ex
@@ -2,5 +2,5 @@ defmodule CommonCore.Defaults.Versions do
   @moduledoc false
 
   @spec bi_stable_version() :: String.t()
-  def bi_stable_version, do: "0.18.1"
+  def bi_stable_version, do: "0.19.0"
 end

--- a/platform_umbrella/apps/common_core/lib/common_core/et/stable_versions_report.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/et/stable_versions_report.ex
@@ -4,5 +4,6 @@ defmodule CommonCore.ET.StableVersionsReport do
 
   batt_embedded_schema do
     field :control_server, :string, default: CommonCore.Defaults.Images.control_server_image()
+    field :bi, :string, default: CommonCore.Defaults.Versions.bi_stable_version()
   end
 end


### PR DESCRIPTION
Summary:
0.19.0 should include enough that the script can work. So start using
it.

Test Plan:
Deploy a new home base and try it out.
