### PR TITLE
feat: enable more logging for cloudnative pg

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/resources/postgres/cloudnative_pg.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/resources/postgres/cloudnative_pg.ex
@@ -226,6 +226,7 @@ defmodule CommonCore.Resources.CloudnativePG do
             %{
               "args" => [
                 "controller",
+                "--log-level=debug",
                 "--leader-elect",
                 "--config-map-name=cnpg-controller-manager-config",
                 "--secret-name=cnpg-controller-manager-config",


### PR DESCRIPTION
Summary:
The default is not useful at all

Test Plan:
bix bootstrap && bix dev

- It all comes up
- The logs are there and more featureful
