### PR TITLE
docs: switch to the new/better dns name for homebase in prod

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/et/urls.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/et/urls.ex
@@ -3,7 +3,7 @@ defmodule CommonCore.ET.URLs do
   alias CommonCore.Batteries.BatteryCoreConfig
 
   @local_home "http://home.127-0-0-1.batrsinc.co:4100/api/v1"
-  @prod_home "https://home-base.battery-traditional.webapp.13-59-225-158.batrsinc.co/api/v1"
+  @prod_home "https://home.batteriesincl.com/api/v1"
   @bi_home "http://home-base.battery-traditional.svc.cluster.local.:4000/api/v1"
 
   def home_base_url(%BatteryCoreConfig{usage: usage} = _config) when usage in [:internal_prod, :internal_int_test],

--- a/static/src/components/widgets/Header.astro
+++ b/static/src/components/widgets/Header.astro
@@ -267,8 +267,7 @@ const currentPath = `/${trimSlash(new URL(Astro.url).pathname)}`;
           <div>
             <a
               class="text-primary font-medium lg:hidden"
-              href="https://home-base.battery-traditional.webapp.13-59-225-158.batrsinc.co/signup"
-              >Sign Up</a
+              href="https://home.batteriesincl.com/signup">Sign Up</a
             >
           </div>
         </div>

--- a/static/src/components/widgets/StartBuild.astro
+++ b/static/src/components/widgets/StartBuild.astro
@@ -15,7 +15,7 @@ import ButtonLink from '~/components/widgets/ButtonLink.astro';
         <div class="mt-8 lg:mt-12 text-center">
           <ButtonLink
             label="Sign Up Now"
-            link="https://home-base.battery-traditional.webapp.13-59-225-158.batrsinc.co/signup"
+            link="https://home.batteriesincl.com/signup"
             variant="tertiary"
             icon="aright"
           />

--- a/static/src/content/post/open-source-payoff.md
+++ b/static/src/content/post/open-source-payoff.md
@@ -136,6 +136,6 @@ in-house expertise to manage and optimize OSS implementations.
 
 As you navigate the complexities of OSS, remember that you don’t have to do it
 alone.
-[Sign up for our public beta](https://home-base.battery-traditional.webapp.13-59-225-158.batrsinc.co/signup)
+[Sign up for our public beta](https://home.batteriesincl.com/signup)
 today and take the first step towards a more efficient, innovative, and
 cost-effective future.

--- a/static/src/content/post/open-source-payoff.md
+++ b/static/src/content/post/open-source-payoff.md
@@ -135,7 +135,6 @@ tasks. Additionally, we offer training to help businesses develop the necessary
 in-house expertise to manage and optimize OSS implementations.
 
 As you navigate the complexities of OSS, remember that you don’t have to do it
-alone.
-[Sign up for our public beta](https://home.batteriesincl.com/signup)
+alone. [Sign up for our public beta](https://home.batteriesincl.com/signup)
 today and take the first step towards a more efficient, innovative, and
 cost-effective future.

--- a/static/src/content/post/public-beta-announcement.md
+++ b/static/src/content/post/public-beta-announcement.md
@@ -9,7 +9,7 @@ image: ./public-beta-announcement/install_screenshot.png
 
 # The automated DevOps platform built to help teams reduce site reliability overheadd
 
-**[Now in public beta](https://home-base.battery-traditional.webapp.13-59-225-158.batrsinc.co/signup):
+**[Now in public beta](https://home.batteriesincl.com/signup):
 Batteries Included automated DevOps platform to leverage the power of open
 source platforms**
 
@@ -85,7 +85,7 @@ free to use for our early adopters. The source code will always be available,
 but currently all usage is free to celebrate.
 
 Get started here →
-[https://home-base.battery-traditional.webapp.13-59-225-158.batrsinc.co/signup](https://home-base.battery-traditional.webapp.13-59-225-158.batrsinc.co/signup)
+[https://home.batteriesincl.com/signup](https://home.batteriesincl.com/signup)
 
 Get the source code here →
 [github.com/batteries-included/batteries-included](https://github.com/batteries-included/batteries-included)

--- a/static/src/content/post/public-beta-announcement.md
+++ b/static/src/content/post/public-beta-announcement.md
@@ -9,9 +9,9 @@ image: ./public-beta-announcement/install_screenshot.png
 
 # The automated DevOps platform built to help teams reduce site reliability overheadd
 
-**[Now in public beta](https://home.batteriesincl.com/signup):
-Batteries Included automated DevOps platform to leverage the power of open
-source platforms**
+**[Now in public beta](https://home.batteriesincl.com/signup): Batteries
+Included automated DevOps platform to leverage the power of open source
+platforms**
 
 For the modern web and full stack developer, it can feel like an impossible feat
 to spin up and manage your DevOps infrastructure. Where to begin, which

--- a/static/src/data/navigation.ts
+++ b/static/src/data/navigation.ts
@@ -209,11 +209,11 @@ export const headerData = [
   },
   {
     label: 'Login',
-    link: 'https://home-base.battery-traditional.webapp.13-59-225-158.batrsinc.co/login',
+    link: 'https://home.batteriesincl.com/login',
   },
   {
     label: 'Sign Up',
-    link: 'https://home-base.battery-traditional.webapp.13-59-225-158.batrsinc.co/signup',
+    link: 'https://home.batteriesincl.com/signup',
   },
 ];
 

--- a/static/src/pages/landing/deploy-at-the-speed-of-users.astro
+++ b/static/src/pages/landing/deploy-at-the-speed-of-users.astro
@@ -113,7 +113,7 @@ const metadata = {
         {
           variant: 'primary',
           text: 'Sign Up Now',
-          href: 'https://home-base.battery-traditional.webapp.13-59-225-158.batrsinc.co/signup',
+          href: 'https://home.batteriesincl.com/signup',
         },
       ]}
       title="Streamlined Innovation: Our Platform Built on Open Source Code"

--- a/static/src/pages/landing/deploy-your-cloud-in-seconds.astro
+++ b/static/src/pages/landing/deploy-your-cloud-in-seconds.astro
@@ -113,7 +113,7 @@ const metadata = {
         {
           variant: 'primary',
           text: 'Sign Up Now',
-          href: 'https://home-base.battery-traditional.webapp.13-59-225-158.batrsinc.co/signup',
+          href: 'https://home.batteriesincl.com/signup',
         },
       ]}
       title="Streamlined Innovation: Our Platform Built on Open Source Code"

--- a/static/src/pages/landing/enable-your-devops-team-to-move-mountains.astro
+++ b/static/src/pages/landing/enable-your-devops-team-to-move-mountains.astro
@@ -26,7 +26,7 @@ const metadata = {
           <div class="-mt-4 md:-mt-10">
             <ButtonLink
               label="Get Started"
-              link="https://home-base.battery-traditional.webapp.13-59-225-158.batrsinc.co/signup"
+              link="https://home.batteriesincl.com/signup"
               variant="tertiary"
             />
           </div>
@@ -186,8 +186,7 @@ const metadata = {
             <div class="mt-8">
               <a
                 class="text-primary underline underline-offset-8"
-                href="https://home-base.battery-traditional.webapp.13-59-225-158.batrsinc.co/signup"
-                >Signup Now</a
+                href="https://home.batteriesincl.com/signup">Signup Now</a
               >
             </div>
           </div>

--- a/static/src/pages/solutions/ai.astro
+++ b/static/src/pages/solutions/ai.astro
@@ -50,7 +50,7 @@ const metadata = {
         text="Get Started"
         variant="fifth"
         icon="aright"
-        href="https://home-base.battery-traditional.webapp.13-59-225-158.batrsinc.co/signup"
+        href="https://home.batteriesincl.com/signup"
         isLightIcon
       />
     </div>

--- a/static/src/pages/solutions/database.astro
+++ b/static/src/pages/solutions/database.astro
@@ -50,7 +50,7 @@ const metadata = {
         text="Get Started"
         variant="fifth"
         icon="aright"
-        href="https://home-base.battery-traditional.webapp.13-59-225-158.batrsinc.co/signup"
+        href="https://home.batteriesincl.com/signup"
         isLightIcon
       />
     </div>

--- a/static/src/pages/solutions/security.astro
+++ b/static/src/pages/solutions/security.astro
@@ -50,7 +50,7 @@ const metadata = {
         text="Get Started"
         variant="fifth"
         icon="aright"
-        href="https://home-base.battery-traditional.webapp.13-59-225-158.batrsinc.co/signup"
+        href="https://home.batteriesincl.com/signup"
         isLightIcon
       />
     </div>

--- a/static/src/pages/solutions/sre_tools.astro
+++ b/static/src/pages/solutions/sre_tools.astro
@@ -50,7 +50,7 @@ const metadata = {
         text="Get Started"
         variant="fifth"
         icon="aright"
-        href="https://home-base.battery-traditional.webapp.13-59-225-158.batrsinc.co/signup"
+        href="https://home.batteriesincl.com/signup"
         isLightIcon
       />
     </div>

--- a/static/src/pages/solutions/web-deploy.astro
+++ b/static/src/pages/solutions/web-deploy.astro
@@ -52,7 +52,7 @@ const metadata = {
         text="Get Started"
         variant="fifth"
         icon="aright"
-        href="https://home-base.battery-traditional.webapp.13-59-225-158.batrsinc.co/signup"
+        href="https://home.batteriesincl.com/signup"
         isLightIcon
       />
     </div>


### PR DESCRIPTION
Summary:

Our internal prod has a cname. We should use that now that JTarasovic
has pulled the rabbit out of the hat, and gotten us dns names for
traditional services

Test Plan:
- CI
- Click on netlify
