### PR TITLE
Add individual postgres users for project resources

### DIFF
--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/ai_form.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/ai_form.ex
@@ -195,6 +195,7 @@ defmodule ControlServerWeb.Projects.AIForm do
             phx_target={@myself}
             with_divider={false}
             ticks={PGCluster.compact_storage_range_ticks()}
+            action={:new}
           />
         </div>
 

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/database_form.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/database_form.ex
@@ -158,6 +158,7 @@ defmodule ControlServerWeb.Projects.DatabaseForm do
           form={to_form(@form[:postgres].value, as: :postgres)}
           phx_target={@myself}
           ticks={PGCluster.compact_storage_range_ticks()}
+          action={:new}
         />
 
         <.input field={@form[:need_redis]} type="switch" label="I need a Redis instance" />
@@ -165,6 +166,7 @@ defmodule ControlServerWeb.Projects.DatabaseForm do
         <RedisFormSubcomponents.size_form
           class={!normalize_value("checkbox", @form[:need_redis].value) && "hidden"}
           form={to_form(@form[:redis].value, as: :redis)}
+          action={:new}
         />
 
         <.input
@@ -180,6 +182,7 @@ defmodule ControlServerWeb.Projects.DatabaseForm do
                !normalize_value("checkbox", @form[:need_ferret].value)) && "hidden"
           }
           form={to_form(@form[:ferret].value, as: :ferret)}
+          action={:new}
         />
 
         <:actions>

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/web_form.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/web_form.ex
@@ -256,6 +256,7 @@ defmodule ControlServerWeb.Projects.WebForm do
             form={to_form(@form[:postgres].value, as: :postgres)}
             phx_target={@myself}
             ticks={PGCluster.compact_storage_range_ticks()}
+            action={:new}
           />
         </.flex>
 
@@ -264,6 +265,7 @@ defmodule ControlServerWeb.Projects.WebForm do
         <RedisFormSubcomponents.size_form
           class={!normalize_value("checkbox", @form[:need_redis].value) && "hidden"}
           form={to_form(@form[:redis].value, as: :redis)}
+          action={:new}
         />
 
         <:actions>


### PR DESCRIPTION
This addresses #469 by creating individual pg users for each service created under a new project. An initial `root` user is created with superuser permissions (but not attached to anything), then `jupyter`, `knative`, and `traditional` users are created with login permissions depending on the project type, and attached to the service.

### Other Fixes

- Allow database name to be edited for new projects