### PR TITLE
fix(ui): update deprecated attribute to silence warnings

### DIFF
--- a/platform_umbrella/apps/common_ui/lib/common_ui/components/button.ex
+++ b/platform_umbrella/apps/common_ui/lib/common_ui/components/button.ex
@@ -71,7 +71,7 @@ defmodule CommonUI.Components.Button do
 
   def button(assigns) do
     ~H"""
-    <.dynamic_tag name={@tag} class={[button_class(assigns[:variant]), @class]} {@rest}>
+    <.dynamic_tag tag_name={@tag} class={[button_class(assigns[:variant]), @class]} {@rest}>
       <.icon
         :if={@icon && @icon_position == :left}
         class={icon_class(assigns[:variant])}

--- a/platform_umbrella/apps/common_ui/lib/common_ui/components/markdown.ex
+++ b/platform_umbrella/apps/common_ui/lib/common_ui/components/markdown.ex
@@ -13,7 +13,7 @@ defmodule CommonUI.Components.Markdown do
 
   def markdown(assigns) do
     ~H"""
-    <.dynamic_tag name={@tag} class={["prose dark:prose-invert", @class]} {@rest}>
+    <.dynamic_tag tag_name={@tag} class={["prose dark:prose-invert", @class]} {@rest}>
       {render(@content, @options)}
     </.dynamic_tag>
     """


### PR DESCRIPTION
```
warning: Passing the tag name to `Phoenix.Component.dynamic_tag/1` using the `name` attribute is deprecated.

Instead of:

    <.dynamic_tag name="p" ...>

use `tag_name` instead:

    <.dynamic_tag tag_name="p" ...>
```


```
grep -R dynamic_tag platform_umbrella/apps
platform_umbrella/apps/common_ui/lib/common_ui/components/button.ex:    <.dynamic_tag tag_name={@tag} class={[button_class(assigns[:variant]), @class]} {@rest}>
platform_umbrella/apps/common_ui/lib/common_ui/components/button.ex:    </.dynamic_tag>
platform_umbrella/apps/common_ui/lib/common_ui/components/markdown.ex:    <.dynamic_tag tag_name={@tag} class={["prose dark:prose-invert", @class]} {@rest}>
platform_umbrella/apps/common_ui/lib/common_ui/components/markdown.ex:    </.dynamic_tag>
```