### PR TITLE
docs: use new youtube embed links for web and main flow

### DIFF
--- a/static/src/pages/index.astro
+++ b/static/src/pages/index.astro
@@ -29,7 +29,7 @@ const metadata = {
     <div class="mt-12 mx-auto max-w-screen-md">
       <div class="flex justify-center">
         <VideoModal
-          url="https://www.youtube.com/embed/RVmMvNO2LUQ?si=8BakJI9Vot-whvKD"
+          url="https://www.youtube.com/embed/4k8CGRuU8BE?si=b3FCJcE9t8GUz9cq"
           client:load>
           <button class="btn-fourth !w-full">
             <p class="flex-shrink-0">Watch the demo</p>

--- a/static/src/pages/index.astro
+++ b/static/src/pages/index.astro
@@ -49,7 +49,7 @@ const metadata = {
       </div>
       <div class="mt-12">
         <VideoModal
-          url="https://www.youtube.com/embed/RVmMvNO2LUQ?si=8BakJI9Vot-whvKD"
+          url="https://www.youtube.com/embed/4k8CGRuU8BE?si=b3FCJcE9t8GUz9cq"
           client:load>
           <button class="aspect-video overflow-hidden group relative">
             <Image

--- a/static/src/pages/solutions/web-deploy.astro
+++ b/static/src/pages/solutions/web-deploy.astro
@@ -36,7 +36,7 @@ const metadata = {
     <div
       class="mt-12 max-w-xs sm:max-w-md md:max-w-none m-auto flex flex-nowrap flex-col sm:flex-row sm:justify-center gap-4">
       <VideoModal
-        url="https://www.youtube.com/embed/RVmMvNO2LUQ?si=8BakJI9Vot-whvKD"
+        url="https://www.youtube.com/embed/8rkuhPjC7bQ?si=PmskV8KEPgRmnHcY"
         client:load>
         <button class="btn-fourth">
           <p class="flex-shrink-0">Watch the Demo</p>


### PR DESCRIPTION
Summary:
We have a couple of new videos to demo our flow. Since they are up we
should use them on the website. This PR updates the web and index pages
to use the new embed code

Test Plan:
- Tested locally
- netlify
- verify that deploy preview embeds the new vides for both pages
