### PR TITLE
feat: secure the api

### DIFF
--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/plug/api_sso_auth.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/plug/api_sso_auth.ex
@@ -1,0 +1,64 @@
+defmodule ControlServerWeb.Plug.ApiSSOAuth do
+  @moduledoc false
+
+  import Phoenix.Controller
+  import Plug.Conn
+
+  alias KubeServices.Keycloak.UserClient
+  alias KubeServices.SystemState.SummaryBatteries
+
+  def init(opts \\ []) do
+    opts
+  end
+
+  def call(conn, opts) do
+    maybe_require_sso(conn, opts)
+  end
+
+  defp maybe_require_sso(conn, _opts) do
+    cond do
+      # There's no sso so let them in
+      !SummaryBatteries.battery_installed(:sso) ->
+        conn
+
+      # In test mode we don't require sso as there's no kubernetes
+      !battery_services_running?() ->
+        conn
+
+      valid_token?(conn) ->
+        conn
+
+      true ->
+        unauthorized(conn)
+    end
+  end
+
+  def valid_token?(conn) do
+    token =
+      conn
+      |> get_req_header("authorization")
+      # Remove "Bearer " from the token
+      |> Enum.map(fn header -> header |> String.replace("Bearer ", "") |> String.trim() end)
+      |> List.last()
+
+    token_ok?(token)
+  end
+
+  defp token_ok?(nil), do: false
+
+  defp token_ok?(token) do
+    case UserClient.userinfo(token) do
+      {:ok, _} -> true
+      _ -> false
+    end
+  end
+
+  def unauthorized(conn) do
+    conn
+    |> put_status(401)
+    |> json(%{error: "Unauthorized"})
+    |> halt()
+  end
+
+  def battery_services_running?, do: KubeServices.Application.start_services?()
+end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/router.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/router.ex
@@ -3,6 +3,8 @@ defmodule ControlServerWeb.Router do
 
   import Phoenix.LiveDashboard.Router
 
+  alias ControlServerWeb.Plug.InstallStatus
+
   require CommonCore.Env
 
   pipeline :browser do
@@ -16,13 +18,15 @@ defmodule ControlServerWeb.Router do
 
   pipeline :auth do
     plug ControlServerWeb.Plug.SessionID
-    plug ControlServerWeb.Plug.InstallStatus
+    plug InstallStatus
     plug ControlServerWeb.Plug.RefreshToken
     plug ControlServerWeb.Plug.SSOAuth
   end
 
   pipeline :api do
     plug :accepts, ["json"]
+    plug InstallStatus
+    plug ControlServerWeb.Plug.ApiSSOAuth
   end
 
   scope "/", ControlServerWeb do


### PR DESCRIPTION
Summary:
For now this isn't very performant, but we check that the api has a
valid token by fetching the userinfo.

Test Plan:
```
curl -X GET -H "Authorization: Bearer $token" http://control.127-0-0-1.batrsinc.co:4000/api/postgres/clusters | jq
```

Adding chars to the token fails everything.
Not passing a token fails everything.
