### PR TITLE
Use current host for constructing email URLs

### DIFF
--- a/platform_umbrella/apps/common_ui/lib/common_ui/components/email.ex
+++ b/platform_umbrella/apps/common_ui/lib/common_ui/components/email.ex
@@ -345,10 +345,10 @@ defmodule CommonUI.Components.Email do
                   <table role="presentation" border="0" cellpadding="0" cellspacing="0">
                     <tr>
                       <td class="logo">
-                        <a href={@home_url}>
+                        <a href={@marketing_url}>
                           <img
                             width="100"
-                            src={URI.merge(@home_url, "/images/emails/logo.png") |> to_string()}
+                            src={URI.merge(@marketing_url, "/images/emails/logo.png") |> to_string()}
                           />
                         </a>
                       </td>

--- a/platform_umbrella/apps/common_ui/lib/common_ui/helpers/email_helpers.ex
+++ b/platform_umbrella/apps/common_ui/lib/common_ui/helpers/email_helpers.ex
@@ -44,7 +44,7 @@ defmodule CommonUI.EmailHelpers do
       into the email footer. This helps to prevent the email from
       being marked as spam.
 
-    * `:home_url` - The URL used when constructing links to
+    * `:marketing_url` - The URL used when constructing links to
       the marketing site and image paths hosted there (such as
       the logo). This is required.
 
@@ -68,7 +68,7 @@ defmodule CommonUI.EmailHelpers do
     endpoint = Keyword.fetch!(opts, :endpoint)
     from = Keyword.get(opts, :from)
     street_address = Keyword.get(opts, :street_address)
-    home_url = Keyword.fetch!(opts, :home_url)
+    marketing_url = Keyword.fetch!(opts, :marketing_url)
 
     quote do
       import CommonUI.EmailHelpers
@@ -83,7 +83,7 @@ defmodule CommonUI.EmailHelpers do
           |> Swoosh.Email.from(Map.get(assigns, :from, unquote(from)))
           |> Swoosh.Email.assign(:street_address, unquote(street_address))
           |> Swoosh.Email.assign(:static_url, unquote(endpoint).static_url())
-          |> Swoosh.Email.assign(:home_url, unquote(home_url))
+          |> Swoosh.Email.assign(:marketing_url, unquote(marketing_url))
 
         email = if Keyword.has_key?(functions, :subject), do: assign_subject(email, __MODULE__), else: email
         email = if Keyword.has_key?(functions, :text), do: render_text(email, __MODULE__), else: email

--- a/platform_umbrella/apps/common_ui/test/common_ui/helpers/email_helpers_test.exs
+++ b/platform_umbrella/apps/common_ui/test/common_ui/helpers/email_helpers_test.exs
@@ -5,7 +5,7 @@ defmodule CommonUI.EmailHelpersTest do
     endpoint: CommonUIWeb.Endpoint,
     from: {"Test", "test@test.com"},
     street_address: "123 Easy St, New York, NY 10001",
-    home_url: "http://127.0.0.1:4321"
+    marketing_url: "http://127.0.0.1:4321"
 
   import Phoenix.Component
 

--- a/platform_umbrella/apps/home_base_web/lib/home_base_web.ex
+++ b/platform_umbrella/apps/home_base_web/lib/home_base_web.ex
@@ -57,7 +57,7 @@ defmodule HomeBaseWeb do
           endpoint: HomeBaseWeb.Endpoint,
           from: {"Batteries Included", "system@batteriesincl.com"},
           street_address: "Batteries Included, 8 The Green, Ste. B, Dover, DE 19901",
-          home_url: Application.fetch_env!(:home_base_web, :home_url)
+          marketing_url: Application.fetch_env!(:home_base_web, :marketing_url)
         ],
         opts
       )

--- a/platform_umbrella/apps/home_base_web/lib/home_base_web/emails/welcome_confirm_email.ex
+++ b/platform_umbrella/apps/home_base_web/lib/home_base_web/emails/welcome_confirm_email.ex
@@ -20,7 +20,7 @@ defmodule HomeBaseWeb.WelcomeConfirmEmail do
     to this email. We'd love to hear from you! If you want to read more
     about our vision and roadmap, visit our blog at:
 
-    #{assigns.home_url}/posts
+    #{assigns.marketing_url}/posts
 
     All the best,
     The Batteries Included Team
@@ -39,7 +39,7 @@ defmodule HomeBaseWeb.WelcomeConfirmEmail do
       <br />
       <p>
         If you have any questions or feedback, please don't hesitate to reply to this email. We'd love to hear from you! If you want to read more about our vision and roadmap, visit <a
-          href={"#{@home_url}/posts"}
+          href={"#{@marketing_url}/posts"}
           target="_blank"
         >our blog</a>.
       </p>

--- a/platform_umbrella/apps/home_base_web/lib/home_base_web/live/forgot_password_live.ex
+++ b/platform_umbrella/apps/home_base_web/lib/home_base_web/live/forgot_password_live.ex
@@ -4,6 +4,8 @@ defmodule HomeBaseWeb.ForgotPasswordLive do
 
   alias HomeBase.Accounts
 
+  on_mount {HomeBaseWeb.RequestURL, :default}
+
   def mount(_params, _session, socket) do
     {:ok,
      socket
@@ -16,7 +18,7 @@ defmodule HomeBaseWeb.ForgotPasswordLive do
     if user = Accounts.get_user_by_email(email) do
       with {:ok, token} <- Accounts.get_user_reset_password_token(user),
            {:ok, _} <-
-             %{to: email, url: url(~p"/reset/#{token}")}
+             %{to: email, url: socket.assigns.request_url <> ~p"/reset/#{token}"}
              |> HomeBaseWeb.ResetPasswordEmail.render()
              |> HomeBase.Mailer.deliver() do
         # No action needed here, the with statement is to appease dialyzer (-_-)

--- a/platform_umbrella/apps/home_base_web/lib/home_base_web/live/installation/show_live.ex
+++ b/platform_umbrella/apps/home_base_web/lib/home_base_web/live/installation/show_live.ex
@@ -116,9 +116,8 @@ defmodule HomeBaseWeb.InstallationShowLive do
         <p class="leading-6 mb-4">
           To download and install the Batteries Included control server in <%= @provider %>, run the script below.
         </p>
-        <!-- TODO: update script src to actual installation script -->
         <.script
-          src={"#{@request_scheme}://#{@request_authority}/api/v1/installations/#{@installation.id}/script"}
+          src={"#{@request_url}/api/v1/installations/#{@installation.id}/script"}
           class="mt-4 mb-8"
         />
         <.markdown content={explanation(@installation)} />
@@ -155,10 +154,7 @@ defmodule HomeBaseWeb.InstallationShowLive do
         <p class="leading-6 mb-4">
           We haven't heard from your installation yet! To download and install the Batteries Included control server in <%= @provider %>, run the script below.
         </p>
-        <.script
-          src={"#{@request_scheme}://#{@request_authority}/api/v1/installations/#{@installation.id}/script"}
-          class="mb-8"
-        />
+        <.script src={"#{@request_url}/api/v1/installations/#{@installation.id}/script"} class="mb-8" />
         <.markdown content={explanation(@installation)} />
       </.panel>
 

--- a/platform_umbrella/apps/home_base_web/lib/home_base_web/live/signup_live.ex
+++ b/platform_umbrella/apps/home_base_web/lib/home_base_web/live/signup_live.ex
@@ -5,6 +5,8 @@ defmodule HomeBaseWeb.SignupLive do
   alias CommonCore.Accounts.User
   alias HomeBase.Accounts
 
+  on_mount {HomeBaseWeb.RequestURL, :default}
+
   def mount(params, _session, socket) do
     changeset =
       Accounts.change_user_registration(%User{
@@ -22,7 +24,7 @@ defmodule HomeBaseWeb.SignupLive do
     with {:ok, user} <- Accounts.register_user(user_params),
          {:ok, token} <- Accounts.get_user_confirmation_token(user),
          {:ok, _} <-
-           %{to: user.email, url: url(~p"/confirm/#{token}")}
+           %{to: user.email, url: socket.assigns.request_url <> ~p"/confirm/#{token}"}
            |> HomeBaseWeb.WelcomeConfirmEmail.render()
            |> HomeBase.Mailer.deliver() do
       changeset = Accounts.change_user_registration(user)

--- a/platform_umbrella/apps/home_base_web/lib/home_base_web/live/teams/new_live.ex
+++ b/platform_umbrella/apps/home_base_web/lib/home_base_web/live/teams/new_live.ex
@@ -7,6 +7,8 @@ defmodule HomeBaseWeb.TeamsNewLive do
   alias CommonCore.Teams.TeamRole
   alias HomeBase.Teams
 
+  on_mount {HomeBaseWeb.RequestURL, :default}
+
   def mount(_params, _session, socket) do
     changeset = Team.changeset(%Team{roles: [empty_role()]})
 
@@ -27,7 +29,7 @@ defmodule HomeBaseWeb.TeamsNewLive do
 
   def handle_event("save", %{"team" => params}, socket) do
     with {:ok, team} <- Teams.create_team(socket.assigns.current_user, params),
-         {:ok, _} <- notify_users_of_role(team) do
+         {:ok, _} <- notify_users_of_role(team, socket.assigns.request_url) do
       {:noreply,
        socket
        |> put_flash(:global_success, "Team created successfully")
@@ -49,19 +51,19 @@ defmodule HomeBaseWeb.TeamsNewLive do
     end
   end
 
-  defp notify_users_of_role(team) do
+  defp notify_users_of_role(team, req_url) do
     team.roles
     |> Enum.map(fn role ->
       # Send a different email to users that already have an account
       case role.user do
         %{email: email} ->
-          HomeBaseWeb.TeamRoleEmail.render(%{to: email, team: team, url: url(~p"/installations")})
+          HomeBaseWeb.TeamRoleEmail.render(%{to: email, team: team, url: req_url <> ~p"/installations"})
 
         _ ->
           HomeBaseWeb.TeamInvitedEmail.render(%{
             to: role.invited_email,
             team: team,
-            url: url(~p"/signup?#{[email: role.invited_email]}")
+            url: req_url <> ~p"/signup?#{[email: role.invited_email]}"
           })
       end
     end)

--- a/platform_umbrella/apps/home_base_web/lib/home_base_web/request_host.ex
+++ b/platform_umbrella/apps/home_base_web/lib/home_base_web/request_host.ex
@@ -23,6 +23,9 @@ defmodule HomeBaseWeb.RequestURL do
     {:cont,
      socket
      |> Phoenix.Component.assign_new(:request_authority, fn -> authority end)
-     |> Phoenix.Component.assign_new(:request_scheme, fn _ -> scheme end)}
+     |> Phoenix.Component.assign_new(:request_scheme, fn _ -> scheme end)
+     |> Phoenix.Component.assign_new(:request_url, fn assigns ->
+       assigns.request_scheme <> "://" <> assigns.request_authority
+     end)}
   end
 end

--- a/platform_umbrella/apps/home_base_web/lib/home_base_web/router.ex
+++ b/platform_umbrella/apps/home_base_web/lib/home_base_web/router.ex
@@ -24,14 +24,11 @@ defmodule HomeBaseWeb.Router do
     plug :put_secure_browser_headers
     plug :put_root_layout, html: @root_layout
     plug :put_layout, false
+    plug :assign_request_info
   end
 
   pipeline :api do
     plug :accepts, ["json"]
-  end
-
-  pipeline :add_request_info do
-    plug :assign_request_info
   end
 
   # Enable LiveDashboard and Swoosh mailbox preview in development
@@ -79,7 +76,7 @@ defmodule HomeBaseWeb.Router do
   end
 
   scope "/", HomeBaseWeb do
-    pipe_through [:browser, :app_layout, :require_authenticated_user, :add_request_info]
+    pipe_through [:browser, :app_layout, :require_authenticated_user]
 
     live_session :app, layout: @app_layout, on_mount: [@ensure_authenticated_user] do
       live "/", DashboardLive

--- a/platform_umbrella/apps/home_base_web/test/home_base_web/emails/welcome_confirm_email_test.exs
+++ b/platform_umbrella/apps/home_base_web/test/home_base_web/emails/welcome_confirm_email_test.exs
@@ -6,14 +6,14 @@ defmodule HomeBaseWeb.WelcomeConfirmEmailTest do
   @url "/confirm"
 
   component_snapshot_test "welcome confirm text email" do
-    WelcomeConfirmEmail.text(%{home_url: nil, url: @url})
+    WelcomeConfirmEmail.text(%{marketing_url: nil, url: @url})
   end
 
   component_snapshot_test "welcome confirm html email" do
-    assigns = %{home_url: nil, url: @url}
+    assigns = %{marketing_url: nil, url: @url}
 
     ~H"""
-    <WelcomeConfirmEmail.html home_url={@home_url} url={@url} />
+    <WelcomeConfirmEmail.html marketing_url={@marketing_url} url={@url} />
     """
   end
 end

--- a/platform_umbrella/config/config.exs
+++ b/platform_umbrella/config/config.exs
@@ -95,7 +95,7 @@ config :home_base_web, HomeBaseWeb.Endpoint,
 config :home_base_web,
   ecto_repos: [HomeBase.Repo],
   generators: [context_app: :home_base, binary_id: true],
-  home_url: "http://127.0.0.1:4321"
+  marketing_url: "http://127.0.0.1:4321"
 
 config :kube_services, KubeServices.SnapshotApply.TimedLauncher,
   delay: 900_000,

--- a/platform_umbrella/config/prod.exs
+++ b/platform_umbrella/config/prod.exs
@@ -36,7 +36,8 @@ import Config
 
 config :common_ui, CommonUIWeb.Endpoint, server: false
 
-config :home_base_web, home_url: "https://www.batteriesincl.com"
+config :home_base_web, HomeBaseWeb.Endpoint, url: [host: "www.batteriesincl.com"]
+config :home_base_web, marketing_url: "https://www.batteriesincl.com"
 
 config :kube_services, :clusters, default: :service_account
 config :kube_services, cluster_type: :prod


### PR DESCRIPTION
Fixes https://github.com/batteries-included/batteries-included/issues/1018 by using the request scheme and authority for constructing URLs in emails. Also renames the `home_url` config value to `marketing_url` as to not confuse it with the home base url.

Related to https://github.com/batteries-included/batteries-included/issues/1013