### PR TITLE
ci: clean asdf cache on changes

### DIFF
--- a/.github/workflows/bix.yml
+++ b/.github/workflows/bix.yml
@@ -26,7 +26,6 @@ jobs:
             ~/.asdf/plugins
             ~/.asdf/shims
           key: ${{ runner.os }}-asdf-tools-${{ hashFiles('.tool-versions') }}
-          restore-keys: ${{ runner.os }}-asdf-tools-
 
       - name: Install ASDF Tools
         uses: asdf-vm/actions/install@v3

--- a/.github/workflows/bix_docker.yml
+++ b/.github/workflows/bix_docker.yml
@@ -36,7 +36,6 @@ jobs:
             ~/.asdf/plugins
             ~/.asdf/shims
           key: ${{ runner.os }}-asdf-tools-${{ hashFiles('.tool-versions') }}
-          restore-keys: ${{ runner.os }}-asdf-tools-
 
       - name: Install ASDF Tools
         uses: asdf-vm/actions/install@v3

--- a/.github/workflows/bix_elixir.yml
+++ b/.github/workflows/bix_elixir.yml
@@ -40,7 +40,7 @@ jobs:
             ~/.asdf/plugins
             ~/.asdf/shims
           key: ${{ runner.os }}-asdf-tools-${{ hashFiles('.tool-versions') }}
-          restore-keys: ${{ runner.os }}-asdf-tools-
+
       - name: Install ASDF Tools
         uses: asdf-vm/actions/install@v3
         # See https://github.com/asdf-vm/actions/issues/445
@@ -89,7 +89,6 @@ jobs:
             ~/.asdf/plugins
             ~/.asdf/shims
           key: ${{ runner.os }}-asdf-tools-${{ hashFiles('.tool-versions') }}
-          restore-keys: ${{ runner.os }}-asdf-tools-
 
       - name: Install ASDF Tools
         uses: asdf-vm/actions/install@v3

--- a/.github/workflows/bix_go.yml
+++ b/.github/workflows/bix_go.yml
@@ -30,7 +30,6 @@ jobs:
             ~/.asdf/plugins
             ~/.asdf/shims
           key: ${{ runner.os }}-asdf-tools-${{ hashFiles('.tool-versions') }}
-          restore-keys: ${{ runner.os }}-asdf-tools-
 
       - name: Install ASDF Tools
         uses: asdf-vm/actions/install@v3
@@ -75,7 +74,6 @@ jobs:
             ~/.asdf/plugins
             ~/.asdf/shims
           key: ${{ runner.os }}-asdf-tools-${{ hashFiles('.tool-versions') }}
-          restore-keys: ${{ runner.os }}-asdf-tools-
 
       - name: Install ASDF Tools
         uses: asdf-vm/actions/install@v3
@@ -120,7 +118,6 @@ jobs:
             ~/.asdf/plugins
             ~/.asdf/shims
           key: ${{ runner.os }}-asdf-tools-${{ hashFiles('.tool-versions') }}
-          restore-keys: ${{ runner.os }}-asdf-tools-
 
       - name: Install ASDF Tools
         uses: asdf-vm/actions/install@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,6 @@ jobs:
             ~/.asdf/plugins
             ~/.asdf/shims
           key: ${{ runner.os }}-asdf-tools-${{ hashFiles('.tool-versions') }}
-          restore-keys: ${{ runner.os }}-asdf-tools-
 
       - name: Install ASDF Tools
         uses: asdf-vm/actions/install@v3


### PR DESCRIPTION
The caches are getting a bit big because we just keep adding new versions to them. For asdf, it seems like we could just take the cache miss when we are updating tools and we'll get a completely fresh cache. Since we generally update multiple at once and the tools don't take _too_ long to install, I think it's a pretty good tradeoff but am not super tied to it if you disagree.