### PR TITLE
fix(monitoring): change vm storage retention from months to days

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/resources/monitoring/vm_cluster.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/resources/monitoring/vm_cluster.ex
@@ -21,7 +21,7 @@ defmodule CommonCore.Resources.VMCluster do
     spec =
       %{}
       |> Map.put("replicationFactor", battery.config.replication_factor)
-      |> Map.put("retentionPeriod", "14")
+      |> Map.put("retentionPeriod", "14d")
       |> Map.put(
         "vminsert",
         %{


### PR DESCRIPTION
related to: #1176 

Unitless number is interpreted as months. Change to days.