### PR TITLE
fix: change the embed url in we deploy as well.

### DIFF
--- a/static/src/pages/solutions/web-deploy.astro
+++ b/static/src/pages/solutions/web-deploy.astro
@@ -67,7 +67,7 @@ const metadata = {
     ]}
     video={{
       srcImage: '~/assets/images/solutions/web-services/demo.png',
-      url: 'https://www.youtube.com/embed/RVmMvNO2LUQ?si=8BakJI9Vot-whvKD',
+      url: 'https://www.youtube.com/embed/8rkuhPjC7bQ?si=PmskV8KEPgRmnHcY',
     }}
   />
 


### PR DESCRIPTION
Summary:

There's an emebd there too that I didn't see

Test Plan:
CI clean
