### PR TITLE
docs: more new install documentation

### DIFF
--- a/platform_umbrella/apps/home_base_web/lib/home_base_web/live/installation/new_live.ex
+++ b/platform_umbrella/apps/home_base_web/lib/home_base_web/live/installation/new_live.ex
@@ -96,7 +96,7 @@ defmodule HomeBaseWeb.InstallationNewLive do
           </.input_panel>
 
           <.input_panel
-            title="What provider will you use?"
+            title="What provider will you use? If you're just testing for the first time, we recommend Kind (only Docker is needed locally)."
             description="What Kubernetes provider will you use for this installation?"
           >
             <.input

--- a/platform_umbrella/apps/home_base_web/priv/markdown/install/aws.md
+++ b/platform_umbrella/apps/home_base_web/priv/markdown/install/aws.md
@@ -10,3 +10,11 @@ and deploy batteries needed to automatically run your cluster. We will:
 - Deploy the Istio battery for mTLS and service mesh
 - Deploy the Istio Ingress Gateway battery for web traffic routing
 - Deploy the Cert Manager battery for SSL certificates
+
+### Needed
+
+For AWS installs the `bi` binary will needed
+
+- an AWS account with admin permissions
+- you have logged in via `aws sso login` or similar
+- You have set your aws profile environment variables correctly `export AWS_PROFILE=<YOUR_PROFILE_NAME>`

--- a/platform_umbrella/apps/home_base_web/priv/markdown/install/aws.md
+++ b/platform_umbrella/apps/home_base_web/priv/markdown/install/aws.md
@@ -17,4 +17,5 @@ For AWS installs the `bi` binary will needed
 
 - an AWS account with admin permissions
 - you have logged in via `aws sso login` or similar
-- You have set your aws profile environment variables correctly `export AWS_PROFILE=<YOUR_PROFILE_NAME>`
+- You have set your aws profile environment variables correctly
+  `export AWS_PROFILE=<YOUR_PROFILE_NAME>`


### PR DESCRIPTION
Summary:
Dockers's the easiest way to test
Aws needs some things to work

Test Plan:
- Deploy after this builds
