### PR TITLE
fix: don't crash with nxdomain on ET.HomeBaseClient for prod

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/et/urls.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/et/urls.ex
@@ -3,7 +3,7 @@ defmodule CommonCore.ET.URLs do
   alias CommonCore.Batteries.BatteryCoreConfig
 
   @local_home "http://home.127-0-0-1.batrsinc.co:4100/api/v1"
-  @prod_home "https://home.prod.batteriesincl.com/api/v1"
+  @prod_home "https://home-base.battery-traditional.webapp.13-59-225-158.batrsinc.co//api/v1"
   @bi_home "http://home-base.battery-traditional.svc.cluster.local.:4000/api/v1"
 
   def home_base_url(%BatteryCoreConfig{usage: usage} = _config) when usage in [:internal_prod, :internal_int_test],

--- a/platform_umbrella/apps/common_core/lib/common_core/et/urls.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/et/urls.ex
@@ -3,7 +3,7 @@ defmodule CommonCore.ET.URLs do
   alias CommonCore.Batteries.BatteryCoreConfig
 
   @local_home "http://home.127-0-0-1.batrsinc.co:4100/api/v1"
-  @prod_home "https://home-base.battery-traditional.webapp.13-59-225-158.batrsinc.co//api/v1"
+  @prod_home "https://home-base.battery-traditional.webapp.13-59-225-158.batrsinc.co/api/v1"
   @bi_home "http://home-base.battery-traditional.svc.cluster.local.:4000/api/v1"
 
   def home_base_url(%BatteryCoreConfig{usage: usage} = _config) when usage in [:internal_prod, :internal_int_test],


### PR DESCRIPTION
Summary:
This has two main parts

- Don't assert that sending a usage report always works. This should
  stop the GenServer from crashing. InstallStatus will still time out
  and everythin will crash after a while if this is isn't correct.

  AKA this fixes #1029

- Change the prod url to a hostname the points to prod home base.

  AKA this fixes #1028

Test Plan:
- Test with latest when possible.
- Code review carefuly please
