### PR TITLE
refactor: use ET report tools to calculate knative pod count

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/et/knative_report.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/et/knative_report.ex
@@ -3,35 +3,30 @@ defmodule CommonCore.ET.KnativeReport do
 
   use CommonCore, :embedded_schema
 
+  import CommonCore.ET.ReportTools
+
   alias CommonCore.Ecto.Schema
   alias CommonCore.Resources.FieldAccessors
   alias CommonCore.StateSummary
-  alias CommonCore.StateSummary.FromKubeState
 
   batt_embedded_schema do
     field :pod_counts, :map
   end
 
   def new(%StateSummary{knative_services: services} = state_summary) do
-    pod_counts =
-      Map.new(services, fn service ->
-        {service.name, num_pods(service, state_summary)}
-      end)
+    # compute the pod count by owner (batt ID) once and pass that around
+    pods_by_owner = count_pods_by(state_summary, &FieldAccessors.labeled_owner/1)
 
-    Schema.schema_new(__MODULE__,
-      pod_counts: pod_counts
-    )
+    pod_counts =
+      Map.new(services, &count_by_service(&1, pods_by_owner))
+
+    Schema.schema_new(__MODULE__, pod_counts: pod_counts)
   end
 
   def new(opts) do
     Schema.schema_new(__MODULE__, opts)
   end
 
-  defp num_pods(service, state_summary) do
-    pods = FromKubeState.all_resources(state_summary, :pod)
-
-    Enum.count(pods, fn pod ->
-      FieldAccessors.labeled_owner(pod) == service.id
-    end)
-  end
+  # create a tuple of service name to pod count using the pre-computed map
+  defp count_by_service(service, pods_by_owner), do: {service.name, Map.get(pods_by_owner, service.id, 0)}
 end


### PR DESCRIPTION
Just a quick refactor to use the report tooling we already have.

Test plan:
- [x] knative not installed: report generated w/o pod counts
- [x] knative installed w/o services: report generated w/o pod counts
- [x] knative + service w/o pod: report generated w/ `{name, 0}` 
- [x] knative + service + pod: report generated w/ `{name, 1}`
- [x] existing CI / tests  