### PR TITLE
fix: tagged releases must be run with -p1 for goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,6 @@ jobs:
             ${{ runner.os }}-go-build-
 
       - name: Release
-        run: goreleaser release --clean --verbose
+        run: goreleaser release --clean --verbose -p 1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Summary:
Since we delete the temp dirs we can't have goreleaser running multiple
builds on tagged releases

Test Plan:
Tag something soon
