### PR TITLE
Add Field and Fieldset components

### DIFF
--- a/platform_umbrella/apps/common_ui/lib/common_ui.ex
+++ b/platform_umbrella/apps/common_ui/lib/common_ui.ex
@@ -34,6 +34,8 @@ defmodule CommonUI do
       import CommonUI.Components.DatetimeDisplay
       import CommonUI.Components.Dropdown
       import CommonUI.Components.Email
+      import CommonUI.Components.Field
+      import CommonUI.Components.Fieldset
       import CommonUI.Components.FlashGroup
       import CommonUI.Components.Form
       import CommonUI.Components.Icon

--- a/platform_umbrella/apps/common_ui/lib/common_ui/components/field.ex
+++ b/platform_umbrella/apps/common_ui/lib/common_ui/components/field.ex
@@ -1,0 +1,64 @@
+defmodule CommonUI.Components.Field do
+  @moduledoc false
+  use CommonUI, :component
+
+  import CommonUI.Components.Icon
+  import CommonUI.Components.Tooltip
+  import CommonUI.IDHelpers
+
+  attr :id, :string
+  attr :variant, :string, default: "stacked", values: ["stacked", "beside"]
+  attr :class, :any, default: nil
+  attr :rest, :global
+
+  slot :inner_block, required: true
+
+  slot :label do
+    attr :help, :string
+    attr :class, :any
+  end
+
+  slot :note do
+    attr :class, :any
+  end
+
+  def field(assigns) do
+    assigns = provide_id(assigns)
+
+    ~H"""
+    <label class={["w-full", @class]} {@rest}>
+      <div class={[@variant == "beside" && "grid grid-cols-1 lg:grid-cols-2 gap-x-4 gap-y-2"]}>
+        <div
+          :for={label <- @label}
+          class={[
+            "flex items-center gap-2 text-sm text-gray-darkest dark:text-gray-lighter",
+            @variant == "stacked" && "mb-2",
+            label[:class]
+          ]}
+        >
+          <div><%= render_slot(label) %></div>
+
+          <div :if={label[:help]}>
+            <.icon
+              solid
+              id={"#{@id}-help"}
+              name={:question_mark_circle}
+              class="size-5 opacity-30 hover:opacity-100"
+            />
+
+            <.tooltip target_id={"#{@id}-help"}>
+              <%= label.help %>
+            </.tooltip>
+          </div>
+        </div>
+
+        <%= render_slot(@inner_block) %>
+      </div>
+
+      <div :for={note <- @note} class={["text-xs text-gray-light mt-2", note[:class]]}>
+        <%= render_slot(note) %>
+      </div>
+    </label>
+    """
+  end
+end

--- a/platform_umbrella/apps/common_ui/lib/common_ui/components/fieldset.ex
+++ b/platform_umbrella/apps/common_ui/lib/common_ui/components/fieldset.ex
@@ -1,0 +1,50 @@
+defmodule CommonUI.Components.Fieldset do
+  @moduledoc false
+  use CommonUI, :component
+
+  import CommonUI.Components.FlashGroup
+  import CommonUI.Components.Typography
+  import CommonUI.IDHelpers
+
+  attr :id, :string
+  attr :responsive, :boolean, default: false
+  attr :flash, :map, default: %{}
+  attr :title, :string, default: nil
+  attr :class, :any, default: nil
+  attr :inner_class, :any, default: nil
+
+  slot :inner_block, required: true
+
+  slot :actions do
+    attr :class, :any
+  end
+
+  def fieldset(assigns) do
+    assigns = provide_id(assigns)
+    dbg(assigns.flash)
+
+    ~H"""
+    <div class={["w-full", @class]}>
+      <.h2 :if={@title}><%= @title %></.h2>
+
+      <div class={[
+        "gap-x-4 gap-y-6",
+        @responsive && "grid grid-cols-1 lg:grid-cols-2",
+        !@responsive && "flex flex-col",
+        @inner_class
+      ]}>
+        <.flash_group id={"#{@id}-flash"} flash={@flash} class="col-span-2" />
+
+        <%= render_slot(@inner_block) %>
+      </div>
+
+      <div
+        :for={actions <- @actions}
+        class={["flex items-center justify-end gap-2 mt-6", actions[:class]]}
+      >
+        <%= render_slot(actions) %>
+      </div>
+    </div>
+    """
+  end
+end

--- a/platform_umbrella/apps/common_ui/lib/common_ui/components/fieldset.ex
+++ b/platform_umbrella/apps/common_ui/lib/common_ui/components/fieldset.ex
@@ -21,7 +21,6 @@ defmodule CommonUI.Components.Fieldset do
 
   def fieldset(assigns) do
     assigns = provide_id(assigns)
-    dbg(assigns.flash)
 
     ~H"""
     <div class={["w-full", @class]}>

--- a/platform_umbrella/apps/common_ui/storybook/components/field.story.exs
+++ b/platform_umbrella/apps/common_ui/storybook/components/field.story.exs
@@ -1,0 +1,47 @@
+defmodule Storybook.Components.Field do
+  @moduledoc false
+  use PhoenixStorybook.Story, :component
+
+  def function, do: &CommonUI.Components.Field.field/1
+  def imports, do: [{CommonUI.Components.Link, a: 1}]
+
+  def variations do
+    [
+      %Variation{
+        id: :stacked,
+        slots: [
+          ~s|<:label help="This is some help text">Label</:label>|,
+          ~s|<div class="bg-gray-200 h-8" />|,
+          ~s|<:note>This is a note</:note>|
+        ]
+      },
+      %Variation{
+        id: :custom_label,
+        slots: [
+          ~s|<:label help="This is some help text">Label <.a href="#">with link</.a></:label>|,
+          ~s|<div class="bg-gray-200 h-8" />|,
+          ~s|<:note>This is a note</:note>|
+        ]
+      },
+      %Variation{
+        id: :custom_note,
+        slots: [
+          ~s|<:label help="This is some help text">Label</:label>|,
+          ~s|<div class="bg-gray-200 h-8" />|,
+          ~s|<:note>This is a note <.a href="#">with a link</.a></:note>|
+        ]
+      },
+      %Variation{
+        id: :beside,
+        slots: [
+          ~s|<:label help="This is some help text">Label</:label>|,
+          ~s|<div class="bg-gray-200 h-8" />|,
+          ~s|<:note>This is a note</:note>|
+        ],
+        attributes: %{
+          variant: "beside"
+        }
+      }
+    ]
+  end
+end

--- a/platform_umbrella/apps/common_ui/storybook/components/fieldset.story.exs
+++ b/platform_umbrella/apps/common_ui/storybook/components/fieldset.story.exs
@@ -1,0 +1,45 @@
+defmodule Storybook.Components.Fieldset do
+  @moduledoc false
+  use PhoenixStorybook.Story, :component
+
+  def function, do: &CommonUI.Components.Fieldset.fieldset/1
+  def imports, do: [{CommonUI.Components.Field, field: 1}, {CommonUI.Components.Button, button: 1}]
+
+  def variations do
+    [
+      %Variation{
+        id: :default,
+        attributes: %{
+          title: "Some Title",
+          flash: %{"info" => "Flash info"}
+        },
+        slots: [
+          ~s|<.field><:label>Label</:label> <div class="bg-gray-200 h-8" /></.field>|,
+          ~s|<.field><:label>Label</:label> <div class="bg-gray-200 h-8" /></.field>|,
+          ~s|<.field><:label>Label</:label> <div class="bg-gray-200 h-8" /></.field>|,
+          ~s|<.field><:label>Label</:label> <div class="bg-gray-200 h-8" /></.field>|,
+          ~s"""
+          <:actions>
+            <.button variant="secondary">Cancel</.button>
+            <.button variant="primary">Save</.button>
+          </:actions>
+          """
+        ]
+      },
+      %Variation{
+        id: :responsive,
+        attributes: %{
+          responsive: true,
+          title: "Some Title",
+          flash: %{"info" => "Flash info"}
+        },
+        slots: [
+          ~s|<.field><:label>Label</:label> <div class="bg-gray-200 h-8" /></.field>|,
+          ~s|<.field><:label>Label</:label> <div class="bg-gray-200 h-8" /></.field>|,
+          ~s|<.field><:label>Label</:label> <div class="bg-gray-200 h-8" /></.field>|,
+          ~s|<.field><:label>Label</:label> <div class="bg-gray-200 h-8" /></.field>|
+        ]
+      }
+    ]
+  end
+end

--- a/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/field_test/test_beside_field_component.heyya_snap
+++ b/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/field_test/test_beside_field_component.heyya_snap
@@ -1,0 +1,14 @@
+<label class="w-full ">
+  <div class="grid grid-cols-1 lg:grid-cols-2 gap-x-4 gap-y-2">
+    <div class="flex items-center gap-2 text-sm text-gray-darkest dark:text-gray-lighter ">
+      <div>Label</div>
+
+      
+    </div>
+
+    
+  
+  </div>
+
+  
+</label>

--- a/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/field_test/test_field_component_with_note_and_help_text.heyya_snap
+++ b/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/field_test/test_field_component_with_note_and_help_text.heyya_snap
@@ -1,0 +1,28 @@
+<label class="w-full ">
+  <div class="">
+    <div class="flex items-center gap-2 text-sm text-gray-darkest dark:text-gray-lighter mb-2">
+      <div>Label</div>
+
+      <div>
+        <svg xmlns="http://www.w3.org/2000/svg" id="hlhvkgdogjjmtdmd-help" class="size-5 opacity-30 hover:opacity-100" aria-hidden="true" fill="currentColor" viewBox="0 0 24 24">
+  <path fill-rule="evenodd" d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm11.378-3.917c-.89-.777-2.366-.777-3.255 0a.75.75 0 0 1-.988-1.129c1.454-1.272 3.776-1.272 5.23 0 1.513 1.324 1.513 3.518 0 4.842a3.75 3.75 0 0 1-.837.552c-.676.328-1.028.774-1.028 1.152v.75a.75.75 0 0 1-1.5 0v-.75c0-1.279 1.06-2.107 1.875-2.502.182-.088.351-.199.503-.331.83-.727.83-1.857 0-2.584ZM12 18a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z" clip-rule="evenodd"/>
+</svg>
+
+        <div class="hidden" id="tooltip-hlhvkgdogjjmtdmd-help" phx-hook="Tooltip" data-target="hlhvkgdogjjmtdmd-help" data-tippy-options="{}">
+  <div>
+    
+          This is some help text
+        
+  </div>
+</div>
+      </div>
+    </div>
+
+    
+  
+  </div>
+
+  <div class="text-xs text-gray-light mt-2 ">
+    This is a note
+  </div>
+</label>

--- a/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/field_test/test_field_component_with_note_and_help_text.heyya_snap
+++ b/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/field_test/test_field_component_with_note_and_help_text.heyya_snap
@@ -4,11 +4,11 @@
       <div>Label</div>
 
       <div>
-        <svg xmlns="http://www.w3.org/2000/svg" id="hlhvkgdogjjmtdmd-help" class="size-5 opacity-30 hover:opacity-100" aria-hidden="true" fill="currentColor" viewBox="0 0 24 24">
+        <svg xmlns="http://www.w3.org/2000/svg" id="foo-help" class="size-5 opacity-30 hover:opacity-100" aria-hidden="true" fill="currentColor" viewBox="0 0 24 24">
   <path fill-rule="evenodd" d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm11.378-3.917c-.89-.777-2.366-.777-3.255 0a.75.75 0 0 1-.988-1.129c1.454-1.272 3.776-1.272 5.23 0 1.513 1.324 1.513 3.518 0 4.842a3.75 3.75 0 0 1-.837.552c-.676.328-1.028.774-1.028 1.152v.75a.75.75 0 0 1-1.5 0v-.75c0-1.279 1.06-2.107 1.875-2.502.182-.088.351-.199.503-.331.83-.727.83-1.857 0-2.584ZM12 18a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z" clip-rule="evenodd"/>
 </svg>
 
-        <div class="hidden" id="tooltip-hlhvkgdogjjmtdmd-help" phx-hook="Tooltip" data-target="hlhvkgdogjjmtdmd-help" data-tippy-options="{}">
+        <div class="hidden" id="tooltip-foo-help" phx-hook="Tooltip" data-target="foo-help" data-tippy-options="{}">
   <div>
     
           This is some help text

--- a/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/field_test/test_stacked_field_component.heyya_snap
+++ b/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/field_test/test_stacked_field_component.heyya_snap
@@ -1,0 +1,14 @@
+<label class="w-full ">
+  <div class="">
+    <div class="flex items-center gap-2 text-sm text-gray-darkest dark:text-gray-lighter mb-2">
+      <div>Label</div>
+
+      
+    </div>
+
+    
+  
+  </div>
+
+  
+</label>

--- a/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/fieldset_test/test_default_fieldset_component.heyya_snap
+++ b/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/fieldset_test/test_default_fieldset_component.heyya_snap
@@ -1,0 +1,13 @@
+<div class="w-full ">
+  <h2 class="text-xl sm:text-3xl font-semibold my-3 text-gray-darkest dark:text-gray-lighter ">
+  Foo
+</h2>
+
+  <div class="gap-x-4 gap-y-6 flex flex-col">
+    
+
+    Bar
+  </div>
+
+  
+</div>

--- a/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/fieldset_test/test_responsive_fieldset_component.heyya_snap
+++ b/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/fieldset_test/test_responsive_fieldset_component.heyya_snap
@@ -1,0 +1,12 @@
+<div class="w-full ">
+  <div class="gap-x-4 gap-y-6 grid grid-cols-1 lg:grid-cols-2">
+    
+  Foobar
+
+  
+  </div>
+
+  <div class="flex items-center justify-end gap-2 mt-6 ">
+    Actions
+  </div>
+</div>

--- a/platform_umbrella/apps/common_ui/test/common_ui/components/field_test.exs
+++ b/platform_umbrella/apps/common_ui/test/common_ui/components/field_test.exs
@@ -7,7 +7,7 @@ defmodule CommonUI.Components.FieldTest do
     assigns = %{}
 
     ~H"""
-    <.field>
+    <.field id="foo">
       <:label>Label</:label>
     </.field>
     """
@@ -17,7 +17,7 @@ defmodule CommonUI.Components.FieldTest do
     assigns = %{}
 
     ~H"""
-    <.field variant="beside">
+    <.field id="foo" variant="beside">
       <:label>Label</:label>
     </.field>
     """
@@ -27,7 +27,7 @@ defmodule CommonUI.Components.FieldTest do
     assigns = %{}
 
     ~H"""
-    <.field>
+    <.field id="foo">
       <:label help="This is some help text">Label</:label>
       <:note>This is a note</:note>
     </.field>

--- a/platform_umbrella/apps/common_ui/test/common_ui/components/field_test.exs
+++ b/platform_umbrella/apps/common_ui/test/common_ui/components/field_test.exs
@@ -1,0 +1,36 @@
+defmodule CommonUI.Components.FieldTest do
+  use Heyya.SnapshotCase
+
+  import CommonUI.Components.Field
+
+  component_snapshot_test "stacked field component" do
+    assigns = %{}
+
+    ~H"""
+    <.field>
+      <:label>Label</:label>
+    </.field>
+    """
+  end
+
+  component_snapshot_test "beside field component" do
+    assigns = %{}
+
+    ~H"""
+    <.field variant="beside">
+      <:label>Label</:label>
+    </.field>
+    """
+  end
+
+  component_snapshot_test "field component with note and help text" do
+    assigns = %{}
+
+    ~H"""
+    <.field>
+      <:label help="This is some help text">Label</:label>
+      <:note>This is a note</:note>
+    </.field>
+    """
+  end
+end

--- a/platform_umbrella/apps/common_ui/test/common_ui/components/fieldset_test.exs
+++ b/platform_umbrella/apps/common_ui/test/common_ui/components/fieldset_test.exs
@@ -1,0 +1,24 @@
+defmodule CommonUI.Components.FieldsetTest do
+  use Heyya.SnapshotCase
+
+  import CommonUI.Components.Fieldset
+
+  component_snapshot_test "default fieldset component" do
+    assigns = %{}
+
+    ~H"""
+    <.fieldset title="Foo">Bar</.fieldset>
+    """
+  end
+
+  component_snapshot_test "responsive fieldset component" do
+    assigns = %{}
+
+    ~H"""
+    <.fieldset responsive>
+      Foobar
+      <:actions>Actions</:actions>
+    </.fieldset>
+    """
+  end
+end

--- a/platform_umbrella/apps/common_ui/test/common_ui/components/fieldset_test.exs
+++ b/platform_umbrella/apps/common_ui/test/common_ui/components/fieldset_test.exs
@@ -7,7 +7,7 @@ defmodule CommonUI.Components.FieldsetTest do
     assigns = %{}
 
     ~H"""
-    <.fieldset title="Foo">Bar</.fieldset>
+    <.fieldset id="foo" title="Foo">Bar</.fieldset>
     """
   end
 
@@ -15,7 +15,7 @@ defmodule CommonUI.Components.FieldsetTest do
     assigns = %{}
 
     ~H"""
-    <.fieldset responsive>
+    <.fieldset id="foo" responsive>
       Foobar
       <:actions>Actions</:actions>
     </.fieldset>


### PR DESCRIPTION
This gets started on https://github.com/batteries-included/batteries-included/issues/23 by adding `Field` and `Fieldset` components. This will help slim down the `Input` component by separating the input styling from the surrounding container and form styling.

---

<img width="557" alt="Screenshot 2024-10-17 at 16 38 42" src="https://github.com/user-attachments/assets/76e10cb8-3b50-46cc-a8c0-e5c27230efc9">
<img width="555" alt="Screenshot 2024-10-17 at 16 38 53" src="https://github.com/user-attachments/assets/741e72b0-970b-4367-b8c0-bd5b76ed5774">
