### PR TITLE
chore(control): fix bootstrap warning

### DIFF
--- a/platform_umbrella/apps/control_server/lib/control_server/release.ex
+++ b/platform_umbrella/apps/control_server/lib/control_server/release.ex
@@ -75,7 +75,7 @@ defmodule ControlServer.Release do
   defp ensure_repo_created(repo) do
     Logger.info("Creating #{inspect(repo)} database if it doesn't exist")
 
-    case repo.__adapter__().storage_up(repo.config) do
+    case repo.__adapter__().storage_up(repo.config()) do
       :ok -> :ok
       {:error, :already_up} -> :ok
       {:error, term} -> {:error, term}


### PR DESCRIPTION
I already fixed this in `home_base` but must have missed it here in `control_server`. Noticed that it was giving a warning during bootstrap as we were troubleshooting the password issue just now.