### PR TITLE
fix: try and fix liveness/readiness probe not bootstrapping

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/resources/battery/control_server.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/resources/battery/control_server.ex
@@ -110,7 +110,25 @@ defmodule CommonCore.Resources.ControlServer do
             name: name,
             base: %{
               "command" => ["/app/bin/start", "control_server"],
-              "ports" => [%{"containerPort" => @server_port}]
+              "ports" => [%{"containerPort" => @server_port}],
+              "readinessProbe" => %{
+                "httpGet" => %{
+                  "path" => "/healthz",
+                  "port" => @server_port
+                },
+                "initialDelaySeconds" => 30,
+                "periodSeconds" => 30,
+                "failureThreshold" => 10
+              },
+              "livenessProbe" => %{
+                "httpGet" => %{
+                  "path" => "/healthz",
+                  "port" => @server_port
+                },
+                "initialDelaySeconds" => 300,
+                "periodSeconds" => 30,
+                "failureThreshold" => 5
+              }
             },
             pg_secret_name: secret_name,
             pg_host: host
@@ -152,18 +170,6 @@ defmodule CommonCore.Resources.ControlServer do
     |> Map.put_new("image", image)
     |> Map.put_new("imagePullPolicy", "IfNotPresent")
     |> Map.put_new("resources", %{"requests" => %{"cpu" => "1000m", "memory" => "2000Mi"}})
-    |> Map.put_new("livenessProbe", %{
-      "httpGet" => %{
-        "path" => "/healthz",
-        "port" => @server_port,
-        "initialDelaySeconds" => 300,
-        "periodSeconds" => 30,
-        "failureThreshold" => 5
-      }
-    })
-    |> Map.put_new("readinessProbe", %{
-      "httpGet" => %{"path" => "/healthz", "port" => @server_port, "periodSeconds" => 30, "failureThreshold" => 10}
-    })
     |> Map.put_new("env", [
       %{
         "name" => "LANG",

--- a/platform_umbrella/apps/kube_bootstrap/lib/kube_bootstrap/kube.ex
+++ b/platform_umbrella/apps/kube_bootstrap/lib/kube_bootstrap/kube.ex
@@ -27,8 +27,12 @@ defmodule KubeBootstrap.Kube do
       # We don't care that the task was successful, just the result
       # unless it couldn't be run at all
       |> Enum.map(fn
-        {:ok, result} -> result
-        {:error, reason} -> {:error, reason}
+        {:ok, result} ->
+          result
+
+        {:error, reason} ->
+          Logger.warning("Failed to create resource #{inspect(reason)}", reason: reason)
+          {:error, reason}
       end)
 
     if Enum.all?(results, &result_ok?/1) do


### PR DESCRIPTION
Summary:
They aren't bootstrapping, but we swallow the error. So add that to logs
Change liveness and readiness to be only on main conatiner for control
server

Test Plan:
After master has built test again /shrug
