### PR TITLE
feat(monitoring): use preset sizes for victoria metrics

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/victoria_metrics_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/victoria_metrics_config.ex
@@ -6,8 +6,42 @@ defmodule CommonCore.Batteries.VictoriaMetricsConfig do
   alias CommonCore.Defaults
   alias CommonCore.Ecto.Schema
   alias CommonCore.Resources.Quantity
+  alias CommonCore.Util.Memory
 
   @read_only_fields ~w(cookie_secret)a
+
+  @presets [
+    %{
+      name: "tiny",
+      vmselect_volume_size: Memory.to_bytes(512, :MB),
+      vmstorage_volume_size: Memory.to_bytes(1, :GB)
+    },
+    %{
+      name: "small",
+      vmselect_volume_size: Memory.to_bytes(5, :GB),
+      vmstorage_volume_size: Memory.to_bytes(10, :GB)
+    },
+    %{
+      name: "medium",
+      vmselect_volume_size: Memory.to_bytes(10, :GB),
+      vmstorage_volume_size: Memory.to_bytes(50, :GB)
+    },
+    %{
+      name: "large",
+      vmselect_volume_size: Memory.to_bytes(100, :GB),
+      vmstorage_volume_size: Memory.to_bytes(200, :GB)
+    },
+    %{
+      name: "xlarge",
+      vmselect_volume_size: Memory.to_bytes(250, :GB),
+      vmstorage_volume_size: Memory.to_bytes(500, :GB)
+    },
+    %{
+      name: "huge",
+      vmselect_volume_size: Memory.to_bytes(1, :TB),
+      vmstorage_volume_size: Memory.to_bytes(2, :TB)
+    }
+  ]
 
   batt_polymorphic_schema type: :victoria_metrics do
     defaultable_field :cluster_image_tag, :string, default: Defaults.Images.vm_cluster_tag()
@@ -21,17 +55,23 @@ defmodule CommonCore.Batteries.VictoriaMetricsConfig do
     field :vmselect_replicas, :integer, default: 1
     field :vmstorage_replicas, :integer, default: 1
 
-    field :vmselect_volume_size, :integer, default: "1Gi" |> Quantity.parse_quantity() |> trunc()
-    field :vmstorage_volume_size, :integer, default: "5Gi" |> Quantity.parse_quantity() |> trunc()
+    field :vmselect_volume_size, :integer
+    field :vmstorage_volume_size, :integer
+
+    # Used in the CRUD form. User picks a "Size", which sets other fields based on presets.
+    field :virtual_size, :string, virtual: true
   end
 
   def changeset(base_struct, args, opts \\ []) do
     base_struct
     |> Schema.schema_changeset(args, opts)
+    |> maybe_set_virtual_size(@presets)
     |> validate_number(:replication_factor, greater_than: 0, less_than: 99)
     |> validate_number(:vmstorage_replicas, greater_than: 0, less_than: 99)
     |> validate_number(:vminsert_replicas, greater_than: 0, less_than: 99)
     |> validate_number(:vmselect_replicas, greater_than: 0, less_than: 99)
+    |> validate_number(:vmselect_volume_size, greater_than_or_equal_to: base_struct.vmselect_volume_size || 0)
+    |> validate_number(:vmstorage_volume_size, greater_than_or_equal_to: base_struct.vmstorage_volume_size || 0)
   end
 
   def load(%{"vmselect_volume_size" => size} = data) when is_binary(size),
@@ -48,5 +88,9 @@ defmodule CommonCore.Batteries.VictoriaMetricsConfig do
     |> trunc()
     |> then(&Map.put(data, field, &1))
     |> load()
+  end
+
+  def preset_options_for_select do
+    Enum.map(@presets, &{String.capitalize(&1.name), &1.name}) ++ [{"Custom", "custom"}]
   end
 end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/batteries/victoria_metrics_form.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/batteries/victoria_metrics_form.ex
@@ -5,6 +5,9 @@ defmodule ControlServerWeb.Batteries.VictoriaMetricsForm do
 
   import ControlServerWeb.BatteriesFormSubcomponents
 
+  alias CommonCore.Batteries.VictoriaMetricsConfig
+  alias CommonCore.Util.Memory
+
   def render(assigns) do
     ~H"""
     <div class="contents">
@@ -51,15 +54,46 @@ defmodule ControlServerWeb.Batteries.VictoriaMetricsForm do
             <.input type="number" field={@form[:vmstorage_replicas]} />
           </.field>
 
-          <.field>
-            <:label>Select Volume Size</:label>
-            <.input field={@form[:vmselect_volume_size]} />
+          <.field id="vm_virtual_size">
+            <:label>Size</:label>
+            <.input
+              type="select"
+              field={@form[:virtual_size]}
+              options={VictoriaMetricsConfig.preset_options_for_select()}
+            />
           </.field>
 
-          <.field>
-            <:label>Storage Volume Size</:label>
-            <.input field={@form[:vmstorage_volume_size]} />
-          </.field>
+          <.data_list
+            :if={@form[:virtual_size].value != "custom"}
+            variant="horizontal-bolded"
+            class="lg:col-span-2"
+            data={[
+              {"VMSelect volume size:", Memory.humanize(@form[:vmselect_volume_size].value)},
+              {"VMStorage volume size:", Memory.humanize(@form[:vmstorage_volume_size].value)}
+            ]}
+          />
+
+          <%= if @form[:virtual_size].value == "custom" do %>
+            <.fieldset>
+              <.field>
+                <:label>
+                  VMSelect Volume Size · <%= Memory.humanize(@form[:vmselect_volume_size].value) %>
+                </:label>
+                <:note>You can't reduce this once it has been created.</:note>
+                <.input type="number" field={@form[:vmselect_volume_size]} debounce={false} />
+              </.field>
+            </.fieldset>
+
+            <.fieldset>
+              <.field>
+                <:label>
+                  VMStorage Volume Size · <%= Memory.humanize(@form[:vmstorage_volume_size].value) %>
+                </:label>
+                <:note>You can't reduce this once it has been created.</:note>
+                <.input type="number" field={@form[:vmstorage_volume_size]} debounce={false} />
+              </.field>
+            </.fieldset>
+          <% end %>
         </.fieldset>
       </.panel>
     </div>


### PR DESCRIPTION
part of: #1176 

This doesn't use sliders yet. Just preset sizes.