### PR TITLE
chore: update bi stable version

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/defaults/versions.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/defaults/versions.ex
@@ -2,5 +2,5 @@ defmodule CommonCore.Defaults.Versions do
   @moduledoc false
 
   @spec bi_stable_version() :: String.t()
-  def bi_stable_version, do: "0.23.0"
+  def bi_stable_version, do: "0.24.0"
 end


### PR DESCRIPTION
Summary:
Preparing for launch marking the latest and greatest bi as stable for
use in the install script

Test Plan:
- Tested with 0.24.0
