### PR TITLE
feat: add timeouts and logging to the oauth flow

### DIFF
--- a/platform_umbrella/apps/kube_services/lib/kube_services/system_state/keycloak_summarizer.ex
+++ b/platform_umbrella/apps/kube_services/lib/kube_services/system_state/keycloak_summarizer.ex
@@ -123,6 +123,6 @@ defmodule KubeServices.SystemState.KeycloakSummarizer do
   end
 
   def snapshot(target \\ @me) do
-    GenServer.call(target, :snapshot, 60_000)
+    GenServer.call(target, :snapshot, 30_000)
   end
 end

--- a/platform_umbrella/apps/kube_services/lib/kube_services/system_state/summarizer.ex
+++ b/platform_umbrella/apps/kube_services/lib/kube_services/system_state/summarizer.ex
@@ -22,7 +22,8 @@ defmodule KubeServices.SystemState.Summarizer do
   end
 
   @spec new(atom | pid | {atom, any} | {:via, atom, any}) :: StateSummary.t()
-  def new(target \\ @me), do: GenServer.call(target, :new)
+  def new(target \\ @me), do: GenServer.call(target, :new, to_timeout(second: 90))
+
   @spec cached(atom | pid | {atom, any} | {:via, atom, any}) :: StateSummary.t()
   def cached(target \\ @me), do: GenServer.call(target, :cached)
   @spec cached_field(atom | pid | {atom, any} | {:via, atom, any}, atom) :: any

--- a/platform_umbrella/config/config.exs
+++ b/platform_umbrella/config/config.exs
@@ -118,8 +118,8 @@ config :logger,
 
 config :oauth2,
   debug: false,
-  adapter: {Tesla.Adapter.Finch, [timeout: 30_000, name: CommonCore.Finch]},
-  middleware: [Tesla.Middleware.Telemetry]
+  adapter: {Tesla.Adapter.Finch, [timeout: 10_500, name: CommonCore.Finch]},
+  middleware: [Tesla.Middleware.Telemetry, {Tesla.Middleware.Timeout, timeout: 10_000}]
 
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason


### PR DESCRIPTION
Summary:
When the oauth server is up, but not responding Summarizer was crashing. That's because the timeouts were all out of wack. So this adds a timeout to everything.

Test:
Ran it on my mac with vpn down and it times out.
