### PR TITLE
Home base dashboard updates

### DIFF
--- a/platform_umbrella/apps/home_base/test/home_base/customer_installs_test.exs
+++ b/platform_umbrella/apps/home_base/test/home_base/customer_installs_test.exs
@@ -29,11 +29,30 @@ defmodule HomeBase.CustomerInstallsTest do
       assert CustomerInstalls.list_installations(team) == [installation]
     end
 
+    test "list_recent_installations/2 returns all recent installations for a user" do
+      user = insert(:user)
+      team = insert(:team)
+
+      insert(:team_role, user_id: user.id, team_id: team.id)
+
+      user_installation = installation_fixture(user_id: user.id)
+      team_installation = installation_fixture(team_id: team.id)
+
+      assert [installation1, installation2] = CustomerInstalls.list_recent_installations(user)
+      assert installation1.id == team_installation.id
+      assert installation2.id == user_installation.id
+    end
+
     test "count_installations/1 returns the count for a user" do
       user = insert(:user)
-      installation_fixture(user_id: user.id)
+      team = insert(:team)
 
-      assert CustomerInstalls.count_installations(user) == 1
+      insert(:team_role, user_id: user.id, team_id: team.id)
+
+      installation_fixture(user_id: user.id)
+      installation_fixture(team_id: team.id)
+
+      assert CustomerInstalls.count_installations(user) == 2
     end
 
     test "count_installations/1 returns the count for a team" do
@@ -42,6 +61,15 @@ defmodule HomeBase.CustomerInstallsTest do
       installation_fixture(team_id: team.id)
 
       assert CustomerInstalls.count_installations(team) == 2
+    end
+
+    test "count_teams/1 returns the count for a user" do
+      user = insert(:user)
+      team = insert(:team)
+
+      insert(:team_role, user_id: user.id, team_id: team.id)
+
+      assert CustomerInstalls.count_teams(user) == 1
     end
 
     test "get_installation!/1 returns the installation with given id" do

--- a/platform_umbrella/apps/home_base_web/lib/home_base_web/live/installation/index_live.ex
+++ b/platform_umbrella/apps/home_base_web/lib/home_base_web/live/installation/index_live.ex
@@ -2,6 +2,7 @@ defmodule HomeBaseWeb.InstallationLive do
   @moduledoc false
   use HomeBaseWeb, :live_view
 
+  alias CommonCore.Teams.Team
   alias HomeBase.CustomerInstalls
   alias HomeBaseWeb.UserAuth
 
@@ -12,9 +13,12 @@ defmodule HomeBaseWeb.InstallationLive do
     {:ok,
      socket
      |> assign(:page, :installations)
-     |> assign(:page_title, "Installations")
+     |> assign(:page_title, "Installations#{title_addon(owner)}")
      |> assign(:installations, installations)}
   end
+
+  defp title_addon(%Team{} = team), do: " for #{team.name}"
+  defp title_addon(_), do: nil
 
   def render(assigns) do
     ~H"""
@@ -34,7 +38,7 @@ defmodule HomeBaseWeb.InstallationLive do
 
     <div :if={@installations != []}>
       <div class="flex items-center justify-between mb-2">
-        <.h2>Installations</.h2>
+        <.h2><%= @page_title %></.h2>
 
         <.button variant="dark" icon={:plus} link={~p"/installations/new"}>
           New Installation
@@ -49,6 +53,7 @@ defmodule HomeBaseWeb.InstallationLive do
         >
           <:col :let={installation} label="ID"><%= installation.id %></:col>
           <:col :let={installation} label="Slug"><%= installation.slug %></:col>
+          <:col :let={installation} label="Provider"><%= installation.kube_provider %></:col>
 
           <:action :let={installation}>
             <.button


### PR DESCRIPTION
Addresses #884 by adding two new panels to replace the checklist for starting an installation/creating a team, a panel for recent installations across all teams (which will automatically switch to the team if clicked), and a total team count. Also changed the total installation count to include installations across all of the user's teams, and removed the placeholder graphs.

---

<img width="1119" alt="Screenshot 2024-10-07 at 17 40 12" src="https://github.com/user-attachments/assets/ac6f419f-ba31-41ca-b5ca-abad10a29310">
<img width="1118" alt="Screenshot 2024-10-07 at 17 40 23" src="https://github.com/user-attachments/assets/61f75184-1da8-4b02-98e6-fe3e555adc19">
