### PR TITLE
chore: regenerate openapi schema for keycloak

### DIFF
--- a/bin/bi-source
+++ b/bin/bi-source
@@ -236,6 +236,26 @@ do_gen_static_specs() {
     run_mix clean
 }
 
+do_gen_keycloak_specs() {
+    log "Generating Keycloak specs"
+    # Make a tempfile
+    local temp_file
+    temp_file=$(mktemp /tmp/keycloak-openai.XXXXXX)
+
+    # Download https://www.keycloak.org/docs-api/latest/rest-api/openapi.json
+    # into the tempfile
+    curl -sSL https://www.keycloak.org/docs-api/latest/rest-api/openapi.json -o "${temp_file}"
+
+    run_mix "do" \
+        deps.get, \
+        compile --force, \
+        gen.openapi.schema "${temp_file}" '*' "KeycloakAdminSchema"
+
+    rm "${temp_file}"
+
+    run_mix "format"
+}
+
 do_print_jwk_json() {
     local path=${1}
     local absolute_path
@@ -313,11 +333,12 @@ Available options:
 
 Available commands:
 
-- fmt               Format code in the project [default: all]
-- check-fmt         Check if all code in the project is formatted  [default: all]
-- gen-static-specs  Generate static installation specs
-- print-jwk-json    Print the JWK key given a path as JSON for use in a secret
-- set-version       Change the version of the project in mix.exs and bin/bix
+- fmt                Format code in the project [default: all]
+- check-fmt          Check if all code in the project is formatted  [default: all]
+- gen-static-specs   Generate static installation specs
+- gen-keycloak-specs Generate Keycloak OpenAPI specs
+- print-jwk-json     Print the JWK key given a path as JSON for use in a secret
+- set-version        Change the version of the project in mix.exs and bin/bix
 EOF
     exit 1
 }
@@ -362,6 +383,9 @@ check-fmt)
     ;;
 gen-static-specs)
     do_gen_static_specs
+    ;;
+gen-keycloak-specs)
+    do_gen_keycloak_specs
     ;;
 print-jwk-json)
     do_print_jwk_json "${args[@]}"

--- a/platform_umbrella/apps/common_core/lib/common_core/ecto/enum.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/ecto/enum.ex
@@ -1,0 +1,121 @@
+defmodule CommonCore.Ecto.Enum do
+  @moduledoc false
+
+  @spec __using__(keyword() | map()) :: Macro.t()
+  defmacro __using__(input) do
+    valid_map =
+      input
+      |> Enum.flat_map(fn {k, v} ->
+        if is_atom(k) and is_binary(v), do: [{k, v}], else: []
+      end)
+      |> Map.new()
+
+    valid_keys = Map.keys(valid_map)
+    valid_values = Map.values(valid_map)
+
+    type_union = type_union(valid_keys)
+    backing_type = backing_type(valid_values)
+
+    quote bind_quoted: [
+            valid_keys: valid_keys,
+            valid_values: valid_values,
+            backing_type: backing_type,
+            type_union: Macro.escape(type_union),
+            valid_map: Macro.escape(valid_map)
+          ] do
+      # This is an ecto type
+      @behaviour Ecto.Type
+
+      # Define the type for this enum module
+      @type t :: unquote(type_union)
+
+      @spec type() :: :string | :integer
+      def type, do: unquote(backing_type)
+
+      @spec cast(term()) :: {:ok, t()} | :error
+
+      for {atom, value} <- valid_map do
+        def cast(unquote(atom)), do: {:ok, unquote(atom)}
+
+        # Do this dance to make sure that value and atom_string are
+        # not the same and defining a method twice
+        for v <- Enum.uniq([value, Atom.to_string(atom)]) do
+          def cast(unquote(v)), do: {:ok, unquote(atom)}
+        end
+      end
+
+      def cast(_other), do: :error
+
+      # Load comes in from the database, so no need to over specify these
+      @spec load(term()) :: {:ok, t()} | no_return()
+      for {atom, value} <- valid_map do
+        def load(unquote(value)), do: {:ok, unquote(atom)}
+      end
+
+      def load(term) do
+        msg =
+          "Value `#{inspect(term)}` is not a valid enum value for `#{inspect(__MODULE__)}`. " <>
+            "Valid values are `#{inspect(__valid_values__())}`"
+
+        raise Ecto.ChangeError, message: msg
+      end
+
+      @spec dump(t() | String.t()) :: {:ok, String.t() | integer()} | no_return()
+      for {atom, value} <- valid_map do
+        def dump(unquote(atom)), do: {:ok, unquote(value)}
+
+        for v <- Enum.uniq([value, Atom.to_string(atom)]) do
+          def dump(unquote(v)), do: {:ok, unquote(value)}
+        end
+      end
+
+      def dump(term) do
+        msg =
+          "Value `#{inspect(term)}` is not a valid enum value for `#{inspect(__MODULE__)}`. " <>
+            "Valid values are `#{inspect(__valid_values__())}`"
+
+        raise Ecto.ChangeError, message: msg
+      end
+
+      @spec valid_value?(term()) :: boolean()
+      for valid_value <- valid_values do
+        def valid_value?(unquote(valid_value)), do: true
+      end
+
+      @spec embed_as(atom()) :: :self
+      def embed_as(_), do: :self
+
+      @spec equal?(term(), term()) :: boolean()
+      def equal?(term1, term2), do: term1 == term2
+
+      def valid_value?(_), do: false
+
+      @spec __enum_map__() :: %{atom() => String.t() | integer()}
+      def __enum_map__, do: unquote(Macro.escape(valid_map))
+
+      @spec __valid_values__() :: [String.t() | integer()]
+      def __valid_values__, do: unquote(valid_values)
+    end
+  end
+
+  defp type_union(valid_keys) do
+    case valid_keys do
+      [] ->
+        quote(do: atom())
+
+      [single] ->
+        quote(do: unquote(single))
+
+      [first | rest] ->
+        Enum.reduce(rest, quote(do: unquote(first)), fn key, acc ->
+          quote(do: unquote(acc) | unquote(key))
+        end)
+    end
+  end
+
+  defp backing_type(valid_values) do
+    (Enum.all?(valid_values, &is_binary/1) && :string) ||
+      (Enum.all?(valid_values, &is_integer/1) && :integer) ||
+      raise ArgumentError, "All enum values must be of the same type, either all strings or all integers."
+  end
+end

--- a/platform_umbrella/apps/common_core/lib/common_core/open_api/keycloak_admin_schema.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/open_api/keycloak_admin_schema.ex
@@ -1,43 +1,150 @@
 defmodule CommonCore.OpenAPI.KeycloakAdminSchema do
   @moduledoc false
-  defmodule AuthenticationExecutionExportRepresentation do
+  defmodule BruteForceStrategy do
+    @moduledoc false
+    use CommonCore.Ecto.Enum, linear: "LINEAR", multiple: "MULTIPLE"
+  end
+
+  defmodule DecisionEffect do
+    @moduledoc false
+    use CommonCore.Ecto.Enum, permit: "PERMIT", deny: "DENY"
+  end
+
+  defmodule DecisionStrategy do
+    @moduledoc false
+    use CommonCore.Ecto.Enum,
+      affirmative: "AFFIRMATIVE",
+      unanimous: "UNANIMOUS",
+      consensus: "CONSENSUS"
+  end
+
+  defmodule EnforcementMode do
+    @moduledoc false
+    use CommonCore.Ecto.Enum,
+      permissive: "PERMISSIVE",
+      enforcing: "ENFORCING",
+      disabled: "DISABLED"
+  end
+
+  defmodule KeyUse do
+    @moduledoc false
+    use CommonCore.Ecto.Enum, sig: "SIG", enc: "ENC"
+  end
+
+  defmodule Logic do
+    @moduledoc false
+    use CommonCore.Ecto.Enum, positive: "POSITIVE", negative: "NEGATIVE"
+  end
+
+  defmodule MembershipType do
+    @moduledoc false
+    use CommonCore.Ecto.Enum, unmanaged: "UNMANAGED", managed: "MANAGED"
+  end
+
+  defmodule PolicyEnforcementMode do
+    @moduledoc false
+    use CommonCore.Ecto.Enum,
+      enforcing: "ENFORCING",
+      permissive: "PERMISSIVE",
+      disabled: "DISABLED"
+  end
+
+  defmodule ScopeEnforcementMode do
+    @moduledoc false
+    use CommonCore.Ecto.Enum, all: "ALL", any: "ANY", disabled: "DISABLED"
+  end
+
+  defmodule UnmanagedAttributePolicy do
+    @moduledoc false
+    use CommonCore.Ecto.Enum,
+      enabled: "ENABLED",
+      admin_view: "ADMIN_VIEW",
+      admin_edit: "ADMIN_EDIT"
+  end
+
+  defmodule UserConsentRepresentation do
     @moduledoc false
     use CommonCore, :embedded_schema
 
     batt_embedded_schema do
-      field :authenticator, :string
-      field :authenticatorConfig, :string
-      field :authenticatorFlow, :boolean
-      field :flowAlias, :string
-      field :priority, :integer
-      field :requirement, :string
-      field :userSetupAllowed, :boolean
+      field :clientId, :string
+      field :createdDate, :integer
+      field :grantedClientScopes, {:array, :string}
+      field :grantedRealmRoles, {:array, :string}
+      field :lastUpdatedDate, :integer
     end
   end
 
-  defmodule AuthenticationFlowRepresentation do
+  defmodule UserProfileAttributeMetadata do
     @moduledoc false
     use CommonCore, :embedded_schema
 
     batt_embedded_schema do
-      field :alias, :string
-      embeds_many :authenticationExecutions, AuthenticationExecutionExportRepresentation
-      field :builtIn, :boolean
-      field :description, :string
-      field :id, :string
-      field :providerId, :string
-      field :topLevel, :boolean
+      field :annotations, :map
+      field :displayName, :string
+      field :group, :string
+      field :multivalued, :boolean
+      field :name, :string
+      field :readOnly, :boolean
+      field :required, :boolean
+      field :validators, :map
     end
   end
 
-  defmodule AuthenticatorConfigRepresentation do
+  defmodule ClaimRepresentation do
     @moduledoc false
     use CommonCore, :embedded_schema
 
     batt_embedded_schema do
-      field :alias, :string
+      field :address, :boolean
+      field :email, :boolean
+      field :gender, :boolean
+      field :locale, :boolean
+      field :name, :boolean
+      field :phone, :boolean
+      field :picture, :boolean
+      field :profile, :boolean
+      field :username, :boolean
+      field :website, :boolean
+    end
+  end
+
+  defmodule UserFederationMapperRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
       field :config, :map
+      field :federationMapperType, :string
+      field :federationProviderDisplayName, :string
       field :id, :string
+      field :name, :string
+    end
+  end
+
+  defmodule ClientInitialAccessPresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :count, :integer
+      field :expiration, :integer
+      field :id, :string
+      field :remainingCount, :integer
+      field :timestamp, :integer
+      field :token, :string
+    end
+  end
+
+  defmodule Permission do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :claims, :map
+      field :rsid, :string
+      field :rsname, :string
+      field :scopes, {:array, :string}
     end
   end
 
@@ -63,56 +170,190 @@ defmodule CommonCore.OpenAPI.KeycloakAdminSchema do
     end
   end
 
-  defmodule ClaimRepresentation do
+  defmodule AuthenticationExecutionRepresentation do
     @moduledoc false
     use CommonCore, :embedded_schema
 
     batt_embedded_schema do
-      field :address, :boolean
-      field :email, :boolean
-      field :gender, :boolean
-      field :locale, :boolean
-      field :name, :boolean
-      field :phone, :boolean
-      field :picture, :boolean
-      field :profile, :boolean
-      field :username, :boolean
-      field :website, :boolean
+      field :authenticator, :string
+      field :authenticatorConfig, :string
+      field :authenticatorFlow, :boolean
+      field :autheticatorFlow, :boolean
+      field :flowId, :string
+      field :id, :string
+      field :parentFlow, :string
+      field :priority, :integer
+      field :requirement, :string
     end
   end
 
-  defmodule ApplicationRepresentation do
+  defmodule ManagementPermissionReference do
     @moduledoc false
     use CommonCore, :embedded_schema
 
     batt_embedded_schema do
-      embeds_one :claims, ClaimRepresentation
+      field :enabled, :boolean
+      field :resource, :string
+      field :scopePermissions, :map
+    end
+  end
+
+  defmodule UserProfileAttributeGroupMetadata do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :annotations, :map
+      field :displayDescription, :string
+      field :displayHeader, :string
       field :name, :string
     end
   end
 
-  defmodule ComponentExportRepresentation do
+  defmodule UPAttributeSelector do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :scopes, {:array, :string}
+    end
+  end
+
+  defmodule Access do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :roles, {:array, :string}
+      field :verify_caller, :boolean
+    end
+  end
+
+  defmodule Authorization do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      embeds_many :permissions, Permission
+    end
+  end
+
+  defmodule UPAttributePermissions do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :edit, {:array, :string}
+      field :view, {:array, :string}
+    end
+  end
+
+  defmodule UserFederationProviderRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :changedSyncPeriod, :integer
+      field :config, :map
+      field :displayName, :string
+      field :fullSyncPeriod, :integer
+      field :id, :string
+      field :lastSync, :integer
+      field :priority, :integer
+      field :providerName, :string
+    end
+  end
+
+  defmodule RequiredActionProviderRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :alias, :string
+      field :config, :map
+      field :defaultAction, :boolean
+      field :enabled, :boolean
+      field :name, :string
+      field :priority, :integer
+      field :providerId, :string
+    end
+  end
+
+  defmodule GlobalRequestResult do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :failedRequests, {:array, :string}
+      field :successRequests, {:array, :string}
+    end
+  end
+
+  defmodule EventRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :clientId, :string
+      field :details, :map
+      field :error, :string
+      field :id, :string
+      field :ipAddress, :string
+      field :realmId, :string
+      field :sessionId, :string
+      field :time, :integer
+      field :type, :string
+      field :userId, :string
+    end
+  end
+
+  defmodule UserSessionRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :clients, :map
+      field :id, :string
+      field :ipAddress, :string
+      field :lastAccess, :integer
+      field :rememberMe, :boolean
+      field :start, :integer
+      field :transientUser, :boolean
+      field :userId, :string
+      field :username, :string
+    end
+  end
+
+  defmodule RequiredActionConfigRepresentation do
     @moduledoc false
     use CommonCore, :embedded_schema
 
     batt_embedded_schema do
       field :config, :map
-      field :id, :string
-      field :name, :string
-      field :providerId, :string
-      field :subComponents, :map
-      field :subType, :string
     end
   end
 
-  defmodule Composites do
+  defmodule ErrorRepresentation do
     @moduledoc false
     use CommonCore, :embedded_schema
 
     batt_embedded_schema do
-      field :application, :map
-      field :client, :map
-      field :realm, {:array, :string}
+      field :errorMessage, :string
+      embeds_many :errors, ErrorRepresentation
+      field :field, :string
+      field :params, {:array, :string}
+    end
+  end
+
+  defmodule ResourceType do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :groupType, :string
+      field :scopeAliases, :map
+      field :scopes, {:array, :string}
+      field :type, :string
     end
   end
 
@@ -128,6 +369,7 @@ defmodule CommonCore.OpenAPI.KeycloakAdminSchema do
       field :credentialData, :string
       field :device, :string
       field :digits, :integer
+      field :federationLink, :string
       field :hashIterations, :integer
       field :hashedSaltedValue, :string
       field :id, :string
@@ -142,30 +384,15 @@ defmodule CommonCore.OpenAPI.KeycloakAdminSchema do
     end
   end
 
-  defmodule FederatedIdentityRepresentation do
+  defmodule UPGroup do
     @moduledoc false
     use CommonCore, :embedded_schema
 
     batt_embedded_schema do
-      field :identityProvider, :string
-      field :userId, :string
-      field :userName, :string
-    end
-  end
-
-  defmodule GroupRepresentation do
-    @moduledoc false
-    use CommonCore, :embedded_schema
-
-    batt_embedded_schema do
-      field :access, :map
-      field :attributes, :map
-      field :clientRoles, :map
-      field :id, :string
+      field :annotations, :map
+      field :displayDescription, :string
+      field :displayHeader, :string
       field :name, :string
-      field :path, :string
-      field :realmRoles, {:array, :string}
-      embeds_many :subGroups, GroupRepresentation
     end
   end
 
@@ -182,6 +409,57 @@ defmodule CommonCore.OpenAPI.KeycloakAdminSchema do
     end
   end
 
+  defmodule GroupRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :access, :map
+      field :attributes, :map
+      field :clientRoles, :map
+      field :description, :string
+      field :id, :string
+      field :name, :string
+      field :parentId, :string
+      field :path, :string
+      field :realmRoles, {:array, :string}
+      field :subGroupCount, :integer
+      embeds_many :subGroups, GroupRepresentation
+    end
+  end
+
+  defmodule FederatedIdentityRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :identityProvider, :string
+      field :userId, :string
+      field :userName, :string
+    end
+  end
+
+  defmodule AbstractPolicyRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :decisionStrategy, DecisionStrategy
+      field :description, :string
+      field :id, :string
+      field :logic, Logic
+      field :name, :string
+      field :owner, :string
+      field :policies, {:array, :string}
+      field :resourceType, :string
+      field :resources, {:array, :string}
+      field :resourcesData, {:array, :string}
+      field :scopes, {:array, :string}
+      field :scopesData, {:array, :string}
+      field :type, :string
+    end
+  end
+
   defmodule IdentityProviderRepresentation do
     @moduledoc false
     use CommonCore, :embedded_schema
@@ -194,22 +472,816 @@ defmodule CommonCore.OpenAPI.KeycloakAdminSchema do
       field :displayName, :string
       field :enabled, :boolean
       field :firstBrokerLoginFlowAlias, :string
+      field :hideOnLogin, :boolean
       field :internalId, :string
       field :linkOnly, :boolean
+      field :organizationId, :string
       field :postBrokerLoginFlowAlias, :string
       field :providerId, :string
       field :storeToken, :boolean
       field :trustEmail, :boolean
+      field :updateProfileFirstLogin, :boolean
       field :updateProfileFirstLoginMode, :string
     end
   end
 
-  defmodule PolicyRepresentation do
+  defmodule ClientPolicyExecutorRepresentation do
     @moduledoc false
     use CommonCore, :embedded_schema
 
     batt_embedded_schema do
+      field :configuration, :map
+      field :executor, :string
+    end
+  end
+
+  defmodule ClientProfileRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :description, :string
+      embeds_many :executors, ClientPolicyExecutorRepresentation
+      field :name, :string
+    end
+  end
+
+  defmodule ClientProfilesRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      embeds_many :globalProfiles, ClientProfileRepresentation
+      embeds_many :profiles, ClientProfileRepresentation
+    end
+  end
+
+  nil
+
+  defmodule SocialLinkRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :socialProvider, :string
+      field :socialUserId, :string
+      field :socialUsername, :string
+    end
+  end
+
+  defmodule PolicyEvaluationRequest do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :clientId, :string
+      field :context, :map
+      field :entitlements, :boolean
+      field :resourceType, :string
+      field :resources, {:array, :string}
+      field :roleIds, {:array, :string}
+      field :userId, :string
+    end
+  end
+
+  defmodule PathCacheConfig do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :lifespan, :integer
+      field :"max-entries", :integer
+    end
+  end
+
+  defmodule KeyStoreConfig do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :format, :string
+      field :keyAlias, :string
+      field :keyPassword, :string
+      field :keySize, :integer
+      field :realmAlias, :string
+      field :realmCertificate, :boolean
+      field :storePassword, :string
+      field :validity, :integer
+    end
+  end
+
+  defmodule UserProfileMetadata do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      embeds_many :attributes, UserProfileAttributeMetadata
+      embeds_many :groups, UserProfileAttributeGroupMetadata
+    end
+  end
+
+  defmodule MemberRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :access, :map
+      field :applicationRoles, :map
+      field :attributes, :map
+      embeds_many :clientConsents, UserConsentRepresentation
+      field :clientRoles, :map
+      field :createdTimestamp, :integer
+      embeds_many :credentials, CredentialRepresentation
+      field :disableableCredentialTypes, {:array, :string}
+      field :email, :string
+      field :emailVerified, :boolean
+      field :enabled, :boolean
+      embeds_many :federatedIdentities, FederatedIdentityRepresentation
+      field :federationLink, :string
+      field :firstName, :string
+      field :groups, {:array, :string}
+      field :id, :string
+      field :lastName, :string
+      field :membershipType, MembershipType
+      field :notBefore, :integer
+      field :origin, :string
+      field :realmRoles, {:array, :string}
+      field :requiredActions, {:array, :string}
+      field :self, :string
+      field :serviceAccountClientId, :string
+      embeds_many :socialLinks, SocialLinkRepresentation
+      field :totp, :boolean
+      embeds_one :userProfileMetadata, UserProfileMetadata
+      field :username, :string
+    end
+  end
+
+  defmodule AddressClaimSet do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :country, :string
+      field :formatted, :string
+      field :locality, :string
+      field :postal_code, :string
+      field :region, :string
+      field :street_address, :string
+    end
+  end
+
+  defmodule IDToken do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :acr, :string
+      embeds_one :address, AddressClaimSet
+      field :at_hash, :string
+      field :auth_time, :integer
+      field :azp, :string
+      field :birthdate, :string
+      field :c_hash, :string
+      field :claims_locales, :string
+      field :email, :string
+      field :email_verified, :boolean
+      field :exp, :integer
+      field :family_name, :string
+      field :gender, :string
+      field :given_name, :string
+      field :iat, :integer
+      field :iss, :string
+      field :jti, :string
+      field :locale, :string
+      field :middle_name, :string
+      field :name, :string
+      field :nbf, :integer
+      field :nickname, :string
+      field :nonce, :string
+      field :otherClaims, :map
+      field :phone_number, :string
+      field :phone_number_verified, :boolean
+      field :picture, :string
+      field :preferred_username, :string
+      field :profile, :string
+      field :s_hash, :string
+      field :sid, :string
+      field :sub, :string
+      field :typ, :string
+      field :updated_at, :integer
+      field :website, :string
+      field :zoneinfo, :string
+    end
+  end
+
+  defmodule CertificateRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :certificate, :string
+      field :kid, :string
+      field :privateKey, :string
+      field :publicKey, :string
+    end
+  end
+
+  defmodule KeyMetadataRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :algorithm, :string
+      field :certificate, :string
+      field :kid, :string
+      field :providerId, :string
+      field :providerPriority, :integer
+      field :publicKey, :string
+      field :status, :string
+      field :type, :string
+      field :use, KeyUse
+      field :validTo, :integer
+    end
+  end
+
+  defmodule ConfigPropertyRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :defaultValue, :string
+      field :helpText, :string
+      field :label, :string
+      field :name, :string
+      field :options, {:array, :string}
+      field :readOnly, :boolean
+      field :required, :boolean
+      field :secret, :boolean
+      field :type, :string
+    end
+  end
+
+  defmodule IdentityProviderMapperTypeRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :category, :string
+      field :helpText, :string
+      field :id, :string
+      field :name, :string
+      embeds_many :properties, ConfigPropertyRepresentation
+    end
+  end
+
+  defmodule AuthenticatorConfigInfoRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :helpText, :string
+      field :name, :string
+      embeds_many :properties, ConfigPropertyRepresentation
+      field :providerId, :string
+    end
+  end
+
+  defmodule RequiredActionConfigInfoRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      embeds_many :properties, ConfigPropertyRepresentation
+    end
+  end
+
+  defmodule UPAttributeRequired do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :roles, {:array, :string}
+      field :scopes, {:array, :string}
+    end
+  end
+
+  defmodule UPAttribute do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :annotations, :map
+      field :displayName, :string
+      field :group, :string
+      field :multivalued, :boolean
+      field :name, :string
+      embeds_one :permissions, UPAttributePermissions
+      embeds_one :required, UPAttributeRequired
+      embeds_one :selector, UPAttributeSelector
+      field :validations, :map
+    end
+  end
+
+  defmodule UPConfig do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      embeds_many :attributes, UPAttribute
+      embeds_many :groups, UPGroup
+      field :unmanagedAttributePolicy, UnmanagedAttributePolicy
+    end
+  end
+
+  defmodule ClientPolicyConditionRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :condition, :string
+      field :configuration, :map
+    end
+  end
+
+  defmodule ComponentRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :config, {:array, :string}
+      field :id, :string
+      field :name, :string
+      field :parentId, :string
+      field :providerId, :string
+      field :providerType, :string
+      field :subType, :string
+    end
+  end
+
+  defmodule PropertyConfig do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :applicable, :boolean
+      field :value, :string
+    end
+  end
+
+  defmodule ClientTypeRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      embeds_many :config, PropertyConfig
+      field :name, :string
+      field :parent, :string
+      field :provider, :string
+    end
+  end
+
+  nil
+
+  defmodule PolicyProviderRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :group, :string
+      field :name, :string
+      field :type, :string
+    end
+  end
+
+  defmodule AuthenticationExecutionExportRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :authenticator, :string
+      field :authenticatorConfig, :string
+      field :authenticatorFlow, :boolean
+      field :autheticatorFlow, :boolean
+      field :flowAlias, :string
+      field :priority, :integer
+      field :requirement, :string
+      field :userSetupAllowed, :boolean
+    end
+  end
+
+  defmodule AuthenticationFlowRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :alias, :string
+      embeds_many :authenticationExecutions, AuthenticationExecutionExportRepresentation
+      field :builtIn, :boolean
+      field :description, :string
+      field :id, :string
+      field :providerId, :string
+      field :topLevel, :boolean
+    end
+  end
+
+  defmodule OrganizationDomainRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :name, :string
+      field :verified, :boolean
+    end
+  end
+
+  defmodule OrganizationRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :alias, :string
+      field :attributes, :map
+      field :description, :string
+      embeds_many :domains, OrganizationDomainRepresentation
+      field :enabled, :boolean
+      field :id, :string
+      embeds_many :identityProviders, IdentityProviderRepresentation
+      embeds_many :members, MemberRepresentation
+      field :name, :string
+      field :redirectUrl, :string
+    end
+  end
+
+  defmodule KeysMetadataRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :active, :map
+      embeds_many :keys, KeyMetadataRepresentation
+    end
+  end
+
+  defmodule Composites do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :application, :map
+      field :client, :map
+      field :realm, {:array, :string}
+    end
+  end
+
+  defmodule RoleRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :attributes, :map
+      field :clientRole, :boolean
+      field :composite, :boolean
+      embeds_one :composites, Composites
+      field :containerId, :string
+      field :description, :string
+      field :id, :string
+      field :name, :string
+      field :scopeParamRequired, :boolean
+    end
+  end
+
+  defmodule RolesRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      embeds_many :application, RoleRepresentation
+      embeds_many :client, RoleRepresentation
+      embeds_many :realm, RoleRepresentation
+    end
+  end
+
+  defmodule ClientMappingsRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :client, :string
+      field :id, :string
+      embeds_many :mappings, RoleRepresentation
+    end
+  end
+
+  defmodule AuthorizationSchema do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      embeds_many :resourceTypes, ResourceType
+    end
+  end
+
+  defmodule AuthDetailsRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :clientId, :string
+      field :ipAddress, :string
+      field :realmId, :string
+      field :userId, :string
+    end
+  end
+
+  defmodule AdminEventRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      embeds_one :authDetails, AuthDetailsRepresentation
+      field :details, :map
+      field :error, :string
+      field :id, :string
+      field :operationType, :string
+      field :realmId, :string
+      field :representation, :string
+      field :resourcePath, :string
+      field :resourceType, :string
+      field :time, :integer
+    end
+  end
+
+  defmodule AuthenticatorConfigRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :alias, :string
       field :config, :map
+      field :id, :string
+    end
+  end
+
+  defmodule ClientInitialAccessCreatePresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :count, :integer
+      field :expiration, :integer
+    end
+  end
+
+  defmodule ClientPolicyRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      embeds_many :conditions, ClientPolicyConditionRepresentation
+      field :description, :string
+      field :enabled, :boolean
+      field :name, :string
+      field :profiles, {:array, :string}
+    end
+  end
+
+  defmodule ClientPoliciesRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      embeds_many :globalPolicies, ClientPolicyRepresentation
+      embeds_many :policies, ClientPolicyRepresentation
+    end
+  end
+
+  defmodule ClientTypesRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      embeds_many :"client-types", ClientTypeRepresentation
+      embeds_many :"global-client-types", ClientTypeRepresentation
+    end
+  end
+
+  defmodule ComponentExportRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :config, {:array, :string}
+      field :id, :string
+      field :name, :string
+      field :providerId, :string
+      field :subComponents, {:array, :map}
+      field :subType, :string
+    end
+  end
+
+  defmodule ComponentTypeRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :helpText, :string
+      field :id, :string
+      field :metadata, :map
+      embeds_many :properties, ConfigPropertyRepresentation
+    end
+  end
+
+  defmodule Confirmation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :jkt, :string
+      field :"x5t#S256", :string
+    end
+  end
+
+  defmodule AccessToken do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :acr, :string
+      embeds_one :address, AddressClaimSet
+      field :"allowed-origins", {:array, :string}
+      field :at_hash, :string
+      field :auth_time, :integer
+      embeds_one :authorization, Authorization
+      field :azp, :string
+      field :birthdate, :string
+      field :c_hash, :string
+      field :claims_locales, :string
+      embeds_one :cnf, Confirmation
+      field :email, :string
+      field :email_verified, :boolean
+      field :exp, :integer
+      field :family_name, :string
+      field :gender, :string
+      field :given_name, :string
+      field :iat, :integer
+      field :iss, :string
+      field :jti, :string
+      field :locale, :string
+      field :middle_name, :string
+      field :name, :string
+      field :nbf, :integer
+      field :nickname, :string
+      field :nonce, :string
+      field :otherClaims, :map
+      field :phone_number, :string
+      field :phone_number_verified, :boolean
+      field :picture, :string
+      field :preferred_username, :string
+      field :profile, :string
+      embeds_one :realm_access, Access
+      embeds_many :resource_access, Access
+      field :s_hash, :string
+      field :scope, :string
+      field :sid, :string
+      field :sub, :string
+      field :"trusted-certs", {:array, :string}
+      field :typ, :string
+      field :updated_at, :integer
+      field :website, :string
+      field :zoneinfo, :string
+    end
+  end
+
+  defmodule MappingsRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      embeds_many :clientMappings, ClientMappingsRepresentation
+      embeds_many :realmMappings, RoleRepresentation
+    end
+  end
+
+  defmodule MethodConfig do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :method, :string
+      field :scopes, {:array, :string}
+      field :"scopes-enforcement-mode", ScopeEnforcementMode
+    end
+  end
+
+  defmodule PathConfig do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :"claim-information-point", :map
+      field :"enforcement-mode", EnforcementMode
+      field :id, :string
+      field :invalidated, :boolean
+      embeds_many :methods, MethodConfig
+      field :name, :string
+      field :path, :string
+      field :scopes, {:array, :string}
+      field :static, :boolean
+      field :staticPath, :boolean
+      field :type, :string
+    end
+  end
+
+  defmodule PolicyEnforcerConfig do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :"auth-server-url", :string
+      field :"claim-information-point", :map
+      field :credentials, :map
+      field :"enforcement-mode", EnforcementMode
+      field :"http-method-as-scope", :boolean
+      field :"lazy-load-paths", :boolean
+      field :"on-deny-redirect-to", :string
+      embeds_one :"path-cache", PathCacheConfig
+      embeds_many :paths, PathConfig
+      field :realm, :string
+      field :resource, :string
+      field :"user-managed-access", :map
+    end
+  end
+
+  defmodule InstallationAdapterConfig do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :"auth-server-url", :string
+      field :"bearer-only", :boolean
+      field :"confidential-port", :integer
+      field :credentials, :map
+      embeds_one :"policy-enforcer", PolicyEnforcerConfig
+      field :"public-client", :boolean
+      field :realm, :string
+      field :"realm-public-key", :string
+      field :resource, :string
+      field :"ssl-required", :string
+      field :"use-resource-role-mappings", :boolean
+      field :"verify-token-audience", :boolean
+    end
+  end
+
+  defmodule PolicyResultRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      embeds_many :associatedPolicies, PolicyResultRepresentation
+      field :policy, :map
+      field :resourceType, :string
+      field :scopes, {:array, :string}
+      field :status, DecisionEffect
+    end
+  end
+
+  defmodule EvaluationResultRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :allowedScopes, {:array, :string}
+      field :deniedScopes, {:array, :string}
+      embeds_many :policies, PolicyResultRepresentation
+      field :resource, :map
+      field :scopes, {:array, :string}
+      field :status, DecisionEffect
+    end
+  end
+
+  defmodule PolicyEvaluationResponse do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :entitlements, :boolean
+      embeds_many :results, EvaluationResultRepresentation
+      embeds_one :rpt, AccessToken
+      field :status, DecisionEffect
+    end
+  end
+
+  defmodule ProtocolMapperEvaluationRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :containerId, :string
+      field :containerName, :string
+      field :containerType, :string
+      field :mapperId, :string
+      field :mapperName, :string
+      field :protocolMapper, :string
     end
   end
 
@@ -265,91 +1337,30 @@ defmodule CommonCore.OpenAPI.KeycloakAdminSchema do
     end
   end
 
-  defmodule RequiredActionProviderRepresentation do
+  defmodule PublishedRealmRepresentation do
     @moduledoc false
     use CommonCore, :embedded_schema
 
     batt_embedded_schema do
-      field :alias, :string
-      field :config, :map
-      field :defaultAction, :boolean
-      field :enabled, :boolean
-      field :name, :string
-      field :priority, :integer
-      field :providerId, :string
+      field :"account-service", :string
+      field :public_key, :string
+      field :realm, :string
+      field :"token-service", :string
+      field :"tokens-not-before", :integer
     end
   end
 
-  defmodule ResourceRepresentation do
+  defmodule RealmEventsConfigRepresentation do
     @moduledoc false
     use CommonCore, :embedded_schema
 
     batt_embedded_schema do
-      field :attributes, :map
-      field :displayName, :string
-      field :iconUri, :string
-      field :id, :string
-      field :name, :string
-      field :owner, :map
-      field :ownerManagedAccess, :boolean
-      field :scopes, {:array, :string}
-      field :type, :string
-      field :uris, {:array, :string}
-    end
-  end
-
-  defmodule RoleRepresentation do
-    @moduledoc false
-    use CommonCore, :embedded_schema
-
-    batt_embedded_schema do
-      field :attributes, :map
-      field :clientRole, :boolean
-      field :composite, :boolean
-      embeds_one :composites, Composites
-      field :containerId, :string
-      field :description, :string
-      field :id, :string
-      field :name, :string
-      field :scopeParamRequired, :boolean
-    end
-  end
-
-  defmodule RolesRepresentation do
-    @moduledoc false
-    use CommonCore, :embedded_schema
-
-    batt_embedded_schema do
-      field :application, :map
-      field :client, :map
-      embeds_many :realm, RoleRepresentation
-    end
-  end
-
-  defmodule ScopeMappingRepresentation do
-    @moduledoc false
-    use CommonCore, :embedded_schema
-
-    batt_embedded_schema do
-      field :client, :string
-      field :clientScope, :string
-      field :clientTemplate, :string
-      field :roles, {:array, :string}
-      field :self, :string
-    end
-  end
-
-  defmodule ScopeRepresentation do
-    @moduledoc false
-    use CommonCore, :embedded_schema
-
-    batt_embedded_schema do
-      field :displayName, :string
-      field :iconUri, :string
-      field :id, :string
-      field :name, :string
-      embeds_many :policies, PolicyRepresentation
-      embeds_many :resources, ResourceRepresentation
+      field :adminEventsDetailsEnabled, :boolean
+      field :adminEventsEnabled, :boolean
+      field :enabledEventTypes, {:array, :string}
+      field :eventsEnabled, :boolean
+      field :eventsExpiration, :integer
+      field :eventsListeners, {:array, :string}
     end
   end
 
@@ -359,14 +1370,68 @@ defmodule CommonCore.OpenAPI.KeycloakAdminSchema do
 
     batt_embedded_schema do
       field :allowRemoteResourceManagement, :boolean
+      embeds_one :authorizationSchema, AuthorizationSchema
       field :clientId, :string
-      field :decisionStrategy, :string
+      field :decisionStrategy, DecisionStrategy
       field :id, :string
       field :name, :string
-      embeds_many :policies, PolicyRepresentation
-      field :policyEnforcementMode, :string
-      embeds_many :resources, ResourceRepresentation
-      embeds_many :scopes, ScopeRepresentation
+      field :policies, {:array, :string}
+      field :policyEnforcementMode, PolicyEnforcementMode
+      field :resources, {:array, :string}
+      field :scopes, {:array, :string}
+    end
+  end
+
+  defmodule ApplicationRepresentation do
+    @moduledoc false
+    use CommonCore, :embedded_schema
+
+    batt_embedded_schema do
+      field :access, :map
+      field :adminUrl, :string
+      field :alwaysDisplayInConsole, :boolean
+      field :attributes, :map
+      field :authenticationFlowBindingOverrides, :map
+      field :authorizationServicesEnabled, :boolean
+      embeds_one :authorizationSettings, ResourceServerRepresentation
+      field :baseUrl, :string
+      field :bearerOnly, :boolean
+      embeds_many :claims, ClaimRepresentation
+      field :clientAuthenticatorType, :string
+      field :clientId, :string
+      field :clientTemplate, :string
+      field :consentRequired, :boolean
+      field :defaultClientScopes, {:array, :string}
+      field :defaultRoles, {:array, :string}
+      field :description, :string
+      field :directAccessGrantsEnabled, :boolean
+      field :directGrantsOnly, :boolean
+      field :enabled, :boolean
+      field :frontchannelLogout, :boolean
+      field :fullScopeAllowed, :boolean
+      field :id, :string
+      field :implicitFlowEnabled, :boolean
+      field :name, :string
+      field :nodeReRegistrationTimeout, :integer
+      field :notBefore, :integer
+      field :optionalClientScopes, {:array, :string}
+      field :origin, :string
+      field :protocol, :string
+      embeds_many :protocolMappers, ProtocolMapperRepresentation
+      field :publicClient, :boolean
+      field :redirectUris, {:array, :string}
+      field :registeredNodes, :map
+      field :registrationAccessToken, :string
+      field :rootUrl, :string
+      field :secret, :string
+      field :serviceAccountsEnabled, :boolean
+      field :standardFlowEnabled, :boolean
+      field :surrogateAuthRequired, :boolean
+      field :type, :string
+      field :useTemplateConfig, :boolean
+      field :useTemplateMappers, :boolean
+      field :useTemplateScope, :boolean
+      field :webOrigins, {:array, :string}
     end
   end
 
@@ -414,6 +1479,7 @@ defmodule CommonCore.OpenAPI.KeycloakAdminSchema do
       field :serviceAccountsEnabled, :boolean
       field :standardFlowEnabled, :boolean
       field :surrogateAuthRequired, :boolean
+      field :type, :string
       field :useTemplateConfig, :boolean
       field :useTemplateMappers, :boolean
       field :useTemplateScope, :boolean
@@ -421,56 +1487,69 @@ defmodule CommonCore.OpenAPI.KeycloakAdminSchema do
     end
   end
 
-  defmodule SocialLinkRepresentation do
+  defmodule OAuthClientRepresentation do
     @moduledoc false
     use CommonCore, :embedded_schema
 
     batt_embedded_schema do
-      field :socialProvider, :string
-      field :socialUserId, :string
-      field :socialUsername, :string
-    end
-  end
-
-  defmodule UserConsentRepresentation do
-    @moduledoc false
-    use CommonCore, :embedded_schema
-
-    batt_embedded_schema do
+      field :access, :map
+      field :adminUrl, :string
+      field :alwaysDisplayInConsole, :boolean
+      field :attributes, :map
+      field :authenticationFlowBindingOverrides, :map
+      field :authorizationServicesEnabled, :boolean
+      embeds_one :authorizationSettings, ResourceServerRepresentation
+      field :baseUrl, :string
+      field :bearerOnly, :boolean
+      embeds_many :claims, ClaimRepresentation
+      field :clientAuthenticatorType, :string
       field :clientId, :string
-      field :createdDate, :integer
-      field :grantedClientScopes, {:array, :string}
-      field :grantedRealmRoles, {:array, :string}
-      field :lastUpdatedDate, :integer
-    end
-  end
-
-  defmodule UserFederationMapperRepresentation do
-    @moduledoc false
-    use CommonCore, :embedded_schema
-
-    batt_embedded_schema do
-      field :config, :map
-      field :federationMapperType, :string
-      field :federationProviderDisplayName, :string
+      field :clientTemplate, :string
+      field :consentRequired, :boolean
+      field :defaultClientScopes, {:array, :string}
+      field :defaultRoles, {:array, :string}
+      field :description, :string
+      field :directAccessGrantsEnabled, :boolean
+      field :directGrantsOnly, :boolean
+      field :enabled, :boolean
+      field :frontchannelLogout, :boolean
+      field :fullScopeAllowed, :boolean
       field :id, :string
+      field :implicitFlowEnabled, :boolean
       field :name, :string
+      field :nodeReRegistrationTimeout, :integer
+      field :notBefore, :integer
+      field :optionalClientScopes, {:array, :string}
+      field :origin, :string
+      field :protocol, :string
+      embeds_many :protocolMappers, ProtocolMapperRepresentation
+      field :publicClient, :boolean
+      field :redirectUris, {:array, :string}
+      field :registeredNodes, :map
+      field :registrationAccessToken, :string
+      field :rootUrl, :string
+      field :secret, :string
+      field :serviceAccountsEnabled, :boolean
+      field :standardFlowEnabled, :boolean
+      field :surrogateAuthRequired, :boolean
+      field :type, :string
+      field :useTemplateConfig, :boolean
+      field :useTemplateMappers, :boolean
+      field :useTemplateScope, :boolean
+      field :webOrigins, {:array, :string}
     end
   end
 
-  defmodule UserFederationProviderRepresentation do
+  defmodule ScopeMappingRepresentation do
     @moduledoc false
     use CommonCore, :embedded_schema
 
     batt_embedded_schema do
-      field :changedSyncPeriod, :integer
-      field :config, :map
-      field :displayName, :string
-      field :fullSyncPeriod, :integer
-      field :id, :string
-      field :lastSync, :integer
-      field :priority, :integer
-      field :providerName, :string
+      field :client, :string
+      field :clientScope, :string
+      field :clientTemplate, :string
+      field :roles, {:array, :string}
+      field :self, :string
     end
   end
 
@@ -504,6 +1583,7 @@ defmodule CommonCore.OpenAPI.KeycloakAdminSchema do
       field :serviceAccountClientId, :string
       embeds_many :socialLinks, SocialLinkRepresentation
       field :totp, :boolean
+      embeds_one :userProfileMetadata, UserProfileMetadata
       field :username, :string
     end
   end
@@ -523,8 +1603,10 @@ defmodule CommonCore.OpenAPI.KeycloakAdminSchema do
       field :actionTokenGeneratedByUserLifespan, :integer
       field :adminEventsDetailsEnabled, :boolean
       field :adminEventsEnabled, :boolean
+      embeds_one :adminPermissionsClient, ClientRepresentation
+      field :adminPermissionsEnabled, :boolean
       field :adminTheme, :string
-      field :applicationScopeMappings, :map
+      embeds_many :applicationScopeMappings, ScopeMappingRepresentation
       embeds_many :applications, ApplicationRepresentation
       field :attributes, :map
       embeds_many :authenticationFlows, AuthenticationFlowRepresentation
@@ -532,18 +1614,21 @@ defmodule CommonCore.OpenAPI.KeycloakAdminSchema do
       field :browserFlow, :string
       field :browserSecurityHeaders, :map
       field :bruteForceProtected, :boolean
+      field :bruteForceStrategy, BruteForceStrategy
       field :certificate, :string
       field :clientAuthenticationFlow, :string
       field :clientOfflineSessionIdleTimeout, :integer
       field :clientOfflineSessionMaxLifespan, :integer
-      field :clientScopeMappings, :map
+      embeds_one :clientPolicies, ClientPoliciesRepresentation
+      embeds_one :clientProfiles, ClientProfilesRepresentation
+      embeds_many :clientScopeMappings, ScopeMappingRepresentation
       embeds_many :clientScopes, ClientScopeRepresentation
       field :clientSessionIdleTimeout, :integer
       field :clientSessionMaxLifespan, :integer
       embeds_many :clientTemplates, ClientTemplateRepresentation
       embeds_many :clients, ClientRepresentation
       field :codeSecret, :string
-      field :components, :map
+      field :components, {:array, :map}
       field :defaultDefaultClientScopes, {:array, :string}
       field :defaultGroups, {:array, :string}
       field :defaultLocale, :string
@@ -565,24 +1650,31 @@ defmodule CommonCore.OpenAPI.KeycloakAdminSchema do
       field :eventsListeners, {:array, :string}
       field :failureFactor, :integer
       embeds_many :federatedUsers, UserRepresentation
+      field :firstBrokerLoginFlow, :string
       embeds_many :groups, GroupRepresentation
       field :id, :string
       embeds_many :identityProviderMappers, IdentityProviderMapperRepresentation
       embeds_many :identityProviders, IdentityProviderRepresentation
       field :internationalizationEnabled, :boolean
       field :keycloakVersion, :string
+      field :localizationTexts, :map
       field :loginTheme, :string
       field :loginWithEmailAllowed, :boolean
       field :maxDeltaTimeSeconds, :integer
       field :maxFailureWaitSeconds, :integer
+      field :maxTemporaryLockouts, :integer
       field :minimumQuickLoginWaitSeconds, :integer
       field :notBefore, :integer
       field :oAuth2DeviceCodeLifespan, :integer
       field :oAuth2DevicePollingInterval, :integer
+      field :oauth2DeviceCodeLifespan, :integer
+      field :oauth2DevicePollingInterval, :integer
       field :oauthClients, {:array, :string}
       field :offlineSessionIdleTimeout, :integer
       field :offlineSessionMaxLifespan, :integer
       field :offlineSessionMaxLifespanEnabled, :boolean
+      embeds_many :organizations, OrganizationRepresentation
+      field :organizationsEnabled, :boolean
       field :otpPolicyAlgorithm, :string
       field :otpPolicyCodeReusable, :boolean
       field :otpPolicyDigits, :integer
@@ -599,6 +1691,7 @@ defmodule CommonCore.OpenAPI.KeycloakAdminSchema do
       field :publicKey, :string
       field :quickLoginCheckMilliSeconds, :integer
       field :realm, :string
+      field :realmCacheEnabled, :boolean
       field :refreshTokenMaxReuse, :integer
       field :registrationAllowed, :boolean
       field :registrationEmailAsUsername, :boolean
@@ -621,10 +1714,12 @@ defmodule CommonCore.OpenAPI.KeycloakAdminSchema do
       field :ssoSessionMaxLifespanRememberMe, :integer
       field :supportedLocales, {:array, :string}
       field :updateProfileOnInitialSocialLogin, :boolean
+      field :userCacheEnabled, :boolean
       embeds_many :userFederationMappers, UserFederationMapperRepresentation
       embeds_many :userFederationProviders, UserFederationProviderRepresentation
       field :userManagedAccessAllowed, :boolean
       embeds_many :users, UserRepresentation
+      field :verifiableCredentialsEnabled, :boolean
       field :verifyEmail, :boolean
       field :waitIncrementSeconds, :integer
       field :webAuthnPolicyAcceptableAaguids, {:array, :string}
@@ -632,11 +1727,14 @@ defmodule CommonCore.OpenAPI.KeycloakAdminSchema do
       field :webAuthnPolicyAuthenticatorAttachment, :string
       field :webAuthnPolicyAvoidSameAuthenticatorRegister, :boolean
       field :webAuthnPolicyCreateTimeout, :integer
+      field :webAuthnPolicyExtraOrigins, {:array, :string}
       field :webAuthnPolicyPasswordlessAcceptableAaguids, {:array, :string}
       field :webAuthnPolicyPasswordlessAttestationConveyancePreference, :string
       field :webAuthnPolicyPasswordlessAuthenticatorAttachment, :string
       field :webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister, :boolean
       field :webAuthnPolicyPasswordlessCreateTimeout, :integer
+      field :webAuthnPolicyPasswordlessExtraOrigins, {:array, :string}
+      field :webAuthnPolicyPasswordlessPasskeysEnabled, :boolean
       field :webAuthnPolicyPasswordlessRequireResidentKey, :string
       field :webAuthnPolicyPasswordlessRpEntityName, :string
       field :webAuthnPolicyPasswordlessRpId, :string

--- a/platform_umbrella/apps/common_core/lib/common_core/port.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/port.ex
@@ -3,21 +3,14 @@ defmodule CommonCore.Port do
   use CommonCore, :embedded_schema
 
   alias CommonCore.Ecto.Schema
+  alias CommonCore.Protocol
 
   @required_fields ~w(name number)a
-
-  @protocols [
-    HTTP: :http,
-    HTTP2: :http2,
-    TCP: :tcp
-    # TODO: do we need this? If so, figure it out
-    # UDP: :udp,
-  ]
 
   batt_embedded_schema do
     field :name, :string
     field :number, :integer
-    field :protocol, Ecto.Enum, values: Keyword.values(@protocols), default: :http2
+    field :protocol, Protocol, default: :http2
   end
 
   def changeset(struct, params \\ %{}, opts \\ []) do
@@ -25,8 +18,4 @@ defmodule CommonCore.Port do
     |> Schema.schema_changeset(params, opts)
     |> downcase_fields([:name])
   end
-
-  def protocols, do: @protocols
-
-  def k8s_protocol(%{protocol: _}), do: "TCP"
 end

--- a/platform_umbrella/apps/common_core/lib/common_core/protocol.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/protocol.ex
@@ -1,0 +1,24 @@
+defmodule CommonCore.Protocol do
+  @moduledoc """
+  Ecto enum for network protocols supported by ports.
+  """
+
+  use CommonCore.Ecto.Enum,
+    http: "http",
+    http2: "http2",
+    tcp: "tcp"
+
+  @doc """
+  Returns protocol options for use in forms and select inputs.
+  Returns a list of {display_name, atom_value} tuples.
+  """
+  def options do
+    [
+      {"HTTP", :http},
+      {"HTTP2", :http2},
+      {"TCP", :tcp}
+    ]
+  end
+
+  def k8s_protocol(_), do: "TCP"
+end

--- a/platform_umbrella/apps/common_core/lib/common_core/resources/traditional_services/traditional_services.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/resources/traditional_services/traditional_services.ex
@@ -7,7 +7,7 @@ defmodule CommonCore.Resources.TraditionalServices do
   import CommonCore.Util.Map
 
   alias CommonCore.Containers.EnvValue
-  alias CommonCore.Port
+  alias CommonCore.Protocol
   alias CommonCore.Resources.Builder, as: B
   alias CommonCore.Resources.FilterResource, as: F
   alias CommonCore.Resources.RouteBuilder, as: R
@@ -210,5 +210,5 @@ defmodule CommonCore.Resources.TraditionalServices do
   defp to_svc_ports(%{ports: ports} = _service), do: Enum.map(ports, &to_svc_port/1)
   defp to_svc_ports(_), do: []
 
-  defp to_svc_port(port), do: %{name: port.name, port: port.number, protocol: Port.k8s_protocol(port)}
+  defp to_svc_port(port), do: %{name: port.name, port: port.number, protocol: Protocol.k8s_protocol(port.protocol)}
 end

--- a/platform_umbrella/apps/common_core/test/common_core/ecto/enum_test.exs
+++ b/platform_umbrella/apps/common_core/test/common_core/ecto/enum_test.exs
@@ -1,0 +1,244 @@
+defmodule CommonCore.Ecto.EnumTest do
+  use ExUnit.Case, async: true
+
+  # Create test enum modules for testing
+  defmodule StatusEnum do
+    @moduledoc false
+    use CommonCore.Ecto.Enum,
+      active: "IS_ACTIVE",
+      inactive: "IS_INACTIVE",
+      pending: "IS_PENDING"
+  end
+
+  defmodule PriorityEnum do
+    @moduledoc false
+    use CommonCore.Ecto.Enum,
+      low: "low",
+      medium: "medium",
+      high: "high",
+      critical: "critical"
+  end
+
+  defmodule EmptyEnum do
+    @moduledoc false
+    use CommonCore.Ecto.Enum, []
+  end
+
+  describe "type/0" do
+    test "returns :string as the underlying ecto type" do
+      assert StatusEnum.type() == :string
+      assert PriorityEnum.type() == :string
+      assert EmptyEnum.type() == :string
+    end
+  end
+
+  describe "cast/1" do
+    test "casts valid atom keys to atoms" do
+      assert StatusEnum.cast(:active) == {:ok, :active}
+      assert StatusEnum.cast(:inactive) == {:ok, :inactive}
+      assert StatusEnum.cast(:pending) == {:ok, :pending}
+    end
+
+    test "casts valid string values to atoms" do
+      assert StatusEnum.cast("IS_ACTIVE") == {:ok, :active}
+      assert StatusEnum.cast("IS_INACTIVE") == {:ok, :inactive}
+      assert StatusEnum.cast("IS_PENDING") == {:ok, :pending}
+    end
+
+    test "returns error for invalid values" do
+      assert StatusEnum.cast(:invalid) == :error
+      assert StatusEnum.cast("invalid") == :error
+      assert StatusEnum.cast(123) == :error
+      assert StatusEnum.cast(nil) == :error
+    end
+
+    test "works with different enum configurations" do
+      assert PriorityEnum.cast(:low) == {:ok, :low}
+      assert PriorityEnum.cast("medium") == {:ok, :medium}
+      assert PriorityEnum.cast(:invalid) == :error
+    end
+
+    test "returns error for empty enum" do
+      assert EmptyEnum.cast(:anything) == :error
+      assert EmptyEnum.cast("anything") == :error
+    end
+  end
+
+  describe "dump/1" do
+    test "dumps valid atoms to string values" do
+      assert StatusEnum.dump(:active) == {:ok, "IS_ACTIVE"}
+      assert StatusEnum.dump(:inactive) == {:ok, "IS_INACTIVE"}
+      assert StatusEnum.dump(:pending) == {:ok, "IS_PENDING"}
+    end
+
+    test "dumps valid string values to themselves" do
+      assert StatusEnum.dump("IS_ACTIVE") == {:ok, "IS_ACTIVE"}
+      assert StatusEnum.dump("IS_INACTIVE") == {:ok, "IS_INACTIVE"}
+      assert StatusEnum.dump("IS_PENDING") == {:ok, "IS_PENDING"}
+    end
+
+    test "raises Ecto.ChangeError for invalid values" do
+      assert_raise Ecto.ChangeError, ~r/Value `123` is not a valid enum value/, fn ->
+        StatusEnum.dump(123)
+      end
+
+      assert_raise Ecto.ChangeError, ~r/Value `:invalid` is not a valid enum value/, fn ->
+        StatusEnum.dump(:invalid)
+      end
+
+      assert_raise Ecto.ChangeError, ~r/Value `"invalid"` is not a valid enum value/, fn ->
+        StatusEnum.dump("invalid")
+      end
+    end
+
+    test "works with different enum configurations" do
+      assert PriorityEnum.dump(:low) == {:ok, "low"}
+      assert PriorityEnum.dump("high") == {:ok, "high"}
+    end
+  end
+
+  describe "load/1" do
+    test "loads valid string values to atoms" do
+      assert StatusEnum.load("IS_ACTIVE") == {:ok, :active}
+      assert StatusEnum.load("IS_INACTIVE") == {:ok, :inactive}
+      assert StatusEnum.load("IS_PENDING") == {:ok, :pending}
+    end
+
+    test "raises Ecto.ChangeError for invalid values" do
+      assert_raise Ecto.ChangeError, ~r/Value `123` is not a valid enum/, fn ->
+        StatusEnum.load(123)
+      end
+
+      assert_raise Ecto.ChangeError, ~r/Value `:invalid` is not a valid enum/, fn ->
+        StatusEnum.load(:invalid)
+      end
+
+      assert_raise Ecto.ChangeError, ~r/Value `"invalid"` is not a valid enum/, fn ->
+        StatusEnum.load("invalid")
+      end
+    end
+
+    test "works with different enum configurations" do
+      assert PriorityEnum.load("medium") == {:ok, :medium}
+    end
+  end
+
+  describe "equal?/2" do
+    test "returns true for equal terms" do
+      assert StatusEnum.equal?(:active, :active) == true
+      assert StatusEnum.equal?("IS_ACTIVE", "IS_ACTIVE") == true
+      assert StatusEnum.equal?(123, 123) == true
+    end
+
+    test "returns false for different terms" do
+      assert StatusEnum.equal?(:active, :inactive) == false
+      assert StatusEnum.equal?("IS_ACTIVE", "IS_INACTIVE") == false
+      assert StatusEnum.equal?(:active, "IS_ACTIVE") == false
+      assert StatusEnum.equal?(123, 456) == false
+    end
+  end
+
+  describe "embed_as/1" do
+    test "returns :self" do
+      assert StatusEnum.embed_as(:any_format) == :self
+      assert PriorityEnum.embed_as(:json) == :self
+    end
+  end
+
+  describe "valid_value?/1" do
+    test "returns true for valid string values" do
+      assert StatusEnum.valid_value?("IS_ACTIVE") == true
+      assert StatusEnum.valid_value?("IS_INACTIVE") == true
+      assert StatusEnum.valid_value?("IS_PENDING") == true
+    end
+
+    test "returns false for invalid values" do
+      assert StatusEnum.valid_value?("invalid") == false
+      assert StatusEnum.valid_value?(:active) == false
+      assert StatusEnum.valid_value?(123) == false
+      assert StatusEnum.valid_value?(nil) == false
+    end
+
+    test "works with different enum configurations" do
+      assert PriorityEnum.valid_value?("low") == true
+      assert PriorityEnum.valid_value?("medium") == true
+      assert PriorityEnum.valid_value?("invalid") == false
+    end
+
+    test "returns false for empty enum" do
+      assert EmptyEnum.valid_value?("anything") == false
+      assert EmptyEnum.valid_value?(:anything) == false
+    end
+  end
+
+  describe "__enum_map__/0" do
+    test "returns the enum mapping" do
+      expected = %{active: "IS_ACTIVE", inactive: "IS_INACTIVE", pending: "IS_PENDING"}
+      assert StatusEnum.__enum_map__() == expected
+    end
+
+    test "returns empty map for empty enum" do
+      assert EmptyEnum.__enum_map__() == %{}
+    end
+  end
+
+  describe "__valid_values__/0" do
+    test "returns list of valid string values" do
+      values = StatusEnum.__valid_values__()
+      assert "IS_ACTIVE" in values
+      assert "IS_INACTIVE" in values
+      assert "IS_PENDING" in values
+      assert length(values) == 3
+    end
+
+    test "returns empty list for empty enum" do
+      assert EmptyEnum.__valid_values__() == []
+    end
+  end
+
+  describe "Ecto.Type behavior compliance" do
+    test "implements all required Ecto.Type callbacks" do
+      # Verify that the module properly implements the Ecto.Type behavior
+      assert function_exported?(StatusEnum, :type, 0)
+      assert function_exported?(StatusEnum, :cast, 1)
+      assert function_exported?(StatusEnum, :load, 1)
+      assert function_exported?(StatusEnum, :dump, 1)
+      assert function_exported?(StatusEnum, :equal?, 2)
+      assert function_exported?(StatusEnum, :embed_as, 1)
+    end
+
+    test "type/0 returns a valid Ecto primitive type" do
+      # The underlying type should be a valid Ecto primitive
+      assert StatusEnum.type() in [
+               :string,
+               :integer,
+               :float,
+               :boolean,
+               :binary,
+               :date,
+               :time,
+               :naive_datetime,
+               :utc_datetime
+             ]
+    end
+
+    test "cast -> dump -> load round trip preserves semantics" do
+      # Test the full cycle: cast user input -> dump to DB -> load from DB
+      {:ok, casted} = StatusEnum.cast(:active)
+      {:ok, dumped} = StatusEnum.dump(casted)
+      {:ok, loaded} = StatusEnum.load(dumped)
+
+      assert loaded == :active
+      assert StatusEnum.equal?(casted, loaded)
+    end
+
+    test "cast -> dump -> load with string input" do
+      {:ok, casted} = StatusEnum.cast("IS_INACTIVE")
+      {:ok, dumped} = StatusEnum.dump(casted)
+      {:ok, loaded} = StatusEnum.load(dumped)
+
+      assert loaded == :inactive
+      assert StatusEnum.equal?(casted, loaded)
+    end
+  end
+end

--- a/platform_umbrella/apps/common_core/test/common_core/port_test.exs
+++ b/platform_umbrella/apps/common_core/test/common_core/port_test.exs
@@ -1,0 +1,42 @@
+defmodule CommonCore.PortTest do
+  use ExUnit.Case, async: true
+
+  alias CommonCore.Port
+
+  describe "changeset/3" do
+    test "creates a valid port with protocol" do
+      attrs = %{name: "web", number: 80, protocol: :http}
+      changeset = Port.changeset(%Port{}, attrs)
+
+      assert changeset.valid?
+      port = Ecto.Changeset.apply_changes(changeset)
+      assert port.protocol == :http
+    end
+
+    test "creates a valid port with string protocol" do
+      attrs = %{name: "web", number: 80, protocol: "tcp"}
+      changeset = Port.changeset(%Port{}, attrs)
+
+      assert changeset.valid?
+      port = Ecto.Changeset.apply_changes(changeset)
+      assert port.protocol == :tcp
+    end
+
+    test "validates protocol values" do
+      attrs = %{name: "web", number: 80, protocol: :invalid}
+      changeset = Port.changeset(%Port{}, attrs)
+
+      refute changeset.valid?
+      assert Keyword.has_key?(changeset.errors, :protocol)
+    end
+
+    test "sets default protocol to http2" do
+      attrs = %{name: "web", number: 80}
+      changeset = Port.changeset(%Port{}, attrs)
+
+      assert changeset.valid?
+      port = Ecto.Changeset.apply_changes(changeset)
+      assert port.protocol == :http2
+    end
+  end
+end

--- a/platform_umbrella/apps/common_core/test/common_core/protocol_test.exs
+++ b/platform_umbrella/apps/common_core/test/common_core/protocol_test.exs
@@ -1,0 +1,75 @@
+defmodule CommonCore.ProtocolTest do
+  use ExUnit.Case, async: true
+
+  alias CommonCore.Protocol
+
+  describe "Protocol enum as Ecto.Type" do
+    test "casts valid atom protocols" do
+      assert Protocol.cast(:http) == {:ok, :http}
+      assert Protocol.cast(:http2) == {:ok, :http2}
+      assert Protocol.cast(:tcp) == {:ok, :tcp}
+    end
+
+    test "casts valid string protocols" do
+      assert Protocol.cast("http") == {:ok, :http}
+      assert Protocol.cast("http2") == {:ok, :http2}
+      assert Protocol.cast("tcp") == {:ok, :tcp}
+    end
+
+    test "returns error for invalid protocols" do
+      assert Protocol.cast(:invalid) == :error
+      assert Protocol.cast("invalid") == :error
+      assert Protocol.cast(123) == :error
+    end
+
+    test "dumps valid protocols to strings" do
+      assert Protocol.dump(:http) == {:ok, "http"}
+      assert Protocol.dump(:http2) == {:ok, "http2"}
+      assert Protocol.dump(:tcp) == {:ok, "tcp"}
+    end
+
+    test "loads valid protocol strings to atoms" do
+      assert Protocol.load("http") == {:ok, :http}
+      assert Protocol.load("http2") == {:ok, :http2}
+      assert Protocol.load("tcp") == {:ok, :tcp}
+    end
+
+    test "returns :string as type" do
+      assert Protocol.type() == :string
+    end
+  end
+
+  describe "options/0" do
+    test "returns protocol options for forms" do
+      options = Protocol.options()
+
+      assert {"HTTP", :http} in options
+      assert {"HTTP2", :http2} in options
+      assert {"TCP", :tcp} in options
+
+      assert length(options) == 3
+    end
+
+    test "all options return atoms as values" do
+      options = Protocol.options()
+
+      Enum.each(options, fn {_label, value} ->
+        assert is_atom(value)
+      end)
+    end
+  end
+
+  describe "valid_value?/1" do
+    test "returns true for valid string values" do
+      assert Protocol.valid_value?("http") == true
+      assert Protocol.valid_value?("http2") == true
+      assert Protocol.valid_value?("tcp") == true
+    end
+
+    test "returns false for invalid values" do
+      assert Protocol.valid_value?("invalid") == false
+      assert Protocol.valid_value?(:http) == false
+      assert Protocol.valid_value?(123) == false
+    end
+  end
+end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/port_modal.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/port_modal.ex
@@ -3,6 +3,7 @@ defmodule ControlServerWeb.PortModal do
   use ControlServerWeb, :live_component
 
   alias CommonCore.Port
+  alias CommonCore.Protocol
   alias Ecto.Changeset
 
   @impl Phoenix.LiveComponent
@@ -103,7 +104,7 @@ defmodule ControlServerWeb.PortModal do
 
             <.field>
               <:label>Protocol</:label>
-              <.input field={@form[:protocol]} type="select" options={Port.protocols()} />
+              <.input field={@form[:protocol]} type="select" options={Protocol.options()} />
             </.field>
           </.fieldset>
 


### PR DESCRIPTION
Summary:
Keycloak now has an openapi schema. So this is the work needed to use
our existing code to regenerate with the latest

Test Plan:

Used it
