### PR TITLE
chore: update bi to 0.20.0

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/defaults/versions.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/defaults/versions.ex
@@ -2,5 +2,5 @@ defmodule CommonCore.Defaults.Versions do
   @moduledoc false
 
   @spec bi_stable_version() :: String.t()
-  def bi_stable_version, do: "0.19.0"
+  def bi_stable_version, do: "0.20.0"
 end


### PR DESCRIPTION
Summary:
0.20.0 bi has fixes that should make it work on localhost even with
different hostnames.

Test Plan:
bix bootstrap
