### PR TITLE
Allow empty lists for containers and env values

### DIFF
--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/knative/form_component.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/knative/form_component.ex
@@ -250,6 +250,12 @@ defmodule ControlServerWeb.Live.Knative.FormComponent do
   end
 
   defp save_service(socket, :edit, service_params) do
+    service_params =
+      service_params
+      |> Map.put_new("containers", %{})
+      |> Map.put_new("init_containers", %{})
+      |> Map.put_new("env_values", %{})
+
     case Knative.update_service(socket.assigns.service, service_params) do
       {:ok, updated_service} ->
         {:noreply,

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/notebooks/form_component.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/notebooks/form_component.ex
@@ -127,6 +127,8 @@ defmodule ControlServerWeb.Live.Notebooks.FormComponent do
   end
 
   defp save_notebook(socket, :edit, params) do
+    params = Map.put_new(params, "env_values", %{})
+
     case Notebooks.update_jupyter_lab_notebook(socket.assigns.notebook, params) do
       {:ok, notebook} ->
         {:noreply,

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/traditional_services/form_component.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/traditional_services/form_component.ex
@@ -342,6 +342,13 @@ defmodule ControlServerWeb.Live.TraditionalServices.FormComponent do
   end
 
   defp save_service(socket, :edit, service_params) do
+    service_params =
+      service_params
+      |> Map.put_new("containers", %{})
+      |> Map.put_new("init_containers", %{})
+      |> Map.put_new("env_values", %{})
+      |> Map.put_new("ports", %{})
+
     case TraditionalServices.update_service(socket.assigns.service, service_params) do
       {:ok, service} ->
         {:noreply,


### PR DESCRIPTION
This temporarily fixes the issue of not being able to delete the last item for Knative containers/env values, Traditional Service containers/env values, and Jupyter notebook env values. This is a workaround until we have a more elegant solution by submitting a PR to Ecto for supporting `drop_param` when casting array fields, and/or delving deeper into the `InputList` component and how can work with the hidden input fields.

Related to https://github.com/batteries-included/batteries-included/issues/904