### PR TITLE
Better UI for adding and editing keycloak users

### DIFF
--- a/platform_umbrella/apps/common_ui/lib/common_ui/components/script.ex
+++ b/platform_umbrella/apps/common_ui/lib/common_ui/components/script.ex
@@ -10,6 +10,8 @@ defmodule CommonUI.Components.Script do
   attr :id, :string
   attr :class, :any, default: nil
   attr :src, :string, required: true
+  attr :link_url, :string, default: nil
+  attr :link_url_text, :string, default: "Open script source"
   attr :template, :string, default: "/bin/bash -c \"$(curl -fsSL @src)\""
   attr :rest, :global
 
@@ -26,8 +28,8 @@ defmodule CommonUI.Components.Script do
       {@rest}
     >
       <div class="relative flex-1 h-full">
-        <div id={@id} class="flex items-center absolute inset-0 whitespace-nowrap overflow-auto px-5">
-          <%= String.replace(@template, "@src", @src) %>
+        <div class="flex items-center absolute inset-0 whitespace-nowrap overflow-auto px-5">
+          <span id={@id}><%= String.replace(@template, "@src", @src) %></span>
         </div>
       </div>
 
@@ -38,11 +40,11 @@ defmodule CommonUI.Components.Script do
 
       <.tooltip target_id={"#{@id}-clipboard"}>Copy to clipboard</.tooltip>
 
-      <.link id={"#{@id}-open"} class={link_class()} href={@src} target="_blank">
+      <.link id={"#{@id}-open"} class={link_class()} href={@link_url || @src} target="_blank">
         <.icon name={:arrow_top_right_on_square} class="size-6" solid />
       </.link>
 
-      <.tooltip target_id={"#{@id}-open"}>Open script source</.tooltip>
+      <.tooltip target_id={"#{@id}-open"}><%= @link_url_text %></.tooltip>
     </div>
     """
   end

--- a/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/script_test/test_script_with_custom_link.heyya_snap
+++ b/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/script_test/test_script_with_custom_link.heyya_snap
@@ -1,7 +1,7 @@
 <div class="relative flex items-center rounded-lg overflow-hidden h-14 bg-gray-darkest-tint text-white text-lg tracking-tighter font-mono font-bold ">
   <div class="relative flex-1 h-full">
     <div class="flex items-center absolute inset-0 whitespace-nowrap overflow-auto px-5">
-      <span id="foobar">/bin/bash -c &quot;$(curl -fsSL https://install.example.com/8ej3l)&quot;</span>
+      <span id="foobar">wget https://install.example.com/8ej3l</span>
     </div>
   </div>
 
@@ -20,7 +20,7 @@
   </div>
 </div>
 
-  <a href="https://install.example.com/8ej3l" id="foobar-open" target="_blank" class="flex items-center justify-center size-14 bg-gray-darkest-tint border-l border-l-gray-darker-tint hover:bg-gray-darker-tint">
+  <a href="https://batteriesincl.com" id="foobar-open" target="_blank" class="flex items-center justify-center size-14 bg-gray-darkest-tint border-l border-l-gray-darker-tint hover:bg-gray-darker-tint">
     <svg xmlns="http://www.w3.org/2000/svg" class="size-6" aria-hidden="true" fill="currentColor" viewBox="0 0 24 24">
   <path fill-rule="evenodd" d="M15.75 2.25H21a.75.75 0 0 1 .75.75v5.25a.75.75 0 0 1-1.5 0V4.81L8.03 17.03a.75.75 0 0 1-1.06-1.06L19.19 3.75h-3.44a.75.75 0 0 1 0-1.5Zm-10.5 4.5a1.5 1.5 0 0 0-1.5 1.5v10.5a1.5 1.5 0 0 0 1.5 1.5h10.5a1.5 1.5 0 0 0 1.5-1.5V10.5a.75.75 0 0 1 1.5 0v8.25a3 3 0 0 1-3 3H5.25a3 3 0 0 1-3-3V8.25a3 3 0 0 1 3-3h8.25a.75.75 0 0 1 0 1.5H5.25Z" clip-rule="evenodd"/>
 </svg>
@@ -28,7 +28,7 @@
 
   <div class="hidden" id="tooltip-foobar-open" phx-hook="Tooltip" data-target="foobar-open" data-tippy-options="{}">
   <div>
-    Open script source
+    Open link
   </div>
 </div>
 </div>

--- a/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/script_test/test_script_with_template_component.heyya_snap
+++ b/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/script_test/test_script_with_template_component.heyya_snap
@@ -1,7 +1,7 @@
 <div class="relative flex items-center rounded-lg overflow-hidden h-14 bg-gray-darkest-tint text-white text-lg tracking-tighter font-mono font-bold ">
   <div class="relative flex-1 h-full">
-    <div id="foobar" class="flex items-center absolute inset-0 whitespace-nowrap overflow-auto px-5">
-      wget https://install.example.com/8ej3l
+    <div class="flex items-center absolute inset-0 whitespace-nowrap overflow-auto px-5">
+      <span id="foobar">wget https://install.example.com/8ej3l</span>
     </div>
   </div>
 

--- a/platform_umbrella/apps/common_ui/test/common_ui/components/script_test.exs
+++ b/platform_umbrella/apps/common_ui/test/common_ui/components/script_test.exs
@@ -18,4 +18,18 @@ defmodule CommonUI.Components.ScriptTest do
     <.script id="foobar" src="https://install.example.com/8ej3l" template="wget @src" />
     """
   end
+
+  component_snapshot_test "script with custom link" do
+    assigns = %{}
+
+    ~H"""
+    <.script
+      id="foobar"
+      src="https://install.example.com/8ej3l"
+      link_url="https://batteriesincl.com"
+      link_url_text="Open link"
+      template="wget @src"
+    />
+    """
+  end
 end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/keycloak/users_table.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/keycloak/users_table.ex
@@ -19,14 +19,15 @@ defmodule ControlServerWeb.Keycloak.UsersTable do
       </:col>
 
       <:action :let={user}>
-        <.a phx-click="reset_password" data-confirm="Are you sure?" phx-value-user-id={user.id}>
-          Reset Password
-        </.a>
-      </:action>
-      <:action :let={user}>
-        <.a phx-click="make_realm_admin" data-confirm="Are you sure?" phx-value-user-id={user.id}>
-          Make Realm Admin
-        </.a>
+        <.button
+          variant="minimal"
+          icon={:pencil}
+          id={"edit_user_" <> user.id}
+          phx-click="edit-user"
+          phx-value-user-id={user.id}
+        />
+
+        <.tooltip target_id={"edit_user_" <> user.id}>Edit User</.tooltip>
       </:action>
     </.table>
     """

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/keycloak/realms_list.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/keycloak/realms_list.ex
@@ -9,20 +9,17 @@ defmodule ControlServerWeb.Live.KeycloakRealmsList do
 
   @impl Phoenix.LiveView
   def mount(%{} = _params, _session, socket) do
-    {:ok, socket |> assign_realms() |> assign_keycloak_url() |> assign_current_page()}
+      socket
+      |> assign(:current_page, :net_sec)
+      |> assign(:keycloak_url, SummaryURLs.url_for_battery(:keycloak))
+      |> assign_realms()
   end
 
-  defp assign_realms(socket) do
-    {:ok, realms} = AdminClient.realms()
-    assign(socket, :realms, realms)
-  end
-
-  defp assign_keycloak_url(socket) do
-    assign(socket, :keycloak_url, SummaryURLs.url_for_battery(:keycloak))
-  end
-
-  defp assign_current_page(socket) do
-    assign(socket, :current_page, :net_sec)
+  def assign_realms(socket) do
+    case AdminClient.realms() do
+      {:ok, realms} -> {:ok, assign(socket, :realms, realms)}
+      _ -> {:ok, assign(socket, :realms, [])}
+    end
   end
 
   @impl Phoenix.LiveView

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/keycloak/realms_list.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/keycloak/realms_list.ex
@@ -9,10 +9,10 @@ defmodule ControlServerWeb.Live.KeycloakRealmsList do
 
   @impl Phoenix.LiveView
   def mount(%{} = _params, _session, socket) do
-      socket
-      |> assign(:current_page, :net_sec)
-      |> assign(:keycloak_url, SummaryURLs.url_for_battery(:keycloak))
-      |> assign_realms()
+    socket
+    |> assign(:current_page, :net_sec)
+    |> assign(:keycloak_url, SummaryURLs.url_for_battery(:keycloak))
+    |> assign_realms()
   end
 
   def assign_realms(socket) do

--- a/platform_umbrella/apps/control_server_web/test/__snapshots__/components/keycloak/tables_test/test_keycloak_users_table__1_with_a_user.heyya_snap
+++ b/platform_umbrella/apps/control_server_web/test/__snapshots__/components/keycloak/tables_test/test_keycloak_users_table__1_with_a_user.heyya_snap
@@ -24,17 +24,21 @@
         <td class="px-2 py-4 align-top first:rounded-l-lg last:rounded-r-lg first:font-semibold">
           <div class="flex items-center justify-end gap-3 lg:gap-4 px-2 whitespace-nowrap text-sm font-semibold">
             
-    <a href="#" class="font-medium text-primary hover:text-primary-dark hover:underline" phx-click="reset_password" data-confirm="Are you sure?" phx-value-user-id="00-00-00-00-00-00-00-00-00-00-01">
+    <button class="inline-flex items-center justify-center gap-2 font-semibold text-sm text-nowrap cursor-pointer disabled:cursor-not-allowed phx-submit-loading:opacity-75 text-gray-dark hover:text-gray disabled:text-gray-light dark:text-gray dark:hover:text-gray-light dark:disabled:text-gray-dark" id="edit_user_00-00-00-00-00-00-00-00-00-00-01" type="button" phx-click="edit-user" phx-value-user-id="00-00-00-00-00-00-00-00-00-00-01">
+  <svg xmlns="http://www.w3.org/2000/svg" class="size-5 text-current stroke-2 pointer-events-none" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+  <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125"/>
+</svg>
+
   
-      Reset Password
-    
-</a>
+
   
-    <a href="#" class="font-medium text-primary hover:text-primary-dark hover:underline" phx-click="make_realm_admin" data-confirm="Are you sure?" phx-value-user-id="00-00-00-00-00-00-00-00-00-00-01">
-  
-      Make Realm Admin
-    
-</a>
+</button>
+
+    <div class="hidden" id="tooltip-edit_user_00-00-00-00-00-00-00-00-00-00-01" phx-hook="Tooltip" data-target="edit_user_00-00-00-00-00-00-00-00-00-00-01" data-tippy-options="{}">
+  <div>
+    Edit User
+  </div>
+</div>
   
           </div>
         </td>

--- a/platform_umbrella/apps/kube_services/lib/kube_services/keycloak/user_manager.ex
+++ b/platform_umbrella/apps/kube_services/lib/kube_services/keycloak/user_manager.ex
@@ -209,6 +209,7 @@ defmodule KubeServices.Keycloak.UserManager do
 
   defp extract_user_id_from_url(url) do
     url
+    |> to_string()
     |> URI.parse()
     |> Map.get(:path)
     |> String.split("/")


### PR DESCRIPTION
This fixes #890 by implementing a better UI for creating new and editing existing keycloak users.

- Replaces the "Reset Password"/"Make Realm Admin" links in the table with an "Edit User" modal containing buttons for the same options
- Styles the temporary password modal with a copy to clipboard button and a link to the keycloak instance
- Automatically generates a temporary password after creating the user
- Adds a switch for making the new user an admin during creation
- Fixes a crash when trying to view all realms and there are none
- Properly displays errors coming from the keycloak API
- Adds global flash messages for errors

---

![Screenshot from 2024-10-09 15-49-15](https://github.com/user-attachments/assets/ce2d342c-1eac-4809-b7b6-3e95c5e23797)
![Screenshot from 2024-10-09 15-51-20](https://github.com/user-attachments/assets/2a5c52cf-149d-418d-853b-e0061468f2fe)
![Screenshot from 2024-10-09 15-52-03](https://github.com/user-attachments/assets/e9c824ce-4ec2-4005-8891-2fe1ccb8df95)
![Screenshot from 2024-10-09 15-50-07](https://github.com/user-attachments/assets/54105edd-cc3e-4b3d-b854-05ca4bb9f3c8)
![Screenshot from 2024-10-09 15-50-32](https://github.com/user-attachments/assets/46f974f8-6d68-4c33-94d7-7196b8f68070)