### PR TITLE
fix(monitoring): get cloudnative pg dashboards working

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/resources/monitoring/vm_agent.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/resources/monitoring/vm_agent.ex
@@ -20,7 +20,6 @@ defmodule CommonCore.Resources.VMAgent do
 
     spec =
       %{}
-      |> Map.put("externalLabels", %{"cluster" => "cluster-name"})
       |> Map.put("extraArgs", %{"promscrape.streamParse" => "true"})
       |> Map.put("image", %{"tag" => battery.config.image_tag})
       |> Map.put("remoteWrite", [


### PR DESCRIPTION
The removed configuration relabels all metrics with `cluster="cluster-name"`. cnpg labels all of their metrics with the cnpg cluster name and the dashboards rely on it but it was getting overwritten. Remove the relabeling.