### PR TITLE
feat(sso): allow requiring MFA

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/actions/sso.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/actions/sso.ex
@@ -4,13 +4,78 @@ defmodule CommonCore.Actions.SSO do
   @behaviour CommonCore.Actions.ActionGenerator
 
   alias CommonCore.Actions.FreshGeneratedAction
+  alias CommonCore.Batteries.SSOConfig
   alias CommonCore.Batteries.SystemBattery
+  alias CommonCore.Defaults.Keycloak
+  alias CommonCore.OpenAPI.KeycloakAdminSchema.RealmRepresentation
+  alias CommonCore.OpenAPI.KeycloakAdminSchema.RequiredActionProviderRepresentation
   alias CommonCore.StateSummary
+  alias CommonCore.StateSummary.KeycloakSummary
+
+  require Logger
 
   @spec materialize(SystemBattery.t(), StateSummary.t()) :: list(FreshGeneratedAction.t() | nil)
-  def materialize(%SystemBattery{} = _system_battery, %StateSummary{} = _state_summary) do
-    [ping()]
+  def materialize(%SystemBattery{} = system_battery, %StateSummary{} = state_summary) do
+    [ping(), ensure_totp_flow(system_battery, state_summary), ensure_totp_required_action(system_battery, state_summary)]
   end
 
   defp ping, do: %FreshGeneratedAction{action: :ping, type: :realm, value: %{}}
+
+  # if mfa isn't enabled, do nothing
+  defp ensure_totp_flow(%SystemBattery{config: %SSOConfig{mfa: false}}, %StateSummary{} = _state_summary), do: nil
+  # if we don't have a good summary, do nothing
+  defp ensure_totp_flow(_, %StateSummary{keycloak_state: nil}), do: nil
+  defp ensure_totp_flow(_, %StateSummary{keycloak_state: %KeycloakSummary{realms: []}}), do: nil
+
+  # if mfa and summary, make sure conditional otp form is required
+  defp ensure_totp_flow(%SystemBattery{config: %SSOConfig{mfa: true}}, %StateSummary{} = _state_summary) do
+    %FreshGeneratedAction{
+      action: :sync,
+      type: :flow_execution,
+      realm: Keycloak.realm_name(),
+      value: %{flow_alias: "browser", display_name: "Browser - Conditional OTP"}
+    }
+  end
+
+  # if mfa isn't enabled, do nothing
+  defp ensure_totp_required_action(%SystemBattery{config: %SSOConfig{mfa: false}}, _), do: nil
+  # if we don't have a good summary, do nothing
+  defp ensure_totp_required_action(_, %StateSummary{keycloak_state: nil}), do: nil
+  defp ensure_totp_required_action(_, %StateSummary{keycloak_state: %KeycloakSummary{realms: []}}), do: nil
+
+  # if mfa and summary, make sure TOTP configure page is enabled
+  defp ensure_totp_required_action(
+         %SystemBattery{config: %SSOConfig{mfa: true}},
+         %StateSummary{keycloak_state: %KeycloakSummary{realms: realms}} = _state_summary
+       ) do
+    realms
+    |> Enum.find(fn %RealmRepresentation{realm: name} = _realm -> name == Keycloak.realm_name() end)
+    |> determine_totp_action()
+  end
+
+  #
+  # Helpers
+  #
+
+  defp determine_totp_action(nil), do: nil
+  defp determine_totp_action(%RealmRepresentation{requiredActions: nil}), do: nil
+
+  defp determine_totp_action(%RealmRepresentation{requiredActions: actions, realm: name}) do
+    case Enum.find(actions, &(&1.alias == "CONFIGURE_TOTP")) do
+      nil ->
+        Logger.warning("Couldn't find OTP required action")
+        nil
+
+      %RequiredActionProviderRepresentation{defaultAction: true} ->
+        nil
+
+      %RequiredActionProviderRepresentation{defaultAction: false} = action ->
+        %FreshGeneratedAction{
+          action: :sync,
+          type: :required_action,
+          realm: name,
+          value: Map.from_struct(%RequiredActionProviderRepresentation{action | defaultAction: true})
+        }
+    end
+  end
 end

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/sso_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/sso_config.ex
@@ -4,7 +4,7 @@ defmodule CommonCore.Batteries.SSOConfig do
   use CommonCore, :embedded_schema
 
   batt_polymorphic_schema type: :sso do
-    defaultable_field :dev, :boolean, default: true
+    field :mfa, :boolean, default: false
 
     defaultable_image_field :oauth2_proxy_image, image_id: :oauth2_proxy
   end

--- a/platform_umbrella/apps/common_core/lib/common_core/state_summary/keycloak_summary.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/state_summary/keycloak_summary.ex
@@ -3,14 +3,14 @@ defmodule CommonCore.StateSummary.KeycloakSummary do
 
   use CommonCore, :embedded_schema
 
-  alias CommonCore.OpenAPI.KeycloakAdminSchema
   alias CommonCore.OpenAPI.KeycloakAdminSchema.ClientRepresentation
+  alias CommonCore.OpenAPI.KeycloakAdminSchema.RealmRepresentation
   alias CommonCore.StateSummary.RealmOIDCConfiguration
 
   require Logger
 
   batt_embedded_schema do
-    embeds_many :realms, KeycloakAdminSchema.RealmRepresentation
+    embeds_many :realms, RealmRepresentation
     embeds_many :realm_configurations, RealmOIDCConfiguration
   end
 
@@ -24,7 +24,7 @@ defmodule CommonCore.StateSummary.KeycloakSummary do
   def realm_member?(%__MODULE__{realms: nil} = _keycloak_summary, _), do: true
 
   def realm_member?(%__MODULE__{realms: realms} = _keycloak_summary, realm_name) do
-    Enum.any?(realms, fn %KeycloakAdminSchema.RealmRepresentation{} = realm ->
+    Enum.any?(realms, fn %RealmRepresentation{} = realm ->
       realm.realm == realm_name
     end)
   end
@@ -78,13 +78,11 @@ defmodule CommonCore.StateSummary.KeycloakSummary do
   end
 
   def clients_for_realm(%__MODULE__{realms: realms}, realm) do
-    existing_realm = Enum.find(realms, &(&1.realm == realm))
-
-    case existing_realm do
+    case Enum.find(realms, &(&1.realm == realm)) do
       nil ->
         []
 
-      _ ->
+      existing_realm ->
         existing_realm.clients
     end
   end

--- a/platform_umbrella/apps/control_server/lib/control_server/snapshot_apply/keycloak_action.ex
+++ b/platform_umbrella/apps/control_server/lib/control_server/snapshot_apply/keycloak_action.ex
@@ -14,7 +14,7 @@ defmodule ControlServer.SnapshotApply.KeycloakAction do
     field :action, Ecto.Enum, values: [:create, :sync, :delete, :ping]
 
     # What we're trying to create
-    field :type, Ecto.Enum, values: [:realm, :client, :user]
+    field :type, Ecto.Enum, values: [:realm, :client, :user, :required_action, :flow_execution]
 
     # The owning realm
     field :realm, :string

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/batteries/sso_form.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/batteries/sso_form.ex
@@ -15,8 +15,8 @@ defmodule ControlServerWeb.Batteries.SSOForm do
       <.panel title="Configuration">
         <.fieldset>
           <.field variant="beside">
-            <:label>Dev</:label>
-            <.input type="switch" field={@form[:dev]} />
+            <:label>Require MFA?</:label>
+            <.input type="switch" field={@form[:mfa]} />
           </.field>
         </.fieldset>
       </.panel>

--- a/platform_umbrella/apps/event_center/lib/event_center/keycloak.ex
+++ b/platform_umbrella/apps/event_center/lib/event_center/keycloak.ex
@@ -14,7 +14,9 @@ defmodule EventCenter.Keycloak do
     :create_realm,
     :create_user,
     :reset_user_password,
-    :update_client
+    :update_client,
+    :update_required_action,
+    :update_flow_execution
   ]
 
   typedstruct module: Payload do

--- a/platform_umbrella/apps/kube_services/lib/kube_services/snapshot_apply/apply_action.ex
+++ b/platform_umbrella/apps/kube_services/lib/kube_services/snapshot_apply/apply_action.ex
@@ -1,6 +1,8 @@
 defmodule KubeServices.SnapshotApply.ApplyAction do
   @moduledoc false
 
+  alias CommonCore.OpenAPI.KeycloakAdminSchema.AuthenticationExecutionInfoRepresentation
+  alias CommonCore.OpenAPI.KeycloakAdminSchema.RequiredActionProviderRepresentation
   alias ControlServer.ContentAddressable.Document
   alias ControlServer.SnapshotApply.KeycloakAction
   alias EventCenter.Keycloak.Payload
@@ -80,6 +82,61 @@ defmodule KubeServices.SnapshotApply.ApplyAction do
     end
   end
 
+  def apply(%KeycloakAction{action: :sync, type: :required_action, realm: realm, document: %Document{value: value}}) do
+    case AdminClient.update_required_action(realm, RequiredActionProviderRepresentation.new!(value)) do
+      {:ok, :success} ->
+        :ok =
+          EventCenter.Keycloak.broadcast(%Payload{
+            action: :update_required_action,
+            resource: %{contents: value}
+          })
+
+        Logger.debug("Updating required_action: #{inspect(value)}")
+        {:ok, nil}
+
+      {:error, err} ->
+        Logger.error("Error updating required_action: #{inspect(err)}")
+        {:error, err}
+    end
+  end
+
+  def apply(%KeycloakAction{
+        action: :sync,
+        type: :flow_execution,
+        realm: realm,
+        document: %Document{value: %{"flow_alias" => flow_alias, "display_name" => display_name}}
+      }) do
+    with {:ok, executions} <- AdminClient.flow_executions(realm, flow_alias) do
+      execution =
+        Enum.find(
+          executions,
+          {:err, "execution not found with display name: #{display_name}"},
+          &(&1.displayName == display_name)
+        )
+
+      case require_flow_execution(realm, flow_alias, execution) do
+        {:ok, :already_required} ->
+          {:ok, nil}
+
+        {:ok, :success} ->
+          updated_execution = Map.from_struct(struct(execution, %{requirement: "REQUIRED"}))
+
+          :ok =
+            EventCenter.Keycloak.broadcast(%Payload{
+              action: :update_flow_execution,
+              resource: %{contents: updated_execution}
+            })
+
+          Logger.debug("Updating flow execution: #{inspect(updated_execution)}")
+          {:ok, nil}
+
+        err ->
+          Logger.error("Failed to require flow execution: #{inspect(err)}")
+          {:err, err}
+      end
+    end
+  end
+
   def apply(%KeycloakAction{action: :ping, type: :realm}) do
     # For ping we check that the openid wellknown
     # for the master realm (which is always created on startup)
@@ -94,4 +151,14 @@ defmodule KubeServices.SnapshotApply.ApplyAction do
   end
 
   def apply(%KeycloakAction{} = _action), do: {:ok, nil}
+
+  defp require_flow_execution(_realm, _alias, %AuthenticationExecutionInfoRepresentation{requirement: "REQUIRED"}),
+    do: {:ok, :already_required}
+
+  defp require_flow_execution(realm, alias, %AuthenticationExecutionInfoRepresentation{} = execution) do
+    AdminClient.update_flow_execution(realm, alias, %AuthenticationExecutionInfoRepresentation{
+      execution
+      | requirement: "REQUIRED"
+    })
+  end
 end


### PR DESCRIPTION
Allows turning on MFA for `batterycore` realm.

Test plan:
- [x] enable keycloak - MFA not enabled
- [x] enable SSO, no MFA - MFA not enabled
- [x] enable SSO + MFA - MFA enabled 
- [x] enable SSO, go back and forth on MFA - MFA is enabled / disabled appropriately 