### PR TITLE
feat: add a healthz controller

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/resources/battery/control_server.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/resources/battery/control_server.ex
@@ -152,11 +152,19 @@ defmodule CommonCore.Resources.ControlServer do
     |> Map.put_new("image", image)
     |> Map.put_new("imagePullPolicy", "IfNotPresent")
     |> Map.put_new("resources", %{"requests" => %{"cpu" => "1000m", "memory" => "2000Mi"}})
+    |> Map.put_new("livenessProbe", %{
+      "httpGet" => %{
+        "path" => "/healthz",
+        "port" => @server_port,
+        "initialDelaySeconds" => 300,
+        "periodSeconds" => 30,
+        "failureThreshold" => 5
+      }
+    })
+    |> Map.put_new("readinessProbe", %{
+      "httpGet" => %{"path" => "/healthz", "port" => @server_port, "periodSeconds" => 30, "failureThreshold" => 10}
+    })
     |> Map.put_new("env", [
-      %{
-        "name" => "LC_CTYPE",
-        "value" => "en_US.UTF-8"
-      },
       %{
         "name" => "LANG",
         "value" => "en_US.UTF-8"
@@ -164,6 +172,10 @@ defmodule CommonCore.Resources.ControlServer do
       %{
         "name" => "LC_ALL",
         "value" => "en_US.UTF-8"
+      },
+      %{
+        "name" => "LANGUAGE",
+        "value" => "en_US:en"
       },
       %{
         "name" => "PORT",

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/controllers/healthz_controller.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/controllers/healthz_controller.ex
@@ -1,0 +1,39 @@
+defmodule ControlServerWeb.HealthzController do
+  use ControlServerWeb, :controller
+
+  action_fallback ControlServerWeb.FallbackController
+
+  def index(conn, params) do
+    status = check_healthz(conn, params)
+
+    conn
+    |> put_status(status[:status])
+    |> json(status)
+  end
+
+  def check_healthz(conn, params) do
+    with {:ok, _} <- check_kube_state_healthz(conn, params),
+         {:ok, _} <- check_sql_repo_healthz(conn, params) do
+      %{status: 200, message: "OK"}
+    else
+      {:error, message} ->
+        %{status: 500, message: "Internal Server Error: #{message}"}
+    end
+  end
+
+  defp check_kube_state_healthz(_conn, _params) do
+    case KubeServices.KubeState.get_all(:pod) do
+      # Assume for now that if there are pods
+      # in the KubeState table, it is healthy
+      [_ | _] ->
+        {:ok, "KubeState is healthy"}
+
+      [] ->
+        {:error, "No pods in KubeState table"}
+    end
+  end
+
+  defp check_sql_repo_healthz(_conn, _params) do
+    Ecto.Adapters.SQL.query(ControlServer.Repo, "SELECT true", [])
+  end
+end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/router.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/router.ex
@@ -37,6 +37,12 @@ defmodule ControlServerWeb.Router do
   end
 
   scope "/", ControlServerWeb do
+    pipe_through :browser
+
+    get "/healthz", HealthzController, :index
+  end
+
+  scope "/", ControlServerWeb do
     pipe_through [:browser, :auth]
 
     live "/", Live.Home, :index


### PR DESCRIPTION
Summary:

- Checks that there are some kube state pods
- Checks that sql is up
- Add that as a liveness and readiness probe

Tests:
- `curl -vvv http://control.127-0-0-1.batrsinc.co:4000/healthz`
- Saw that fail with no pods when startin up
- Passes after 1 second
- Once this is in master and an image is built I'll bix start local
