### PR TITLE
fix: don't crash on incomparable versions

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/version.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/version.ex
@@ -27,7 +27,7 @@ defmodule CommonCore.Version do
   end
 
   # Parse a dotted version string into a list of integers
-  @spec parse(String.t()) :: [integer()]
+  @spec parse(String.t()) :: [integer() | nil]
   defp parse(str) do
     str
     |> String.split(".")
@@ -37,17 +37,27 @@ defmodule CommonCore.Version do
   # This parses the integer part of dotted version strings
   # The last part can include a dash and a hash or other suffix
   # This function will only parse the integer part
-  @spec parse_integer(String.t()) :: integer()
+  @spec parse_integer(String.t()) :: integer() | nil
   defp parse_integer(str) do
-    str
-    |> String.split("-")
-    |> List.first()
-    |> String.to_integer()
+    result =
+      str
+      |> String.split("-")
+      |> List.first()
+      |> Integer.parse()
+
+    case result do
+      {int, _} ->
+        int
+
+      :error ->
+        nil
+    end
   end
 
-  @spec inner_compare([integer()], [integer()]) ::
+  @spec inner_compare([integer() | nil], [integer() | nil]) ::
           {:ok, :equal} | {:ok, :greater} | {:ok, :lesser} | {:error, :incomparable}
   defp inner_compare([], []), do: {:ok, :equal}
+  defp inner_compare([a | _], [b | _]) when is_nil(a) or is_nil(b), do: {:error, :incomparable}
   defp inner_compare([a | as], [b | bs]) when a == b, do: inner_compare(as, bs)
   defp inner_compare([a | _], [b | _]) when a > b, do: {:ok, :greater}
   defp inner_compare([a | _], [b | _]) when a < b, do: {:ok, :lesser}

--- a/platform_umbrella/apps/common_core/test/common_core/version_test.exs
+++ b/platform_umbrella/apps/common_core/test/common_core/version_test.exs
@@ -37,5 +37,10 @@ defmodule CommonCore.VersionTest do
     test "compare_version/2 returns {:ok, :greater} when first version is greater in last place" do
       assert CommonCore.Version.compare("1.2.4", "1.2.3") == {:ok, :greater}
     end
+
+    test "compare_version/2 returns {:error, :incomparable} when an invalid version is used" do
+      assert CommonCore.Version.compare("1.2.4", "jdt-test") == {:error, :incomparable}
+      assert CommonCore.Version.compare("jdt-test", "1.2.3") == {:error, :incomparable}
+    end
   end
 end


### PR DESCRIPTION
Trying to use an override version runs into issues when comparing version. This fixes it.