### PR TITLE
fix: don't crash logging success

### DIFF
--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/controllers/healthz_controller.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/controllers/healthz_controller.ex
@@ -50,7 +50,8 @@ defmodule ControlServerWeb.HealthzController do
       #
       # This check is simply here to make sure that the worker is running
       %CommonCore.ET.InstallStatus{} = status ->
-        {:ok, "InstallStatusWorker is healthy: #{status}"}
+        {:ok,
+         "InstallStatusWorker is healthy. staus: #{status.status} iss: #{status.iss} exp: #{status.exp} message: #{status.message}"}
 
       _ ->
         {:error, "InstallStatusWorker is not healthy"}


### PR DESCRIPTION
Summary:
Healthz wasn't working

Test Plan:
`curl -vvv http://control.127-0-0-1.batrsinc.co:4000/healthz`
