### PR TITLE
fix: update the cloud native pg cluster role

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/resources/postgres/cloudnative_pg.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/resources/postgres/cloudnative_pg.ex
@@ -27,7 +27,7 @@ defmodule CommonCore.Resources.CloudnativePG do
     |> B.subject(B.build_service_account("cloudnative-pg", namespace))
   end
 
-  resource(:cluster_role_cnpg_cloudnative_pg) do
+  resource(:cluster_role_cloudnative_pg) do
     rules = [
       %{
         "apiGroups" => [""],

--- a/platform_umbrella/apps/common_core/lib/common_core/resources/postgres/cloudnative_pg.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/resources/postgres/cloudnative_pg.ex
@@ -27,59 +27,35 @@ defmodule CommonCore.Resources.CloudnativePG do
     |> B.subject(B.build_service_account("cloudnative-pg", namespace))
   end
 
-  resource(:cluster_role_cloudnative_pg) do
+  resource(:cluster_role_cnpg_cloudnative_pg) do
     rules = [
       %{
         "apiGroups" => [""],
-        "resources" => ["configmaps"],
+        "resources" => ["configmaps", "secrets", "services"],
         "verbs" => ["create", "delete", "get", "list", "patch", "update", "watch"]
       },
-      %{"apiGroups" => [""], "resources" => ["configmaps/status"], "verbs" => ["get", "patch", "update"]},
+      %{
+        "apiGroups" => [""],
+        "resources" => ["configmaps/status", "secrets/status"],
+        "verbs" => ["get", "patch", "update"]
+      },
       %{"apiGroups" => [""], "resources" => ["events"], "verbs" => ["create", "patch"]},
-      %{"apiGroups" => [""], "resources" => ["namespaces"], "verbs" => ["get", "list", "watch"]},
       %{"apiGroups" => [""], "resources" => ["nodes"], "verbs" => ["get", "list", "watch"]},
       %{
         "apiGroups" => [""],
-        "resources" => ["persistentvolumeclaims"],
-        "verbs" => ["create", "delete", "get", "list", "patch", "watch"]
-      },
-      %{"apiGroups" => [""], "resources" => ["pods"], "verbs" => ["create", "delete", "get", "list", "patch", "watch"]},
-      %{
-        "apiGroups" => [""],
-        "resources" => ["pods/exec"],
+        "resources" => ["persistentvolumeclaims", "pods", "pods/exec"],
         "verbs" => ["create", "delete", "get", "list", "patch", "watch"]
       },
       %{"apiGroups" => [""], "resources" => ["pods/status"], "verbs" => ["get"]},
-      %{
-        "apiGroups" => [""],
-        "resources" => ["secrets"],
-        "verbs" => ["create", "delete", "get", "list", "patch", "update", "watch"]
-      },
-      %{"apiGroups" => [""], "resources" => ["secrets/status"], "verbs" => ["get", "patch", "update"]},
       %{
         "apiGroups" => [""],
         "resources" => ["serviceaccounts"],
         "verbs" => ["create", "get", "list", "patch", "update", "watch"]
       },
       %{
-        "apiGroups" => [""],
-        "resources" => ["services"],
-        "verbs" => ["create", "delete", "get", "list", "patch", "update", "watch"]
-      },
-      %{
         "apiGroups" => ["admissionregistration.k8s.io"],
-        "resources" => ["mutatingwebhookconfigurations"],
-        "verbs" => ["get", "list", "patch", "update"]
-      },
-      %{
-        "apiGroups" => ["admissionregistration.k8s.io"],
-        "resources" => ["validatingwebhookconfigurations"],
-        "verbs" => ["get", "list", "patch", "update"]
-      },
-      %{
-        "apiGroups" => ["apiextensions.k8s.io"],
-        "resources" => ["customresourcedefinitions"],
-        "verbs" => ["get", "list", "update"]
+        "resources" => ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"],
+        "verbs" => ["get", "patch"]
       },
       %{
         "apiGroups" => ["apps"],
@@ -104,56 +80,32 @@ defmodule CommonCore.Resources.CloudnativePG do
       },
       %{
         "apiGroups" => ["postgresql.cnpg.io"],
-        "resources" => ["backups"],
+        "resources" => ["backups", "clusters", "poolers", "scheduledbackups"],
         "verbs" => ["create", "delete", "get", "list", "patch", "update", "watch"]
       },
-      %{"apiGroups" => ["postgresql.cnpg.io"], "resources" => ["backups/status"], "verbs" => ["get", "patch", "update"]},
       %{
         "apiGroups" => ["postgresql.cnpg.io"],
-        "resources" => ["clusterimagecatalogs"],
+        "resources" => ["backups/status", "scheduledbackups/status"],
+        "verbs" => ["get", "patch", "update"]
+      },
+      %{
+        "apiGroups" => ["postgresql.cnpg.io"],
+        "resources" => ["clusterimagecatalogs", "imagecatalogs"],
         "verbs" => ["get", "list", "watch"]
       },
       %{
         "apiGroups" => ["postgresql.cnpg.io"],
-        "resources" => ["clusters"],
-        "verbs" => ["create", "delete", "get", "list", "patch", "update", "watch"]
+        "resources" => ["clusters/finalizers", "poolers/finalizers"],
+        "verbs" => ["update"]
       },
-      %{"apiGroups" => ["postgresql.cnpg.io"], "resources" => ["clusters/finalizers"], "verbs" => ["update"]},
       %{
         "apiGroups" => ["postgresql.cnpg.io"],
-        "resources" => ["clusters/status"],
-        "verbs" => ["get", "patch", "update", "watch"]
-      },
-      %{"apiGroups" => ["postgresql.cnpg.io"], "resources" => ["imagecatalogs"], "verbs" => ["get", "list", "watch"]},
-      %{
-        "apiGroups" => ["postgresql.cnpg.io"],
-        "resources" => ["poolers"],
-        "verbs" => ["create", "delete", "get", "list", "patch", "update", "watch"]
-      },
-      %{"apiGroups" => ["postgresql.cnpg.io"], "resources" => ["poolers/finalizers"], "verbs" => ["update"]},
-      %{
-        "apiGroups" => ["postgresql.cnpg.io"],
-        "resources" => ["poolers/status"],
+        "resources" => ["clusters/status", "poolers/status"],
         "verbs" => ["get", "patch", "update", "watch"]
       },
       %{
-        "apiGroups" => ["postgresql.cnpg.io"],
-        "resources" => ["scheduledbackups"],
-        "verbs" => ["create", "delete", "get", "list", "patch", "update", "watch"]
-      },
-      %{
-        "apiGroups" => ["postgresql.cnpg.io"],
-        "resources" => ["scheduledbackups/status"],
-        "verbs" => ["get", "patch", "update"]
-      },
-      %{
         "apiGroups" => ["rbac.authorization.k8s.io"],
-        "resources" => ["rolebindings"],
-        "verbs" => ["create", "get", "list", "patch", "update", "watch"]
-      },
-      %{
-        "apiGroups" => ["rbac.authorization.k8s.io"],
-        "resources" => ["roles"],
+        "resources" => ["rolebindings", "roles"],
         "verbs" => ["create", "get", "list", "patch", "update", "watch"]
       },
       %{
@@ -332,7 +284,7 @@ defmodule CommonCore.Resources.CloudnativePG do
           }
         },
         "failurePolicy" => "Fail",
-        "name" => "mbackup.kb.io",
+        "name" => "mbackup.cnpg.io",
         "rules" => [
           %{
             "apiGroups" => ["postgresql.cnpg.io"],
@@ -354,7 +306,7 @@ defmodule CommonCore.Resources.CloudnativePG do
           }
         },
         "failurePolicy" => "Fail",
-        "name" => "mcluster.kb.io",
+        "name" => "mcluster.cnpg.io",
         "rules" => [
           %{
             "apiGroups" => ["postgresql.cnpg.io"],
@@ -376,7 +328,7 @@ defmodule CommonCore.Resources.CloudnativePG do
           }
         },
         "failurePolicy" => "Fail",
-        "name" => "mscheduledbackup.kb.io",
+        "name" => "mscheduledbackup.cnpg.io",
         "rules" => [
           %{
             "apiGroups" => ["postgresql.cnpg.io"],
@@ -436,7 +388,7 @@ defmodule CommonCore.Resources.CloudnativePG do
           }
         },
         "failurePolicy" => "Fail",
-        "name" => "vbackup.kb.io",
+        "name" => "vbackup.cnpg.io",
         "rules" => [
           %{
             "apiGroups" => ["postgresql.cnpg.io"],
@@ -458,7 +410,7 @@ defmodule CommonCore.Resources.CloudnativePG do
           }
         },
         "failurePolicy" => "Fail",
-        "name" => "vcluster.kb.io",
+        "name" => "vcluster.cnpg.io",
         "rules" => [
           %{
             "apiGroups" => ["postgresql.cnpg.io"],
@@ -480,7 +432,7 @@ defmodule CommonCore.Resources.CloudnativePG do
           }
         },
         "failurePolicy" => "Fail",
-        "name" => "vscheduledbackup.kb.io",
+        "name" => "vscheduledbackup.cnpg.io",
         "rules" => [
           %{
             "apiGroups" => ["postgresql.cnpg.io"],
@@ -502,7 +454,7 @@ defmodule CommonCore.Resources.CloudnativePG do
           }
         },
         "failurePolicy" => "Fail",
-        "name" => "vpooler.kb.io",
+        "name" => "vpooler.cnpg.io",
         "rules" => [
           %{
             "apiGroups" => ["postgresql.cnpg.io"],

--- a/platform_umbrella/apps/common_core/priv/manifests/cloudnative_pg/clusters_postgresql_cnpg_io.yaml
+++ b/platform_umbrella/apps/common_core/priv/manifests/cloudnative_pg/clusters_postgresql_cnpg_io.yaml
@@ -85,6 +85,11 @@ spec:
                             and services.
                             More info: http://kubernetes.io/docs/user-guide/labels
                           type: object
+                        name:
+                          description:
+                            The name of the resource. Only supported for certain
+                            types
+                          type: string
                       type: object
                   required:
                     - metadata
@@ -157,11 +162,13 @@ spec:
                                   items:
                                     type: string
                                   type: array
+                                  x-kubernetes-list-type: atomic
                               required:
                                 - key
                                 - operator
                               type: object
                             type: array
+                            x-kubernetes-list-type: atomic
                           matchLabels:
                             additionalProperties:
                               type: string
@@ -182,7 +189,6 @@ spec:
                           MatchLabelKeys cannot be set when LabelSelector isn't set.
                           Keys that don't exist in the incoming pod labels will
                           be ignored. A null or empty list means only match against labelSelector.
-
 
                           This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
                         items:
@@ -223,7 +229,6 @@ spec:
                           Valid values are integers greater than 0.
                           When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
 
-
                           For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
                           labelSelector spread as 2/2/2:
                           | zone1 | zone2 | zone3 |
@@ -232,9 +237,6 @@ spec:
                           In this situation, new pod with the same labelSelector cannot be scheduled,
                           because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
                           it will violate MaxSkew.
-
-
-                          This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).
                         format: int32
                         type: integer
                       nodeAffinityPolicy:
@@ -243,7 +245,6 @@ spec:
                           when calculating pod topology spread skew. Options are:
                           - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
                           - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
-
 
                           If this value is nil, the behavior is equivalent to the Honor policy.
                           This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
@@ -255,7 +256,6 @@ spec:
                           - Honor: nodes without taints, along with tainted nodes for which the incoming pod
                           has a toleration, are included.
                           - Ignore: node taints are ignored. All nodes are included.
-
 
                           If this value is nil, the behavior is equivalent to the Ignore policy.
                           This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
@@ -374,6 +374,7 @@ spec:
                           items:
                             type: string
                           type: array
+                          x-kubernetes-list-type: atomic
                         dataSource:
                           description: |-
                             dataSource field can be used to specify either:
@@ -520,11 +521,13 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                 required:
                                   - key
                                   - operator
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                             matchLabels:
                               additionalProperties:
                                 type: string
@@ -552,8 +555,8 @@ spec:
                             If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                             set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                             exists.
-                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                            (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
+                            More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                            (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                           type: string
                         volumeMode:
                           description: |-
@@ -686,12 +689,10 @@ spec:
                                   provide flexibility to customize the backup process further according to
                                   specific requirements or configurations.
 
-
                                   Example:
                                   In a scenario where specialized backup options are required, such as setting
                                   a specific timeout or defining custom behavior, users can use this field
                                   to specify additional command arguments.
-
 
                                   Note:
                                   It's essential to ensure that the provided arguments are valid and supported
@@ -880,6 +881,24 @@ spec:
                               When not defined, WAL files will be stored uncompressed and may be
                               unencrypted in the object store, according to the bucket default policy.
                             properties:
+                              archiveAdditionalCommandArgs:
+                                description: |-
+                                  Additional arguments that can be appended to the 'barman-cloud-wal-archive'
+                                  command-line invocation. These arguments provide flexibility to customize
+                                  the WAL archive process further, according to specific requirements or configurations.
+
+                                  Example:
+                                  In a scenario where specialized backup options are required, such as setting
+                                  a specific timeout or defining custom behavior, users can use this field
+                                  to specify additional command arguments.
+
+                                  Note:
+                                  It's essential to ensure that the provided arguments are valid and supported
+                                  by the 'barman-cloud-wal-archive' command, to avoid potential errors or unintended
+                                  behavior during execution.
+                                items:
+                                  type: string
+                                type: array
                               compression:
                                 description: |-
                                   Compress a WAL file before sending it to the object store. Available
@@ -909,6 +928,24 @@ spec:
                                   value - with 1 being the minimum accepted value.
                                 minimum: 1
                                 type: integer
+                              restoreAdditionalCommandArgs:
+                                description: |-
+                                  Additional arguments that can be appended to the 'barman-cloud-wal-restore'
+                                  command-line invocation. These arguments provide flexibility to customize
+                                  the WAL restore process further, according to specific requirements or configurations.
+
+                                  Example:
+                                  In a scenario where specialized backup options are required, such as setting
+                                  a specific timeout or defining custom behavior, users can use this field
+                                  to specify additional command arguments.
+
+                                  Note:
+                                  It's essential to ensure that the provided arguments are valid and supported
+                                  by the 'barman-cloud-wal-restore' command, to avoid potential errors or unintended
+                                  behavior during execution.
+                                items:
+                                  type: string
+                                type: array
                             type: object
                         required:
                           - destinationPath
@@ -939,10 +976,13 @@ spec:
                               valid secret key.
                             type: string
                           name:
+                            default: ''
                             description: |-
                               Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?
                             type: string
                           optional:
                             description:
@@ -964,10 +1004,13 @@ spec:
                               valid secret key.
                             type: string
                           name:
+                            default: ''
                             description: |-
                               Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?
                             type: string
                           optional:
                             description:
@@ -989,10 +1032,13 @@ spec:
                               valid secret key.
                             type: string
                           name:
+                            default: ''
                             description: |-
                               Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?
                             type: string
                           optional:
                             description:
@@ -1014,10 +1060,13 @@ spec:
                               valid secret key.
                             type: string
                           name:
+                            default: ''
                             description: |-
                               Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?
                             type: string
                           optional:
                             description:
@@ -1047,6 +1096,7 @@ spec:
                           items:
                             type: string
                           type: array
+                          x-kubernetes-list-type: atomic
                         dataSource:
                           description: |-
                             dataSource field can be used to specify either:
@@ -1193,11 +1243,13 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                 required:
                                   - key
                                   - operator
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                             matchLabels:
                               additionalProperties:
                                 type: string
@@ -1225,8 +1277,8 @@ spec:
                             If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                             set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                             exists.
-                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                            (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
+                            More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                            (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                           type: string
                         volumeMode:
                           description: |-
@@ -1295,10 +1347,13 @@ spec:
                                 description: The key to select.
                                 type: string
                               name:
+                                default: ''
                                 description: |-
                                   Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                 type: string
                               optional:
                                 description:
@@ -1364,10 +1419,13 @@ spec:
                                   a valid secret key.
                                 type: string
                               name:
+                                default: ''
                                 description: |-
                                   Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                 type: string
                               optional:
                                 description:
@@ -1415,7 +1473,6 @@ spec:
                       description: |-
                         type indicates which kind of seccomp profile will be applied.
                         Valid options are:
-
 
                         Localhost - a profile defined in a file on the node should be used.
                         RuntimeDefault - the container runtime default profile should be used.
@@ -1481,10 +1538,13 @@ spec:
                                     be a valid secret key.
                                   type: string
                                 name:
+                                  default: ''
                                   description: |-
                                     Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
                                     More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
                                   description:
@@ -1579,6 +1639,56 @@ spec:
                       required:
                         - enabled
                       type: object
+                    synchronous:
+                      description:
+                        Configuration of the PostgreSQL synchronous replication
+                        feature
+                      properties:
+                        maxStandbyNamesFromCluster:
+                          description: |-
+                            Specifies the maximum number of local cluster pods that can be
+                            automatically included in the `synchronous_standby_names` option in
+                            PostgreSQL.
+                          type: integer
+                        method:
+                          description: |-
+                            Method to select synchronous replication standbys from the listed
+                            servers, accepting 'any' (quorum-based synchronous replication) or
+                            'first' (priority-based synchronous replication) as values.
+                          enum:
+                            - any
+                            - first
+                          type: string
+                        number:
+                          description: |-
+                            Specifies the number of synchronous standby servers that
+                            transactions must wait for responses from.
+                          type: integer
+                          x-kubernetes-validations:
+                            - message:
+                                The number of synchronous replicas should be
+                                greater than zero
+                              rule: self > 0
+                        standbyNamesPost:
+                          description: |-
+                            A user-defined list of application names to be added to
+                            `synchronous_standby_names` after local cluster pods (the order is
+                            only useful for priority-based synchronous replication).
+                          items:
+                            type: string
+                          type: array
+                        standbyNamesPre:
+                          description: |-
+                            A user-defined list of application names to be added to
+                            `synchronous_standby_names` before local cluster pods (the order is
+                            only useful for priority-based synchronous replication).
+                          items:
+                            type: string
+                          type: array
+                      required:
+                        - method
+                        - number
+                      type: object
                   type: object
                 affinity:
                   description: Affinity/Anti-affinity rules for Pods
@@ -1644,11 +1754,13 @@ spec:
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                           required:
                                             - key
                                             - operator
                                           type: object
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       matchLabels:
                                         additionalProperties:
                                           type: string
@@ -1663,13 +1775,13 @@ spec:
                                     description: |-
                                       MatchLabelKeys is a set of pod label keys to select which pods will
                                       be taken into consideration. The keys are used to lookup values from the
-                                      incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
                                       to select the group of existing pods which pods will be taken into consideration
                                       for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
                                       pod labels will be ignored. The default value is empty.
-                                      The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                                      Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
-                                      This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                     items:
                                       type: string
                                     type: array
@@ -1678,13 +1790,13 @@ spec:
                                     description: |-
                                       MismatchLabelKeys is a set of pod label keys to select which pods will
                                       be taken into consideration. The keys are used to lookup values from the
-                                      incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
                                       to select the group of existing pods which pods will be taken into consideration
                                       for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
                                       pod labels will be ignored. The default value is empty.
-                                      The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
-                                      Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
-                                      This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                     items:
                                       type: string
                                     type: array
@@ -1726,11 +1838,13 @@ spec:
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                           required:
                                             - key
                                             - operator
                                           type: object
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       matchLabels:
                                         additionalProperties:
                                           type: string
@@ -1750,6 +1864,7 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   topologyKey:
                                     description: |-
                                       This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
@@ -1772,6 +1887,7 @@ spec:
                               - weight
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                         requiredDuringSchedulingIgnoredDuringExecution:
                           description: |-
                             If the affinity requirements specified by this field are not met at
@@ -1824,11 +1940,13 @@ spec:
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       required:
                                         - key
                                         - operator
                                       type: object
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   matchLabels:
                                     additionalProperties:
                                       type: string
@@ -1843,13 +1961,13 @@ spec:
                                 description: |-
                                   MatchLabelKeys is a set of pod label keys to select which pods will
                                   be taken into consideration. The keys are used to lookup values from the
-                                  incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
                                   to select the group of existing pods which pods will be taken into consideration
                                   for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
                                   pod labels will be ignored. The default value is empty.
-                                  The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                                  Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
-                                  This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                  The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                  Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                  This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                 items:
                                   type: string
                                 type: array
@@ -1858,13 +1976,13 @@ spec:
                                 description: |-
                                   MismatchLabelKeys is a set of pod label keys to select which pods will
                                   be taken into consideration. The keys are used to lookup values from the
-                                  incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
                                   to select the group of existing pods which pods will be taken into consideration
                                   for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
                                   pod labels will be ignored. The default value is empty.
-                                  The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
-                                  Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
-                                  This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                  The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                  Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                  This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                 items:
                                   type: string
                                 type: array
@@ -1906,11 +2024,13 @@ spec:
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       required:
                                         - key
                                         - operator
                                       type: object
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   matchLabels:
                                     additionalProperties:
                                       type: string
@@ -1930,6 +2050,7 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                               topologyKey:
                                 description: |-
                                   This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
@@ -1942,6 +2063,7 @@ spec:
                               - topologyKey
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                       type: object
                     additionalPodAntiAffinity:
                       description: |-
@@ -2004,11 +2126,13 @@ spec:
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                           required:
                                             - key
                                             - operator
                                           type: object
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       matchLabels:
                                         additionalProperties:
                                           type: string
@@ -2023,13 +2147,13 @@ spec:
                                     description: |-
                                       MatchLabelKeys is a set of pod label keys to select which pods will
                                       be taken into consideration. The keys are used to lookup values from the
-                                      incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
                                       to select the group of existing pods which pods will be taken into consideration
                                       for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
                                       pod labels will be ignored. The default value is empty.
-                                      The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                                      Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
-                                      This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                      The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                      Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                     items:
                                       type: string
                                     type: array
@@ -2038,13 +2162,13 @@ spec:
                                     description: |-
                                       MismatchLabelKeys is a set of pod label keys to select which pods will
                                       be taken into consideration. The keys are used to lookup values from the
-                                      incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                      incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
                                       to select the group of existing pods which pods will be taken into consideration
                                       for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
                                       pod labels will be ignored. The default value is empty.
-                                      The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
-                                      Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
-                                      This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                      The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                      Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                     items:
                                       type: string
                                     type: array
@@ -2086,11 +2210,13 @@ spec:
                                               items:
                                                 type: string
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                           required:
                                             - key
                                             - operator
                                           type: object
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       matchLabels:
                                         additionalProperties:
                                           type: string
@@ -2110,6 +2236,7 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   topologyKey:
                                     description: |-
                                       This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
@@ -2132,6 +2259,7 @@ spec:
                               - weight
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                         requiredDuringSchedulingIgnoredDuringExecution:
                           description: |-
                             If the anti-affinity requirements specified by this field are not met at
@@ -2184,11 +2312,13 @@ spec:
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       required:
                                         - key
                                         - operator
                                       type: object
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   matchLabels:
                                     additionalProperties:
                                       type: string
@@ -2203,13 +2333,13 @@ spec:
                                 description: |-
                                   MatchLabelKeys is a set of pod label keys to select which pods will
                                   be taken into consideration. The keys are used to lookup values from the
-                                  incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
                                   to select the group of existing pods which pods will be taken into consideration
                                   for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
                                   pod labels will be ignored. The default value is empty.
-                                  The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                                  Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
-                                  This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                  The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                  Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                  This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                 items:
                                   type: string
                                 type: array
@@ -2218,13 +2348,13 @@ spec:
                                 description: |-
                                   MismatchLabelKeys is a set of pod label keys to select which pods will
                                   be taken into consideration. The keys are used to lookup values from the
-                                  incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
                                   to select the group of existing pods which pods will be taken into consideration
                                   for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
                                   pod labels will be ignored. The default value is empty.
-                                  The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
-                                  Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
-                                  This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                  The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                  Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                  This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                 items:
                                   type: string
                                 type: array
@@ -2266,11 +2396,13 @@ spec:
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       required:
                                         - key
                                         - operator
                                       type: object
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   matchLabels:
                                     additionalProperties:
                                       type: string
@@ -2290,6 +2422,7 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                               topologyKey:
                                 description: |-
                                   This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
@@ -2302,6 +2435,7 @@ spec:
                               - topologyKey
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                       type: object
                     enablePodAntiAffinity:
                       description: |-
@@ -2363,11 +2497,13 @@ spec:
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       required:
                                         - key
                                         - operator
                                       type: object
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   matchFields:
                                     description:
                                       A list of node selector requirements by
@@ -2397,11 +2533,13 @@ spec:
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       required:
                                         - key
                                         - operator
                                       type: object
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                 type: object
                                 x-kubernetes-map-type: atomic
                               weight:
@@ -2416,6 +2554,7 @@ spec:
                               - weight
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                         requiredDuringSchedulingIgnoredDuringExecution:
                           description: |-
                             If the affinity requirements specified by this field are not met at
@@ -2463,11 +2602,13 @@ spec:
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       required:
                                         - key
                                         - operator
                                       type: object
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   matchFields:
                                     description:
                                       A list of node selector requirements by
@@ -2497,14 +2638,17 @@ spec:
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       required:
                                         - key
                                         - operator
                                       type: object
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                 type: object
                                 x-kubernetes-map-type: atomic
                               type: array
+                              x-kubernetes-list-type: atomic
                           required:
                             - nodeSelectorTerms
                           type: object
@@ -2601,6 +2745,14 @@ spec:
                     to be unhealthy
                   format: int32
                   type: integer
+                livenessProbeTimeout:
+                  description: |-
+                    LivenessProbeTimeout is the time (in seconds) that is allowed for a PostgreSQL instance
+                    to successfully respond to the liveness probe (default 30).
+                    The Liveness probe failure threshold is derived from this value using the formula:
+                    ceiling(livenessProbe / 10).
+                  format: int32
+                  type: integer
                 instances:
                   default: 1
                   description: Number of instances required in the cluster
@@ -2673,10 +2825,8 @@ spec:
                         Claims lists the names of resources, defined in spec.resourceClaims,
                         that are used by this container.
 
-
                         This is an alpha field and requires enabling the
                         DynamicResourceAllocation feature gate.
-
 
                         This field is immutable. It can only be set for containers.
                       items:
@@ -2689,6 +2839,12 @@ spec:
                               Name must match the name of one entry in pod.spec.resourceClaims of
                               the Pod where this field is used. It makes that resource available
                               inside a container.
+                            type: string
+                          request:
+                            description: |-
+                              Request is the name chosen for a request in the referenced claim.
+                              If empty, everything from the claim is made available, otherwise
+                              only the result of this request.
                             type: string
                         required:
                           - name
@@ -2850,6 +3006,29 @@ spec:
                         object store or via streaming through pg_basebackup.
                         Refer to the Replica clusters page of the documentation for more information.
                       type: boolean
+                    minApplyDelay:
+                      description: |-
+                        When replica mode is enabled, this parameter allows you to replay
+                        transactions only when the system time is at least the configured
+                        time past the commit time. This provides an opportunity to correct
+                        data loss errors. Note that when this parameter is set, a promotion
+                        token cannot be used.
+                      type: string
+                    primary:
+                      description: |-
+                        Primary defines which Cluster is defined to be the primary in the distributed PostgreSQL cluster, based on the
+                        topology specified in externalClusters
+                      type: string
+                    promotionToken:
+                      description: |-
+                        A demotion token generated by an external cluster used to
+                        check if the promotion requirements are met.
+                      type: string
+                    self:
+                      description: |-
+                        Self defines the name of this cluster. It is used to determine if this is a primary
+                        or a replica cluster, comparing it with `primary`
+                      type: string
                     source:
                       description:
                         The name of the external cluster which is the
@@ -2857,7 +3036,6 @@ spec:
                       minLength: 1
                       type: string
                   required:
-                    - enabled
                     - source
                   type: object
                 managed:
@@ -2872,7 +3050,6 @@ spec:
                           RoleConfiguration is the representation, in Kubernetes, of a PostgreSQL role
                           with the additional field Ensure specifying whether to ensure the presence or
                           absence of the role in the database
-
 
                           The defaults of the CREATE ROLE command are applied
                           Reference: https://www.postgresql.org/docs/current/sql-createrole.html
@@ -2979,6 +3156,447 @@ spec:
                           - name
                         type: object
                       type: array
+                    services:
+                      description: Services roles managed by the `Cluster`
+                      properties:
+                        additional:
+                          description:
+                            Additional is a list of additional managed services
+                            specified by the user.
+                          items:
+                            description: |-
+                              ManagedService represents a specific service managed by the cluster.
+                              It includes the type of service and its associated template specification.
+                            properties:
+                              selectorType:
+                                allOf:
+                                  - enum:
+                                      - rw
+                                      - r
+                                      - ro
+                                  - enum:
+                                      - rw
+                                      - r
+                                      - ro
+                                description: |-
+                                  SelectorType specifies the type of selectors that the service will have.
+                                  Valid values are "rw", "r", and "ro", representing read-write, read, and read-only services.
+                                type: string
+                              serviceTemplate:
+                                description:
+                                  ServiceTemplate is the template specification
+                                  for the service.
+                                properties:
+                                  metadata:
+                                    description: |-
+                                      Standard object's metadata.
+                                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          Annotations is an unstructured key value map stored with a resource that may be
+                                          set by external tools to store and retrieve arbitrary metadata. They are not
+                                          queryable and should be preserved when modifying objects.
+                                          More info: http://kubernetes.io/docs/user-guide/annotations
+                                        type: object
+                                      labels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          Map of string keys and values that can be used to organize and categorize
+                                          (scope and select) objects. May match selectors of replication controllers
+                                          and services.
+                                          More info: http://kubernetes.io/docs/user-guide/labels
+                                        type: object
+                                      name:
+                                        description:
+                                          The name of the resource. Only
+                                          supported for certain types
+                                        type: string
+                                    type: object
+                                  spec:
+                                    description: |-
+                                      Specification of the desired behavior of the service.
+                                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                                    properties:
+                                      allocateLoadBalancerNodePorts:
+                                        description: |-
+                                          allocateLoadBalancerNodePorts defines if NodePorts will be automatically
+                                          allocated for services with type LoadBalancer.  Default is "true". It
+                                          may be set to "false" if the cluster load-balancer does not rely on
+                                          NodePorts.  If the caller requests specific NodePorts (by specifying a
+                                          value), those requests will be respected, regardless of this field.
+                                          This field may only be set for services with type LoadBalancer and will
+                                          be cleared if the type is changed to any other type.
+                                        type: boolean
+                                      clusterIP:
+                                        description: |-
+                                          clusterIP is the IP address of the service and is usually assigned
+                                          randomly. If an address is specified manually, is in-range (as per
+                                          system configuration), and is not in use, it will be allocated to the
+                                          service; otherwise creation of the service will fail. This field may not
+                                          be changed through updates unless the type field is also being changed
+                                          to ExternalName (which requires this field to be blank) or the type
+                                          field is being changed from ExternalName (in which case this field may
+                                          optionally be specified, as describe above).  Valid values are "None",
+                                          empty string (""), or a valid IP address. Setting this to "None" makes a
+                                          "headless service" (no virtual IP), which is useful when direct endpoint
+                                          connections are preferred and proxying is not required.  Only applies to
+                                          types ClusterIP, NodePort, and LoadBalancer. If this field is specified
+                                          when creating a Service of type ExternalName, creation will fail. This
+                                          field will be wiped when updating a Service to type ExternalName.
+                                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+                                        type: string
+                                      clusterIPs:
+                                        description: |-
+                                          ClusterIPs is a list of IP addresses assigned to this service, and are
+                                          usually assigned randomly.  If an address is specified manually, is
+                                          in-range (as per system configuration), and is not in use, it will be
+                                          allocated to the service; otherwise creation of the service will fail.
+                                          This field may not be changed through updates unless the type field is
+                                          also being changed to ExternalName (which requires this field to be
+                                          empty) or the type field is being changed from ExternalName (in which
+                                          case this field may optionally be specified, as describe above).  Valid
+                                          values are "None", empty string (""), or a valid IP address.  Setting
+                                          this to "None" makes a "headless service" (no virtual IP), which is
+                                          useful when direct endpoint connections are preferred and proxying is
+                                          not required.  Only applies to types ClusterIP, NodePort, and
+                                          LoadBalancer. If this field is specified when creating a Service of type
+                                          ExternalName, creation will fail. This field will be wiped when updating
+                                          a Service to type ExternalName.  If this field is not specified, it will
+                                          be initialized from the clusterIP field.  If this field is specified,
+                                          clients must ensure that clusterIPs[0] and clusterIP have the same
+                                          value.
+
+                                          This field may hold a maximum of two entries (dual-stack IPs, in either order).
+                                          These IPs must correspond to the values of the ipFamilies field. Both
+                                          clusterIPs and ipFamilies are governed by the ipFamilyPolicy field.
+                                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      externalIPs:
+                                        description: |-
+                                          externalIPs is a list of IP addresses for which nodes in the cluster
+                                          will also accept traffic for this service.  These IPs are not managed by
+                                          Kubernetes.  The user is responsible for ensuring that traffic arrives
+                                          at a node with this IP.  A common example is external load-balancers
+                                          that are not part of the Kubernetes system.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      externalName:
+                                        description: |-
+                                          externalName is the external reference that discovery mechanisms will
+                                          return as an alias for this service (e.g. a DNS CNAME record). No
+                                          proxying will be involved.  Must be a lowercase RFC-1123 hostname
+                                          (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
+                                        type: string
+                                      externalTrafficPolicy:
+                                        description: |-
+                                          externalTrafficPolicy describes how nodes distribute service traffic they
+                                          receive on one of the Service's "externally-facing" addresses (NodePorts,
+                                          ExternalIPs, and LoadBalancer IPs). If set to "Local", the proxy will configure
+                                          the service in a way that assumes that external load balancers will take care
+                                          of balancing the service traffic between nodes, and so each node will deliver
+                                          traffic only to the node-local endpoints of the service, without masquerading
+                                          the client source IP. (Traffic mistakenly sent to a node with no endpoints will
+                                          be dropped.) The default value, "Cluster", uses the standard behavior of
+                                          routing to all endpoints evenly (possibly modified by topology and other
+                                          features). Note that traffic sent to an External IP or LoadBalancer IP from
+                                          within the cluster will always get "Cluster" semantics, but clients sending to
+                                          a NodePort from within the cluster may need to take traffic policy into account
+                                          when picking a node.
+                                        type: string
+                                      healthCheckNodePort:
+                                        description: |-
+                                          healthCheckNodePort specifies the healthcheck nodePort for the service.
+                                          This only applies when type is set to LoadBalancer and
+                                          externalTrafficPolicy is set to Local. If a value is specified, is
+                                          in-range, and is not in use, it will be used.  If not specified, a value
+                                          will be automatically allocated.  External systems (e.g. load-balancers)
+                                          can use this port to determine if a given node holds endpoints for this
+                                          service or not.  If this field is specified when creating a Service
+                                          which does not need it, creation will fail. This field will be wiped
+                                          when updating a Service to no longer need it (e.g. changing type).
+                                          This field cannot be updated once set.
+                                        format: int32
+                                        type: integer
+                                      internalTrafficPolicy:
+                                        description: |-
+                                          InternalTrafficPolicy describes how nodes distribute service traffic they
+                                          receive on the ClusterIP. If set to "Local", the proxy will assume that pods
+                                          only want to talk to endpoints of the service on the same node as the pod,
+                                          dropping the traffic if there are no local endpoints. The default value,
+                                          "Cluster", uses the standard behavior of routing to all endpoints evenly
+                                          (possibly modified by topology and other features).
+                                        type: string
+                                      ipFamilies:
+                                        description: |-
+                                          IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this
+                                          service. This field is usually assigned automatically based on cluster
+                                          configuration and the ipFamilyPolicy field. If this field is specified
+                                          manually, the requested family is available in the cluster,
+                                          and ipFamilyPolicy allows it, it will be used; otherwise creation of
+                                          the service will fail. This field is conditionally mutable: it allows
+                                          for adding or removing a secondary IP family, but it does not allow
+                                          changing the primary IP family of the Service. Valid values are "IPv4"
+                                          and "IPv6".  This field only applies to Services of types ClusterIP,
+                                          NodePort, and LoadBalancer, and does apply to "headless" services.
+                                          This field will be wiped when updating a Service to type ExternalName.
+
+                                          This field may hold a maximum of two entries (dual-stack families, in
+                                          either order).  These families must correspond to the values of the
+                                          clusterIPs field, if specified. Both clusterIPs and ipFamilies are
+                                          governed by the ipFamilyPolicy field.
+                                        items:
+                                          description: |-
+                                            IPFamily represents the IP Family (IPv4 or IPv6). This type is used
+                                            to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      ipFamilyPolicy:
+                                        description: |-
+                                          IPFamilyPolicy represents the dual-stack-ness requested or required by
+                                          this Service. If there is no value provided, then this field will be set
+                                          to SingleStack. Services can be "SingleStack" (a single IP family),
+                                          "PreferDualStack" (two IP families on dual-stack configured clusters or
+                                          a single IP family on single-stack clusters), or "RequireDualStack"
+                                          (two IP families on dual-stack configured clusters, otherwise fail). The
+                                          ipFamilies and clusterIPs fields depend on the value of this field. This
+                                          field will be wiped when updating a service to type ExternalName.
+                                        type: string
+                                      loadBalancerClass:
+                                        description: |-
+                                          loadBalancerClass is the class of the load balancer implementation this Service belongs to.
+                                          If specified, the value of this field must be a label-style identifier, with an optional prefix,
+                                          e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users.
+                                          This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load
+                                          balancer implementation is used, today this is typically done through the cloud provider integration,
+                                          but should apply for any default implementation. If set, it is assumed that a load balancer
+                                          implementation is watching for Services with a matching class. Any default load balancer
+                                          implementation (e.g. cloud providers) should ignore Services that set this field.
+                                          This field can only be set when creating or updating a Service to type 'LoadBalancer'.
+                                          Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.
+                                        type: string
+                                      loadBalancerIP:
+                                        description: |-
+                                          Only applies to Service Type: LoadBalancer.
+                                          This feature depends on whether the underlying cloud-provider supports specifying
+                                          the loadBalancerIP when a load balancer is created.
+                                          This field will be ignored if the cloud-provider does not support the feature.
+                                          Deprecated: This field was under-specified and its meaning varies across implementations.
+                                          Using it is non-portable and it may not support dual-stack.
+                                          Users are encouraged to use implementation-specific annotations when available.
+                                        type: string
+                                      loadBalancerSourceRanges:
+                                        description: |-
+                                          If specified and supported by the platform, this will restrict traffic through the cloud-provider
+                                          load-balancer will be restricted to the specified client IPs. This field will be ignored if the
+                                          cloud-provider does not support the feature."
+                                          More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      ports:
+                                        description: |-
+                                          The list of ports that are exposed by this service.
+                                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+                                        items:
+                                          description:
+                                            ServicePort contains information on
+                                            service's port.
+                                          properties:
+                                            appProtocol:
+                                              description: |-
+                                                The application protocol for this port.
+                                                This is used as a hint for implementations to offer richer behavior for protocols that they understand.
+                                                This field follows standard Kubernetes label syntax.
+                                                Valid values are either:
+
+                                                * Un-prefixed protocol names - reserved for IANA standard service names (as per
+                                                RFC-6335 and https://www.iana.org/assignments/service-names).
+
+                                                * Kubernetes-defined prefixed names:
+                                                  * 'kubernetes.io/h2c' - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
+                                                  * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
+                                                  * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
+
+                                                * Other protocols should use implementation-defined prefixed names such as
+                                                mycompany.com/my-custom-protocol.
+                                              type: string
+                                            name:
+                                              description: |-
+                                                The name of this port within the service. This must be a DNS_LABEL.
+                                                All ports within a ServiceSpec must have unique names. When considering
+                                                the endpoints for a Service, this must match the 'name' field in the
+                                                EndpointPort.
+                                                Optional if only one ServicePort is defined on this service.
+                                              type: string
+                                            nodePort:
+                                              description: |-
+                                                The port on each node on which this service is exposed when type is
+                                                NodePort or LoadBalancer.  Usually assigned by the system. If a value is
+                                                specified, in-range, and not in use it will be used, otherwise the
+                                                operation will fail.  If not specified, a port will be allocated if this
+                                                Service requires one.  If this field is specified when creating a
+                                                Service which does not need it, creation will fail. This field will be
+                                                wiped when updating a Service to no longer need it (e.g. changing type
+                                                from NodePort to ClusterIP).
+                                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+                                              format: int32
+                                              type: integer
+                                            port:
+                                              description:
+                                                The port that will be exposed by
+                                                this service.
+                                              format: int32
+                                              type: integer
+                                            protocol:
+                                              default: TCP
+                                              description: |-
+                                                The IP protocol for this port. Supports "TCP", "UDP", and "SCTP".
+                                                Default is TCP.
+                                              type: string
+                                            targetPort:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              description: |-
+                                                Number or name of the port to access on the pods targeted by the service.
+                                                Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                                If this is a string, it will be looked up as a named port in the
+                                                target Pod's container ports. If this is not specified, the value
+                                                of the 'port' field is used (an identity map).
+                                                This field is ignored for services with clusterIP=None, and should be
+                                                omitted or set equal to the 'port' field.
+                                                More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                            - port
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - port
+                                          - protocol
+                                        x-kubernetes-list-type: map
+                                      publishNotReadyAddresses:
+                                        description: |-
+                                          publishNotReadyAddresses indicates that any agent which deals with endpoints for this
+                                          Service should disregard any indications of ready/not-ready.
+                                          The primary use case for setting this field is for a StatefulSet's Headless Service to
+                                          propagate SRV DNS records for its Pods for the purpose of peer discovery.
+                                          The Kubernetes controllers that generate Endpoints and EndpointSlice resources for
+                                          Services interpret this to mean that all endpoints are considered "ready" even if the
+                                          Pods themselves are not. Agents which consume only Kubernetes generated endpoints
+                                          through the Endpoints or EndpointSlice resources can safely assume this behavior.
+                                        type: boolean
+                                      selector:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          Route service traffic to pods with label keys and values matching this
+                                          selector. If empty or not present, the service is assumed to have an
+                                          external process managing its endpoints, which Kubernetes will not
+                                          modify. Only applies to types ClusterIP, NodePort, and LoadBalancer.
+                                          Ignored if type is ExternalName.
+                                          More info: https://kubernetes.io/docs/concepts/services-networking/service/
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      sessionAffinity:
+                                        description: |-
+                                          Supports "ClientIP" and "None". Used to maintain session affinity.
+                                          Enable client IP based session affinity.
+                                          Must be ClientIP or None.
+                                          Defaults to None.
+                                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+                                        type: string
+                                      sessionAffinityConfig:
+                                        description:
+                                          sessionAffinityConfig contains the
+                                          configurations of session affinity.
+                                        properties:
+                                          clientIP:
+                                            description:
+                                              clientIP contains the
+                                              configurations of Client IP based
+                                              session affinity.
+                                            properties:
+                                              timeoutSeconds:
+                                                description: |-
+                                                  timeoutSeconds specifies the seconds of ClientIP type session sticky time.
+                                                  The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP".
+                                                  Default value is 10800(for 3 hours).
+                                                format: int32
+                                                type: integer
+                                            type: object
+                                        type: object
+                                      trafficDistribution:
+                                        description: |-
+                                          TrafficDistribution offers a way to express preferences for how traffic is
+                                          distributed to Service endpoints. Implementations can use this field as a
+                                          hint, but are not required to guarantee strict adherence. If the field is
+                                          not set, the implementation will apply its default routing strategy. If set
+                                          to "PreferClose", implementations should prioritize endpoints that are
+                                          topologically close (e.g., same zone).
+                                          This is an alpha field and requires enabling ServiceTrafficDistribution feature.
+                                        type: string
+                                      type:
+                                        description: |-
+                                          type determines how the Service is exposed. Defaults to ClusterIP. Valid
+                                          options are ExternalName, ClusterIP, NodePort, and LoadBalancer.
+                                          "ClusterIP" allocates a cluster-internal IP address for load-balancing
+                                          to endpoints. Endpoints are determined by the selector or if that is not
+                                          specified, by manual construction of an Endpoints object or
+                                          EndpointSlice objects. If clusterIP is "None", no virtual IP is
+                                          allocated and the endpoints are published as a set of endpoints rather
+                                          than a virtual IP.
+                                          "NodePort" builds on ClusterIP and allocates a port on every node which
+                                          routes to the same endpoints as the clusterIP.
+                                          "LoadBalancer" builds on NodePort and creates an external load-balancer
+                                          (if supported in the current cloud) which routes to the same endpoints
+                                          as the clusterIP.
+                                          "ExternalName" aliases this service to the specified externalName.
+                                          Several other fields do not apply to ExternalName services.
+                                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+                                        type: string
+                                    type: object
+                                type: object
+                              updateStrategy:
+                                default: patch
+                                description:
+                                  UpdateStrategy describes how the service
+                                  differences should be reconciled
+                                enum:
+                                  - patch
+                                  - replace
+                                type: string
+                            required:
+                              - selectorType
+                              - serviceTemplate
+                            type: object
+                          type: array
+                        disabledDefaultServices:
+                          description: |-
+                            DisabledDefaultServices is a list of service types that are disabled by default.
+                            Valid values are "r", and "ro", representing read, and read-only services.
+                          items:
+                            description: |-
+                              ServiceSelectorType describes a valid value for generating the service selectors.
+                              It indicates which type of service the selector applies to, such as read-write, read, or read-only
+                            enum:
+                              - rw
+                              - r
+                              - ro
+                            type: string
+                          type: array
+                      type: object
                   type: object
                 envFrom:
                   description: |-
@@ -2992,10 +3610,13 @@ spec:
                         description: The ConfigMap to select from
                         properties:
                           name:
+                            default: ''
                             description: |-
                               Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?
                             type: string
                           optional:
                             description:
@@ -3012,10 +3633,13 @@ spec:
                         description: The Secret to select from
                         properties:
                           name:
+                            default: ''
                             description: |-
                               Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
                               More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?
                             type: string
                           optional:
                             description:
@@ -3125,17 +3749,19 @@ spec:
                         postInitApplicationSQL:
                           description: |-
                             List of SQL queries to be executed as a superuser in the application
-                            database right after is created - to be used with extreme care
+                            database right after the cluster has been created - to be used with extreme care
                             (by default empty)
                           items:
                             type: string
                           type: array
                         postInitApplicationSQLRefs:
                           description: |-
-                            PostInitApplicationSQLRefs points references to ConfigMaps or Secrets which
-                            contain SQL files, the general implementation order to these references is
-                            from all Secrets to all ConfigMaps, and inside Secrets or ConfigMaps,
-                            the implementation order is same as the order of each array
+                            List of references to ConfigMaps or Secrets containing SQL files
+                            to be executed as a superuser in the application database right after
+                            the cluster has been created. The references are processed in a specific order:
+                            first, all Secrets are processed, followed by all ConfigMaps.
+                            Within each group, the processing order follows the sequence specified
+                            in their respective arrays.
                             (by default empty)
                           properties:
                             configMapRefs:
@@ -3180,20 +3806,120 @@ spec:
                           type: object
                         postInitSQL:
                           description: |-
-                            List of SQL queries to be executed as a superuser immediately
-                            after the cluster has been created - to be used with extreme care
+                            List of SQL queries to be executed as a superuser in the `postgres`
+                            database right after the cluster has been created - to be used with extreme care
                             (by default empty)
                           items:
                             type: string
                           type: array
+                        postInitSQLRefs:
+                          description: |-
+                            List of references to ConfigMaps or Secrets containing SQL files
+                            to be executed as a superuser in the `postgres` database right after
+                            the cluster has been created. The references are processed in a specific order:
+                            first, all Secrets are processed, followed by all ConfigMaps.
+                            Within each group, the processing order follows the sequence specified
+                            in their respective arrays.
+                            (by default empty)
+                          properties:
+                            configMapRefs:
+                              description:
+                                ConfigMapRefs holds a list of references to
+                                ConfigMaps
+                              items:
+                                description: |-
+                                  ConfigMapKeySelector contains enough information to let you locate
+                                  the key of a ConfigMap
+                                properties:
+                                  key:
+                                    description: The key to select
+                                    type: string
+                                  name:
+                                    description: Name of the referent.
+                                    type: string
+                                required:
+                                  - key
+                                  - name
+                                type: object
+                              type: array
+                            secretRefs:
+                              description:
+                                SecretRefs holds a list of references to Secrets
+                              items:
+                                description: |-
+                                  SecretKeySelector contains enough information to let you locate
+                                  the key of a Secret
+                                properties:
+                                  key:
+                                    description: The key to select
+                                    type: string
+                                  name:
+                                    description: Name of the referent.
+                                    type: string
+                                required:
+                                  - key
+                                  - name
+                                type: object
+                              type: array
+                          type: object
                         postInitTemplateSQL:
                           description: |-
                             List of SQL queries to be executed as a superuser in the `template1`
-                            after the cluster has been created - to be used with extreme care
+                            database right after the cluster has been created - to be used with extreme care
                             (by default empty)
                           items:
                             type: string
                           type: array
+                        postInitTemplateSQLRefs:
+                          description: |-
+                            List of references to ConfigMaps or Secrets containing SQL files
+                            to be executed as a superuser in the `template1` database right after
+                            the cluster has been created. The references are processed in a specific order:
+                            first, all Secrets are processed, followed by all ConfigMaps.
+                            Within each group, the processing order follows the sequence specified
+                            in their respective arrays.
+                            (by default empty)
+                          properties:
+                            configMapRefs:
+                              description:
+                                ConfigMapRefs holds a list of references to
+                                ConfigMaps
+                              items:
+                                description: |-
+                                  ConfigMapKeySelector contains enough information to let you locate
+                                  the key of a ConfigMap
+                                properties:
+                                  key:
+                                    description: The key to select
+                                    type: string
+                                  name:
+                                    description: Name of the referent.
+                                    type: string
+                                required:
+                                  - key
+                                  - name
+                                type: object
+                              type: array
+                            secretRefs:
+                              description:
+                                SecretRefs holds a list of references to Secrets
+                              items:
+                                description: |-
+                                  SecretKeySelector contains enough information to let you locate
+                                  the key of a Secret
+                                properties:
+                                  key:
+                                    description: The key to select
+                                    type: string
+                                  name:
+                                    description: Name of the referent.
+                                    type: string
+                                required:
+                                  - key
+                                  - name
+                                type: object
+                              type: array
+                          type: object
                         secret:
                           description: |-
                             Name of the secret containing the initial credentials for the
@@ -3471,7 +4197,6 @@ spec:
                         entry. Pod validation will reject the pod if the concatenated name
                         is not valid for a PVC (for example, too long).
 
-
                         An existing PVC with that name that is not owned by the pod
                         will *not* be used for the pod to avoid using an unrelated
                         volume by mistake. Starting the pod is then blocked until
@@ -3481,10 +4206,8 @@ spec:
                         this should not be necessary, but it may be useful when
                         manually reconstructing a broken cluster.
 
-
                         This field is read-only and no changes will be made by Kubernetes
                         to the PVC after it has been created.
-
 
                         Required, must not be nil.
                       properties:
@@ -3508,6 +4231,7 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             dataSource:
                               description: |-
                                 dataSource field can be used to specify either:
@@ -3658,11 +4382,13 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                     required:
                                       - key
                                       - operator
                                     type: object
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 matchLabels:
                                   additionalProperties:
                                     type: string
@@ -3690,8 +4416,8 @@ spec:
                                 If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                 set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                 exists.
-                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                                (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
+                                More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                               type: string
                             volumeMode:
                               description: |-
@@ -3809,6 +4535,7 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                               dataSource:
                                 description: |-
                                   dataSource field can be used to specify either:
@@ -3960,11 +4687,13 @@ spec:
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       required:
                                         - key
                                         - operator
                                       type: object
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   matchLabels:
                                     additionalProperties:
                                       type: string
@@ -3992,8 +4721,8 @@ spec:
                                   If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                   set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                   exists.
-                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                                  (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                  (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                 type: string
                               volumeMode:
                                 description: |-
@@ -4123,7 +4852,6 @@ spec:
                           RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
                           scraped samples and remote write samples.
 
-
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
@@ -4131,10 +4859,8 @@ spec:
                             description: |-
                               Action to perform based on the regex matching.
 
-
                               `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
-
 
                               Default: "Replace"
                             enum:
@@ -4165,7 +4891,6 @@ spec:
                             description: |-
                               Modulus to take of the hash of the source label values.
 
-
                               Only applicable when the action is `HashMod`.
                             format: int64
                             type: integer
@@ -4178,7 +4903,6 @@ spec:
                             description: |-
                               Replacement value against which a Replace action is performed if the
                               regular expression matches.
-
 
                               Regex capture groups are available.
                             type: string
@@ -4203,10 +4927,8 @@ spec:
                             description: |-
                               Label to which the resulting string is written in a replacement.
 
-
                               It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
                               `KeepEqual` and `DropEqual` actions.
-
 
                               Regex capture groups are available.
                             type: string
@@ -4221,7 +4943,6 @@ spec:
                           RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
                           scraped samples and remote write samples.
 
-
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
@@ -4229,10 +4950,8 @@ spec:
                             description: |-
                               Action to perform based on the regex matching.
 
-
                               `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
-
 
                               Default: "Replace"
                             enum:
@@ -4263,7 +4982,6 @@ spec:
                             description: |-
                               Modulus to take of the hash of the source label values.
 
-
                               Only applicable when the action is `HashMod`.
                             format: int64
                             type: integer
@@ -4276,7 +4994,6 @@ spec:
                             description: |-
                               Replacement value against which a Replace action is performed if the
                               regular expression matches.
-
 
                               Regex capture groups are available.
                             type: string
@@ -4301,15 +5018,25 @@ spec:
                             description: |-
                               Label to which the resulting string is written in a replacement.
 
-
                               It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
                               `KeepEqual` and `DropEqual` actions.
-
 
                               Regex capture groups are available.
                             type: string
                         type: object
                       type: array
+                    tls:
+                      description: |-
+                        Configure TLS communication for the metrics endpoint.
+                        Changing tls.enabled option will force a rollout of all instances.
+                      properties:
+                        enabled:
+                          default: false
+                          description: |-
+                            Enable TLS for the monitoring endpoint.
+                            Changing this option will force a rollout of all instances.
+                          type: boolean
+                      type: object
                   type: object
                 backup:
                   description: The configuration to be used for backups
@@ -4400,12 +5127,10 @@ spec:
                                 provide flexibility to customize the backup process further according to
                                 specific requirements or configurations.
 
-
                                 Example:
                                 In a scenario where specialized backup options are required, such as setting
                                 a specific timeout or defining custom behavior, users can use this field
                                 to specify additional command arguments.
-
 
                                 Note:
                                 It's essential to ensure that the provided arguments are valid and supported
@@ -4594,6 +5319,24 @@ spec:
                             When not defined, WAL files will be stored uncompressed and may be
                             unencrypted in the object store, according to the bucket default policy.
                           properties:
+                            archiveAdditionalCommandArgs:
+                              description: |-
+                                Additional arguments that can be appended to the 'barman-cloud-wal-archive'
+                                command-line invocation. These arguments provide flexibility to customize
+                                the WAL archive process further, according to specific requirements or configurations.
+
+                                Example:
+                                In a scenario where specialized backup options are required, such as setting
+                                a specific timeout or defining custom behavior, users can use this field
+                                to specify additional command arguments.
+
+                                Note:
+                                It's essential to ensure that the provided arguments are valid and supported
+                                by the 'barman-cloud-wal-archive' command, to avoid potential errors or unintended
+                                behavior during execution.
+                              items:
+                                type: string
+                              type: array
                             compression:
                               description: |-
                                 Compress a WAL file before sending it to the object store. Available
@@ -4623,6 +5366,24 @@ spec:
                                 value - with 1 being the minimum accepted value.
                               minimum: 1
                               type: integer
+                            restoreAdditionalCommandArgs:
+                              description: |-
+                                Additional arguments that can be appended to the 'barman-cloud-wal-restore'
+                                command-line invocation. These arguments provide flexibility to customize
+                                the WAL restore process further, according to specific requirements or configurations.
+
+                                Example:
+                                In a scenario where specialized backup options are required, such as setting
+                                a specific timeout or defining custom behavior, users can use this field
+                                to specify additional command arguments.
+
+                                Note:
+                                It's essential to ensure that the provided arguments are valid and supported
+                                by the 'barman-cloud-wal-restore' command, to avoid potential errors or unintended
+                                behavior during execution.
+                              items:
+                                type: string
+                              type: array
                           type: object
                       required:
                         - destinationPath
@@ -4747,24 +5508,23 @@ spec:
                       format: int32
                       type: integer
                     sources:
-                      description: sources is the list of volume projections
+                      description: |-
+                        sources is the list of volume projections. Each entry in this list
+                        handles one source.
                       items:
-                        description:
-                          Projection that may be projected along with other
-                          supported volume types
+                        description: |-
+                          Projection that may be projected along with other supported volume types.
+                          Exactly one of these fields must be set.
                         properties:
                           clusterTrustBundle:
                             description: |-
                               ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
                               of ClusterTrustBundle objects in an auto-updating file.
 
-
                               Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
 
                               ClusterTrustBundle objects can either be selected by name, or by the
                               combination of signer name and a label selector.
-
 
                               Kubelet performs aggressive normalization of the PEM contents written
                               into the pod filesystem.  Esoteric PEM features such as inter-block
@@ -4808,11 +5568,13 @@ spec:
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       required:
                                         - key
                                         - operator
                                       type: object
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   matchLabels:
                                     additionalProperties:
                                       type: string
@@ -4893,11 +5655,15 @@ spec:
                                     - path
                                   type: object
                                 type: array
+                                x-kubernetes-list-type: atomic
                               name:
+                                default: ''
                                 description: |-
                                   Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                 type: string
                               optional:
                                 description:
@@ -4922,8 +5688,8 @@ spec:
                                     fieldRef:
                                       description:
                                         'Required: Selects a field of the pod:
-                                        only annotations, labels, name and
-                                        namespace are supported.'
+                                        only annotations, labels, name,
+                                        namespace and uid are supported.'
                                       properties:
                                         apiVersion:
                                           description:
@@ -4990,6 +5756,7 @@ spec:
                                     - path
                                   type: object
                                 type: array
+                                x-kubernetes-list-type: atomic
                             type: object
                           secret:
                             description:
@@ -5034,11 +5801,15 @@ spec:
                                     - path
                                   type: object
                                 type: array
+                                x-kubernetes-list-type: atomic
                               name:
+                                default: ''
                                 description: |-
                                   Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                 type: string
                               optional:
                                 description:
@@ -5079,6 +5850,7 @@ spec:
                             type: object
                         type: object
                       type: array
+                      x-kubernetes-list-type: atomic
                   type: object
               required:
                 - instances
@@ -5108,6 +5880,11 @@ spec:
                           type: array
                       type: object
                   type: object
+                lastPromotionToken:
+                  description: |-
+                    LastPromotionToken is the last verified promotion token that
+                    was used to promote a replica cluster
+                  type: string
                 availableArchitectures:
                   description:
                     AvailableArchitectures reports the available architectures
@@ -5189,24 +5966,9 @@ spec:
                 conditions:
                   description: Conditions for cluster object
                   items:
-                    description: |-
-                      Condition contains details for one aspect of the current state of this API Resource.
-                      ---
-                      This struct is intended for direct use as an array at the field path .status.conditions.  For example,
-
-
-                      	type FooStatus struct{
-                      	    // Represents the observations of a foo's current state.
-                      	    // Known .status.conditions.type are: "Available", "Progressing", and "Degraded"
-                      	    // +patchMergeKey=type
-                      	    // +patchStrategy=merge
-                      	    // +listType=map
-                      	    // +listMapKey=type
-                      	    Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
-
-
-                      	    // other fields
-                      	}
+                    description:
+                      Condition contains details for one aspect of the current
+                      state of this API Resource.
                     properties:
                       lastTransitionTime:
                         description: |-
@@ -5248,12 +6010,9 @@ spec:
                           - Unknown
                         type: string
                       type:
-                        description: |-
-                          type of condition in CamelCase or in foo.example.com/CamelCase.
-                          ---
-                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                          useful (see .node.status.conditions), the ability to deconflict is important.
-                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        description:
+                          type of condition in CamelCase or in
+                          foo.example.com/CamelCase.
                         maxLength: 316
                         pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                         type: string
@@ -5419,6 +6178,11 @@ spec:
                         items:
                           type: string
                         type: array
+                      status:
+                        description:
+                          Status contain the status reported by the plugin
+                          through the SetStatusInCluster interface
+                        type: string
                       version:
                         description: |-
                           Version is the version of the plugin loaded by the
@@ -5667,6 +6431,13 @@ spec:
                         switching a cluster to a replica cluster.
                       type: boolean
                   type: object
+                demotionToken:
+                  description: |-
+                    DemotionToken is a JSON token containing the information
+                    from pg_controldata such as Database system identifier, Latest checkpoint's
+                    TimeLineID, Latest checkpoint's REDO location, Latest checkpoint's REDO
+                    WAL file, and Time of latest checkpoint
+                  type: string
                 currentPrimary:
                   description: Current primary instance
                   type: string

--- a/platform_umbrella/apps/common_core/priv/manifests/cloudnative_pg/poolers_postgresql_cnpg_io.yaml
+++ b/platform_umbrella/apps/common_core/priv/manifests/cloudnative_pg/poolers_postgresql_cnpg_io.yaml
@@ -69,9 +69,6 @@ spec:
                       description: |-
                         Rolling update config params. Present only if DeploymentStrategyType =
                         RollingUpdate.
-                        ---
-                        TODO: Update this to follow our convention for oneOf, whatever we decide it
-                        to be.
                       properties:
                         maxSurge:
                           anyOf:
@@ -136,7 +133,6 @@ spec:
                           RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
                           scraped samples and remote write samples.
 
-
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
@@ -144,10 +140,8 @@ spec:
                             description: |-
                               Action to perform based on the regex matching.
 
-
                               `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
-
 
                               Default: "Replace"
                             enum:
@@ -178,7 +172,6 @@ spec:
                             description: |-
                               Modulus to take of the hash of the source label values.
 
-
                               Only applicable when the action is `HashMod`.
                             format: int64
                             type: integer
@@ -191,7 +184,6 @@ spec:
                             description: |-
                               Replacement value against which a Replace action is performed if the
                               regular expression matches.
-
 
                               Regex capture groups are available.
                             type: string
@@ -216,10 +208,8 @@ spec:
                             description: |-
                               Label to which the resulting string is written in a replacement.
 
-
                               It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
                               `KeepEqual` and `DropEqual` actions.
-
 
                               Regex capture groups are available.
                             type: string
@@ -234,7 +224,6 @@ spec:
                           RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
                           scraped samples and remote write samples.
 
-
                           More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
                         properties:
                           action:
@@ -242,10 +231,8 @@ spec:
                             description: |-
                               Action to perform based on the regex matching.
 
-
                               `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
                               `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
-
 
                               Default: "Replace"
                             enum:
@@ -276,7 +263,6 @@ spec:
                             description: |-
                               Modulus to take of the hash of the source label values.
 
-
                               Only applicable when the action is `HashMod`.
                             format: int64
                             type: integer
@@ -289,7 +275,6 @@ spec:
                             description: |-
                               Replacement value against which a Replace action is performed if the
                               regular expression matches.
-
 
                               Regex capture groups are available.
                             type: string
@@ -314,10 +299,8 @@ spec:
                             description: |-
                               Label to which the resulting string is written in a replacement.
 
-
                               It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
                               `KeepEqual` and `DropEqual` actions.
-
 
                               Regex capture groups are available.
                             type: string
@@ -403,6 +386,11 @@ spec:
                             and services.
                             More info: http://kubernetes.io/docs/user-guide/labels
                           type: object
+                        name:
+                          description:
+                            The name of the resource. Only supported for certain
+                            types
+                          type: string
                       type: object
                     spec:
                       description: |-
@@ -458,7 +446,6 @@ spec:
                             clients must ensure that clusterIPs[0] and clusterIP have the same
                             value.
 
-
                             This field may hold a maximum of two entries (dual-stack IPs, in either order).
                             These IPs must correspond to the values of the ipFamilies field. Both
                             clusterIPs and ipFamilies are governed by the ipFamilyPolicy field.
@@ -477,6 +464,7 @@ spec:
                           items:
                             type: string
                           type: array
+                          x-kubernetes-list-type: atomic
                         externalName:
                           description: |-
                             externalName is the external reference that discovery mechanisms will
@@ -537,7 +525,6 @@ spec:
                             NodePort, and LoadBalancer, and does apply to "headless" services.
                             This field will be wiped when updating a Service to type ExternalName.
 
-
                             This field may hold a maximum of two entries (dual-stack families, in
                             either order).  These families must correspond to the values of the
                             clusterIPs field, if specified. Both clusterIPs and ipFamilies are
@@ -592,6 +579,7 @@ spec:
                           items:
                             type: string
                           type: array
+                          x-kubernetes-list-type: atomic
                         ports:
                           description: |-
                             The list of ports that are exposed by this service.
@@ -608,16 +596,13 @@ spec:
                                   This field follows standard Kubernetes label syntax.
                                   Valid values are either:
 
-
                                   * Un-prefixed protocol names - reserved for IANA standard service names (as per
                                   RFC-6335 and https://www.iana.org/assignments/service-names).
-
 
                                   * Kubernetes-defined prefixed names:
                                     * 'kubernetes.io/h2c' - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
                                     * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
                                     * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
-
 
                                   * Other protocols should use implementation-defined prefixed names such as
                                   mycompany.com/my-custom-protocol.
@@ -726,6 +711,16 @@ spec:
                                   type: integer
                               type: object
                           type: object
+                        trafficDistribution:
+                          description: |-
+                            TrafficDistribution offers a way to express preferences for how traffic is
+                            distributed to Service endpoints. Implementations can use this field as a
+                            hint, but are not required to guarantee strict adherence. If the field is
+                            not set, the implementation will apply its default routing strategy. If set
+                            to "PreferClose", implementations should prioritize endpoints that are
+                            topologically close (e.g., same zone).
+                            This is an alpha field and requires enabling ServiceTrafficDistribution feature.
+                          type: string
                         type:
                           description: |-
                             type determines how the Service is exposed. Defaults to ClusterIP. Valid
@@ -773,6 +768,11 @@ spec:
                             and services.
                             More info: http://kubernetes.io/docs/user-guide/labels
                           type: object
+                        name:
+                          description:
+                            The name of the resource. Only supported for certain
+                            types
+                          type: string
                       type: object
                     spec:
                       description: |-
@@ -789,9 +789,11 @@ spec:
                           type: boolean
                         nodeName:
                           description: |-
-                            NodeName is a request to schedule this pod onto a specific node. If it is non-empty,
-                            the scheduler simply schedules this pod onto that node, assuming that it fits resource
-                            requirements.
+                            NodeName indicates in which node this pod is scheduled.
+                            If empty, this pod is a candidate for scheduling by the scheduler defined in schedulerName.
+                            Once this field is set, the kubelet for this node becomes responsible for the lifecycle of this pod.
+                            This field should not be used to express a desire for the pod to be scheduled on a specific node.
+                            https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodename
                           type: string
                         serviceAccountName:
                           description: |-
@@ -843,11 +845,13 @@ spec:
                                           items:
                                             type: string
                                           type: array
+                                          x-kubernetes-list-type: atomic
                                       required:
                                         - key
                                         - operator
                                       type: object
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   matchLabels:
                                     additionalProperties:
                                       type: string
@@ -868,7 +872,6 @@ spec:
                                   MatchLabelKeys cannot be set when LabelSelector isn't set.
                                   Keys that don't exist in the incoming pod labels will
                                   be ignored. A null or empty list means only match against labelSelector.
-
 
                                   This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
                                 items:
@@ -909,7 +912,6 @@ spec:
                                   Valid values are integers greater than 0.
                                   When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
 
-
                                   For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
                                   labelSelector spread as 2/2/2:
                                   | zone1 | zone2 | zone3 |
@@ -918,9 +920,6 @@ spec:
                                   In this situation, new pod with the same labelSelector cannot be scheduled,
                                   because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
                                   it will violate MaxSkew.
-
-
-                                  This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).
                                 format: int32
                                 type: integer
                               nodeAffinityPolicy:
@@ -929,7 +928,6 @@ spec:
                                   when calculating pod topology spread skew. Options are:
                                   - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
                                   - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
-
 
                                   If this value is nil, the behavior is equivalent to the Honor policy.
                                   This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
@@ -941,7 +939,6 @@ spec:
                                   - Honor: nodes without taints, along with tainted nodes for which the incoming pod
                                   has a toleration, are included.
                                   - Ignore: node taints are ignored. All nodes are included.
-
 
                                   If this value is nil, the behavior is equivalent to the Ignore policy.
                                   This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
@@ -1017,6 +1014,7 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                             options:
                               description: |-
                                 A list of DNS resolver options.
@@ -1035,6 +1033,7 @@ spec:
                                     type: string
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                             searches:
                               description: |-
                                 A list of DNS search domains for host-name lookup.
@@ -1043,6 +1042,7 @@ spec:
                               items:
                                 type: string
                               type: array
+                              x-kubernetes-list-type: atomic
                           type: object
                         nodeSelector:
                           additionalProperties:
@@ -1087,7 +1087,6 @@ spec:
                                       Tip: Ensure that the filesystem type is supported by the host operating system.
                                       Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                       More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                      TODO: how do we prevent errors in the filesystem from compromising the machine
                                     type: string
                                   partition:
                                     description: |-
@@ -1131,6 +1130,7 @@ spec:
                                       blob storage
                                     type: string
                                   fsType:
+                                    default: ext4
                                     description: |-
                                       fsType is Filesystem type to mount.
                                       Must be a filesystem type supported by the host operating system.
@@ -1146,6 +1146,7 @@ spec:
                                       defaults to shared'
                                     type: string
                                   readOnly:
+                                    default: false
                                     description: |-
                                       readOnly Defaults to false (read/write). ReadOnly here will force
                                       the ReadOnly setting in VolumeMounts.
@@ -1190,6 +1191,7 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   path:
                                     description:
                                       'path is Optional: Used as the mounted
@@ -1213,10 +1215,13 @@ spec:
                                       More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                     properties:
                                       name:
+                                        default: ''
                                         description: |-
                                           Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -1252,10 +1257,13 @@ spec:
                                       to OpenStack.
                                     properties:
                                       name:
+                                        default: ''
                                         description: |-
                                           Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -1323,11 +1331,15 @@ spec:
                                         - path
                                       type: object
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   name:
+                                    default: ''
                                     description: |-
                                       Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
                                       More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                   optional:
                                     description:
@@ -1362,10 +1374,13 @@ spec:
                                       secret object contains more than one secret, all secret references are passed.
                                     properties:
                                       name:
+                                        default: ''
                                         description: |-
                                           Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -1414,8 +1429,8 @@ spec:
                                         fieldRef:
                                           description:
                                             'Required: Selects a field of the
-                                            pod: only annotations, labels, name
-                                            and namespace are supported.'
+                                            pod: only annotations, labels, name,
+                                            namespace and uid are supported.'
                                           properties:
                                             apiVersion:
                                               description:
@@ -1483,6 +1498,7 @@ spec:
                                         - path
                                       type: object
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                 type: object
                               emptyDir:
                                 description: |-
@@ -1516,7 +1532,6 @@ spec:
                                   The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
                                   and deleted when the pod is removed.
 
-
                                   Use this if:
                                   a) the volume is only needed while the pod runs,
                                   b) features of normal volumes like restoring from snapshot or capacity
@@ -1527,16 +1542,13 @@ spec:
                                      information on the connection between this volume type
                                      and PersistentVolumeClaim).
 
-
                                   Use PersistentVolumeClaim or one of the vendor-specific
                                   APIs for volumes that persist for longer than the lifecycle
                                   of an individual pod.
 
-
                                   Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
                                   be used that way - see the documentation of the driver for
                                   more information.
-
 
                                   A pod can use both types of ephemeral volumes and
                                   persistent volumes at the same time.
@@ -1551,7 +1563,6 @@ spec:
                                       entry. Pod validation will reject the pod if the concatenated name
                                       is not valid for a PVC (for example, too long).
 
-
                                       An existing PVC with that name that is not owned by the pod
                                       will *not* be used for the pod to avoid using an unrelated
                                       volume by mistake. Starting the pod is then blocked until
@@ -1561,10 +1572,8 @@ spec:
                                       this should not be necessary, but it may be useful when
                                       manually reconstructing a broken cluster.
 
-
                                       This field is read-only and no changes will be made by Kubernetes
                                       to the PVC after it has been created.
-
 
                                       Required, must not be nil.
                                     properties:
@@ -1588,6 +1597,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           dataSource:
                                             description: |-
                                               dataSource field can be used to specify either:
@@ -1740,11 +1750,13 @@ spec:
                                                       items:
                                                         type: string
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                     - key
                                                     - operator
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
@@ -1772,8 +1784,8 @@ spec:
                                               If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
                                               set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
                                               exists.
-                                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                                              (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
+                                              More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                              (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
                                             type: string
                                           volumeMode:
                                             description: |-
@@ -1802,7 +1814,6 @@ spec:
                                       fsType is the filesystem type to mount.
                                       Must be a filesystem type supported by the host operating system.
                                       Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                                      TODO: how do we prevent errors in the filesystem from compromising the machine
                                     type: string
                                   lun:
                                     description:
@@ -1821,6 +1832,7 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   wwids:
                                     description: |-
                                       wwids Optional: FC volume world wide identifiers (wwids)
@@ -1828,6 +1840,7 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                 type: object
                               flexVolume:
                                 description: |-
@@ -1866,10 +1879,13 @@ spec:
                                       scripts.
                                     properties:
                                       name:
+                                        default: ''
                                         description: |-
                                           Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -1906,7 +1922,6 @@ spec:
                                       Tip: Ensure that the filesystem type is supported by the host operating system.
                                       Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                       More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                      TODO: how do we prevent errors in the filesystem from compromising the machine
                                     type: string
                                   partition:
                                     description: |-
@@ -1988,9 +2003,6 @@ spec:
                                   used for system agents or other privileged things that are allowed
                                   to see the host machine. Most containers will NOT need this.
                                   More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                  ---
-                                  TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
-                                  mount host directories as read/write.
                                 properties:
                                   path:
                                     description: |-
@@ -2006,6 +2018,41 @@ spec:
                                     type: string
                                 required:
                                   - path
+                                type: object
+                              image:
+                                description: |-
+                                  image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.
+                                  The volume is resolved at pod startup depending on which PullPolicy value is provided:
+
+                                  - Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                  - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                  - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+
+                                  The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.
+                                  A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
+                                  The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
+                                  The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
+                                  The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                  Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).
+                                  The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
+                                properties:
+                                  pullPolicy:
+                                    description: |-
+                                      Policy for pulling OCI objects. Possible values are:
+                                      Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                      Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                      IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                      Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                    type: string
+                                  reference:
+                                    description: |-
+                                      Required: Image or artifact reference to be used.
+                                      Behaves in the same way as pod.spec.containers[*].image.
+                                      Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images
+                                      This field is optional to allow higher level config management to default or override
+                                      container images in workload controllers like Deployments and StatefulSets.
+                                    type: string
                                 type: object
                               iscsi:
                                 description: |-
@@ -2029,7 +2076,6 @@ spec:
                                       Tip: Ensure that the filesystem type is supported by the host operating system.
                                       Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                       More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                      TODO: how do we prevent errors in the filesystem from compromising the machine
                                     type: string
                                   initiatorName:
                                     description: |-
@@ -2042,6 +2088,7 @@ spec:
                                       iqn is the target iSCSI Qualified Name.
                                     type: string
                                   iscsiInterface:
+                                    default: default
                                     description: |-
                                       iscsiInterface is the interface Name that uses an iSCSI transport.
                                       Defaults to 'default' (tcp).
@@ -2058,6 +2105,7 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   readOnly:
                                     description: |-
                                       readOnly here will force the ReadOnly setting in VolumeMounts.
@@ -2069,10 +2117,13 @@ spec:
                                       target and initiator authentication
                                     properties:
                                       name:
+                                        default: ''
                                         description: |-
                                           Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -2196,25 +2247,23 @@ spec:
                                     format: int32
                                     type: integer
                                   sources:
-                                    description:
-                                      sources is the list of volume projections
+                                    description: |-
+                                      sources is the list of volume projections. Each entry in this list
+                                      handles one source.
                                     items:
-                                      description:
-                                        Projection that may be projected along
-                                        with other supported volume types
+                                      description: |-
+                                        Projection that may be projected along with other supported volume types.
+                                        Exactly one of these fields must be set.
                                       properties:
                                         clusterTrustBundle:
                                           description: |-
                                             ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
                                             of ClusterTrustBundle objects in an auto-updating file.
 
-
                                             Alpha, gated by the ClusterTrustBundleProjection feature gate.
-
 
                                             ClusterTrustBundle objects can either be selected by name, or by the
                                             combination of signer name and a label selector.
-
 
                                             Kubelet performs aggressive normalization of the PEM contents written
                                             into the pod filesystem.  Esoteric PEM features such as inter-block
@@ -2260,11 +2309,13 @@ spec:
                                                         items:
                                                           type: string
                                                         type: array
+                                                        x-kubernetes-list-type: atomic
                                                     required:
                                                       - key
                                                       - operator
                                                     type: object
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                                 matchLabels:
                                                   additionalProperties:
                                                     type: string
@@ -2347,11 +2398,15 @@ spec:
                                                   - path
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             name:
+                                              default: ''
                                               description: |-
                                                 Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description:
@@ -2381,8 +2436,8 @@ spec:
                                                     description:
                                                       'Required: Selects a field
                                                       of the pod: only
-                                                      annotations, labels, name
-                                                      and namespace are
+                                                      annotations, labels, name,
+                                                      namespace and uid are
                                                       supported.'
                                                     properties:
                                                       apiVersion:
@@ -2458,6 +2513,7 @@ spec:
                                                   - path
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                           type: object
                                         secret:
                                           description:
@@ -2504,11 +2560,15 @@ spec:
                                                   - path
                                                 type: object
                                               type: array
+                                              x-kubernetes-list-type: atomic
                                             name:
+                                              default: ''
                                               description: |-
                                                 Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description:
@@ -2551,6 +2611,7 @@ spec:
                                           type: object
                                       type: object
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                 type: object
                               quobyte:
                                 description:
@@ -2603,7 +2664,6 @@ spec:
                                       Tip: Ensure that the filesystem type is supported by the host operating system.
                                       Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                       More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                      TODO: how do we prevent errors in the filesystem from compromising the machine
                                     type: string
                                   image:
                                     description: |-
@@ -2611,6 +2671,7 @@ spec:
                                       More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                     type: string
                                   keyring:
+                                    default: /etc/ceph/keyring
                                     description: |-
                                       keyring is the path to key ring for RBDUser.
                                       Default is /etc/ceph/keyring.
@@ -2623,7 +2684,9 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   pool:
+                                    default: rbd
                                     description: |-
                                       pool is the rados pool name.
                                       Default is rbd.
@@ -2643,14 +2706,18 @@ spec:
                                       More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                     properties:
                                       name:
+                                        default: ''
                                         description: |-
                                           Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   user:
+                                    default: admin
                                     description: |-
                                       user is the rados user name.
                                       Default is admin.
@@ -2666,6 +2733,7 @@ spec:
                                   attached and mounted on Kubernetes nodes.
                                 properties:
                                   fsType:
+                                    default: xfs
                                     description: |-
                                       fsType is the filesystem type to mount.
                                       Must be a filesystem type supported by the host operating system.
@@ -2694,10 +2762,13 @@ spec:
                                       sensitive information. If this is not provided, Login operation will fail.
                                     properties:
                                       name:
+                                        default: ''
                                         description: |-
                                           Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -2707,6 +2778,7 @@ spec:
                                       communication with Gateway, default false
                                     type: boolean
                                   storageMode:
+                                    default: ThinProvisioned
                                     description: |-
                                       storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
                                       Default is ThinProvisioned.
@@ -2787,6 +2859,7 @@ spec:
                                         - path
                                       type: object
                                     type: array
+                                    x-kubernetes-list-type: atomic
                                   optional:
                                     description:
                                       optional field specify whether the Secret
@@ -2820,10 +2893,13 @@ spec:
                                       credentials.  If not specified, default values will be attempted.
                                     properties:
                                       name:
+                                        default: ''
                                         description: |-
                                           Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
                                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -2876,6 +2952,9 @@ spec:
                               - name
                             type: object
                           type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
                         imagePullSecrets:
                           description: |-
                             ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
@@ -2887,18 +2966,24 @@ spec:
                               referenced object inside the same namespace.
                             properties:
                               name:
+                                default: ''
                                 description: |-
                                   Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
                                   More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
                           type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
                         hostAliases:
                           description: |-
                             HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts
-                            file if specified. This is only valid for non-hostNetwork pods.
+                            file if specified.
                           items:
                             description: |-
                               HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
@@ -2909,11 +2994,17 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                               ip:
                                 description: IP address of the host file entry.
                                 type: string
+                            required:
+                              - ip
                             type: object
                           type: array
+                          x-kubernetes-list-map-keys:
+                            - ip
+                          x-kubernetes-list-type: map
                         hostPID:
                           description: |-
                             Use the host's pid namespace.
@@ -2943,6 +3034,7 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                               command:
                                 description: |-
                                   Entrypoint array. Not executed within a shell.
@@ -2956,6 +3048,7 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                               env:
                                 description: |-
                                   List of environment variables to set in the container.
@@ -2996,10 +3089,13 @@ spec:
                                               description: The key to select.
                                               type: string
                                             name:
+                                              default: ''
                                               description: |-
                                                 Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description:
@@ -3070,10 +3166,13 @@ spec:
                                                 key.
                                               type: string
                                             name:
+                                              default: ''
                                               description: |-
                                                 Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description:
@@ -3089,6 +3188,9 @@ spec:
                                     - name
                                   type: object
                                 type: array
+                                x-kubernetes-list-map-keys:
+                                  - name
+                                x-kubernetes-list-type: map
                               envFrom:
                                 description: |-
                                   List of sources to populate environment variables in the container.
@@ -3106,10 +3208,13 @@ spec:
                                       description: The ConfigMap to select from
                                       properties:
                                         name:
+                                          default: ''
                                           description: |-
                                             Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
                                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                           type: string
                                         optional:
                                           description:
@@ -3128,10 +3233,13 @@ spec:
                                       description: The Secret to select from
                                       properties:
                                         name:
+                                          default: ''
                                           description: |-
                                             Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
                                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                           type: string
                                         optional:
                                           description:
@@ -3142,6 +3250,7 @@ spec:
                                       x-kubernetes-map-type: atomic
                                   type: object
                                 type: array
+                                x-kubernetes-list-type: atomic
                               image:
                                 description: |-
                                   Container image name.
@@ -3183,6 +3292,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       httpGet:
                                         description:
@@ -3218,6 +3328,7 @@ spec:
                                                 - value
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           path:
                                             description:
                                               Path to access on the HTTP server.
@@ -3304,6 +3415,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       httpGet:
                                         description:
@@ -3339,6 +3451,7 @@ spec:
                                                 - value
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           path:
                                             description:
                                               Path to access on the HTTP server.
@@ -3421,6 +3534,7 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                     type: object
                                   failureThreshold:
                                     description: |-
@@ -3441,10 +3555,10 @@ spec:
                                         format: int32
                                         type: integer
                                       service:
+                                        default: ''
                                         description: |-
                                           Service is the name of the service to place in the gRPC HealthCheckRequest
                                           (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
 
                                           If this is not specified, the default behavior is defined by gRPC.
                                         type: string
@@ -3484,6 +3598,7 @@ spec:
                                             - value
                                           type: object
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       path:
                                         description:
                                           Path to access on the HTTP server.
@@ -3647,6 +3762,7 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                     type: object
                                   failureThreshold:
                                     description: |-
@@ -3667,10 +3783,10 @@ spec:
                                         format: int32
                                         type: integer
                                       service:
+                                        default: ''
                                         description: |-
                                           Service is the name of the service to place in the gRPC HealthCheckRequest
                                           (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
 
                                           If this is not specified, the default behavior is defined by gRPC.
                                         type: string
@@ -3710,6 +3826,7 @@ spec:
                                             - value
                                           type: object
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       path:
                                         description:
                                           Path to access on the HTTP server.
@@ -3828,10 +3945,8 @@ spec:
                                       Claims lists the names of resources, defined in spec.resourceClaims,
                                       that are used by this container.
 
-
                                       This is an alpha field and requires enabling the
                                       DynamicResourceAllocation feature gate.
-
 
                                       This field is immutable. It can only be set for containers.
                                     items:
@@ -3844,6 +3959,12 @@ spec:
                                             Name must match the name of one entry in pod.spec.resourceClaims of
                                             the Pod where this field is used. It makes that resource available
                                             inside a container.
+                                          type: string
+                                        request:
+                                          description: |-
+                                            Request is the name chosen for a request in the referenced claim.
+                                            If empty, everything from the claim is made available, otherwise
+                                            only the result of this request.
                                           type: string
                                       required:
                                         - name
@@ -3911,6 +4032,30 @@ spec:
                                       2) has CAP_SYS_ADMIN
                                       Note that this field cannot be set when spec.os.name is windows.
                                     type: boolean
+                                  appArmorProfile:
+                                    description: |-
+                                      appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                      overrides the pod's appArmorProfile.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    properties:
+                                      localhostProfile:
+                                        description: |-
+                                          localhostProfile indicates a profile loaded on the node that should be used.
+                                          The profile must be preconfigured on the node to work.
+                                          Must match the loaded name of the profile.
+                                          Must be set if and only if type is "Localhost".
+                                        type: string
+                                      type:
+                                        description: |-
+                                          type indicates which kind of AppArmor profile will be applied.
+                                          Valid options are:
+                                            Localhost - a profile pre-loaded on the node.
+                                            RuntimeDefault - the container runtime's default profile.
+                                            Unconfined - no AppArmor enforcement.
+                                        type: string
+                                    required:
+                                      - type
+                                    type: object
                                   capabilities:
                                     description: |-
                                       The capabilities to add/drop when running containers.
@@ -3925,6 +4070,7 @@ spec:
                                             capabilities type
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       drop:
                                         description: Removed capabilities
                                         items:
@@ -3933,6 +4079,7 @@ spec:
                                             capabilities type
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                     type: object
                                   privileged:
                                     description: |-
@@ -3944,7 +4091,7 @@ spec:
                                   procMount:
                                     description: |-
                                       procMount denotes the type of proc mount to use for the containers.
-                                      The default is DefaultProcMount which uses the container runtime defaults for
+                                      The default value is Default which uses the container runtime defaults for
                                       readonly paths and masked paths.
                                       This requires the ProcMountType feature flag to be enabled.
                                       Note that this field cannot be set when spec.os.name is windows.
@@ -4030,7 +4177,6 @@ spec:
                                           type indicates which kind of seccomp profile will be applied.
                                           Valid options are:
 
-
                                           Localhost - a profile defined in a file on the node should be used.
                                           RuntimeDefault - the container runtime default profile should be used.
                                           Unconfined - no profile should be applied.
@@ -4096,6 +4242,7 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                     type: object
                                   failureThreshold:
                                     description: |-
@@ -4116,10 +4263,10 @@ spec:
                                         format: int32
                                         type: integer
                                       service:
+                                        default: ''
                                         description: |-
                                           Service is the name of the service to place in the gRPC HealthCheckRequest
                                           (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
 
                                           If this is not specified, the default behavior is defined by gRPC.
                                         type: string
@@ -4159,6 +4306,7 @@ spec:
                                             - value
                                           type: object
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       path:
                                         description:
                                           Path to access on the HTTP server.
@@ -4308,6 +4456,9 @@ spec:
                                     - name
                                   type: object
                                 type: array
+                                x-kubernetes-list-map-keys:
+                                  - devicePath
+                                x-kubernetes-list-type: map
                               volumeMounts:
                                 description: |-
                                   Pod volumes to mount into the container's filesystem.
@@ -4328,6 +4479,8 @@ spec:
                                         to container and the other way around.
                                         When not set, MountPropagationNone is used.
                                         This field is beta in 1.10.
+                                        When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                        (which defaults to None).
                                       type: string
                                     name:
                                       description:
@@ -4338,6 +4491,25 @@ spec:
                                         Mounted read-only if true, read-write otherwise (false or unspecified).
                                         Defaults to false.
                                       type: boolean
+                                    recursiveReadOnly:
+                                      description: |-
+                                        RecursiveReadOnly specifies whether read-only mounts should be handled
+                                        recursively.
+
+                                        If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                        If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                        recursively read-only.  If this field is set to IfPossible, the mount is made
+                                        recursively read-only, if it is supported by the container runtime.  If this
+                                        field is set to Enabled, the mount is made recursively read-only if it is
+                                        supported by the container runtime, otherwise the pod will not be started and
+                                        an error will be generated to indicate the reason.
+
+                                        If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                        None (or be unspecified, which defaults to None).
+
+                                        If this field is not specified, it is treated as an equivalent of Disabled.
+                                      type: string
                                     subPath:
                                       description: |-
                                         Path within the volume from which the container's volume should be mounted.
@@ -4355,6 +4527,9 @@ spec:
                                     - name
                                   type: object
                                 type: array
+                                x-kubernetes-list-map-keys:
+                                  - mountPath
+                                x-kubernetes-list-type: map
                               workingDir:
                                 description: |-
                                   Container's working directory.
@@ -4366,6 +4541,9 @@ spec:
                               - name
                             type: object
                           type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
                         ephemeralContainers:
                           description: |-
                             List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing
@@ -4379,7 +4557,6 @@ spec:
                               scheduling guarantees, and they will not be restarted when they exit or when a Pod is
                               removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the
                               Pod to exceed its resource allocation.
-
 
                               To add an ephemeral container, use the ephemeralcontainers subresource of an existing
                               Pod. Ephemeral containers may not be removed or restarted.
@@ -4397,6 +4574,7 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                               command:
                                 description: |-
                                   Entrypoint array. Not executed within a shell.
@@ -4410,6 +4588,7 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                               env:
                                 description: |-
                                   List of environment variables to set in the container.
@@ -4450,10 +4629,13 @@ spec:
                                               description: The key to select.
                                               type: string
                                             name:
+                                              default: ''
                                               description: |-
                                                 Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description:
@@ -4524,10 +4706,13 @@ spec:
                                                 key.
                                               type: string
                                             name:
+                                              default: ''
                                               description: |-
                                                 Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description:
@@ -4543,6 +4728,9 @@ spec:
                                     - name
                                   type: object
                                 type: array
+                                x-kubernetes-list-map-keys:
+                                  - name
+                                x-kubernetes-list-type: map
                               envFrom:
                                 description: |-
                                   List of sources to populate environment variables in the container.
@@ -4560,10 +4748,13 @@ spec:
                                       description: The ConfigMap to select from
                                       properties:
                                         name:
+                                          default: ''
                                           description: |-
                                             Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
                                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                           type: string
                                         optional:
                                           description:
@@ -4582,10 +4773,13 @@ spec:
                                       description: The Secret to select from
                                       properties:
                                         name:
+                                          default: ''
                                           description: |-
                                             Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
                                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                           type: string
                                         optional:
                                           description:
@@ -4596,6 +4790,7 @@ spec:
                                       x-kubernetes-map-type: atomic
                                   type: object
                                 type: array
+                                x-kubernetes-list-type: atomic
                               image:
                                 description: |-
                                   Container image name.
@@ -4635,6 +4830,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       httpGet:
                                         description:
@@ -4670,6 +4866,7 @@ spec:
                                                 - value
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           path:
                                             description:
                                               Path to access on the HTTP server.
@@ -4756,6 +4953,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       httpGet:
                                         description:
@@ -4791,6 +4989,7 @@ spec:
                                                 - value
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           path:
                                             description:
                                               Path to access on the HTTP server.
@@ -4871,6 +5070,7 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                     type: object
                                   failureThreshold:
                                     description: |-
@@ -4891,10 +5091,10 @@ spec:
                                         format: int32
                                         type: integer
                                       service:
+                                        default: ''
                                         description: |-
                                           Service is the name of the service to place in the gRPC HealthCheckRequest
                                           (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
 
                                           If this is not specified, the default behavior is defined by gRPC.
                                         type: string
@@ -4934,6 +5134,7 @@ spec:
                                             - value
                                           type: object
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       path:
                                         description:
                                           Path to access on the HTTP server.
@@ -5089,6 +5290,7 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                     type: object
                                   failureThreshold:
                                     description: |-
@@ -5109,10 +5311,10 @@ spec:
                                         format: int32
                                         type: integer
                                       service:
+                                        default: ''
                                         description: |-
                                           Service is the name of the service to place in the gRPC HealthCheckRequest
                                           (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
 
                                           If this is not specified, the default behavior is defined by gRPC.
                                         type: string
@@ -5152,6 +5354,7 @@ spec:
                                             - value
                                           type: object
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       path:
                                         description:
                                           Path to access on the HTTP server.
@@ -5269,10 +5472,8 @@ spec:
                                       Claims lists the names of resources, defined in spec.resourceClaims,
                                       that are used by this container.
 
-
                                       This is an alpha field and requires enabling the
                                       DynamicResourceAllocation feature gate.
-
 
                                       This field is immutable. It can only be set for containers.
                                     items:
@@ -5285,6 +5486,12 @@ spec:
                                             Name must match the name of one entry in pod.spec.resourceClaims of
                                             the Pod where this field is used. It makes that resource available
                                             inside a container.
+                                          type: string
+                                        request:
+                                          description: |-
+                                            Request is the name chosen for a request in the referenced claim.
+                                            If empty, everything from the claim is made available, otherwise
+                                            only the result of this request.
                                           type: string
                                       required:
                                         - name
@@ -5340,6 +5547,30 @@ spec:
                                       2) has CAP_SYS_ADMIN
                                       Note that this field cannot be set when spec.os.name is windows.
                                     type: boolean
+                                  appArmorProfile:
+                                    description: |-
+                                      appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                      overrides the pod's appArmorProfile.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    properties:
+                                      localhostProfile:
+                                        description: |-
+                                          localhostProfile indicates a profile loaded on the node that should be used.
+                                          The profile must be preconfigured on the node to work.
+                                          Must match the loaded name of the profile.
+                                          Must be set if and only if type is "Localhost".
+                                        type: string
+                                      type:
+                                        description: |-
+                                          type indicates which kind of AppArmor profile will be applied.
+                                          Valid options are:
+                                            Localhost - a profile pre-loaded on the node.
+                                            RuntimeDefault - the container runtime's default profile.
+                                            Unconfined - no AppArmor enforcement.
+                                        type: string
+                                    required:
+                                      - type
+                                    type: object
                                   capabilities:
                                     description: |-
                                       The capabilities to add/drop when running containers.
@@ -5354,6 +5585,7 @@ spec:
                                             capabilities type
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       drop:
                                         description: Removed capabilities
                                         items:
@@ -5362,6 +5594,7 @@ spec:
                                             capabilities type
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                     type: object
                                   privileged:
                                     description: |-
@@ -5373,7 +5606,7 @@ spec:
                                   procMount:
                                     description: |-
                                       procMount denotes the type of proc mount to use for the containers.
-                                      The default is DefaultProcMount which uses the container runtime defaults for
+                                      The default value is Default which uses the container runtime defaults for
                                       readonly paths and masked paths.
                                       This requires the ProcMountType feature flag to be enabled.
                                       Note that this field cannot be set when spec.os.name is windows.
@@ -5459,7 +5692,6 @@ spec:
                                           type indicates which kind of seccomp profile will be applied.
                                           Valid options are:
 
-
                                           Localhost - a profile defined in a file on the node should be used.
                                           RuntimeDefault - the container runtime default profile should be used.
                                           Unconfined - no profile should be applied.
@@ -5520,6 +5752,7 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                     type: object
                                   failureThreshold:
                                     description: |-
@@ -5540,10 +5773,10 @@ spec:
                                         format: int32
                                         type: integer
                                       service:
+                                        default: ''
                                         description: |-
                                           Service is the name of the service to place in the gRPC HealthCheckRequest
                                           (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
 
                                           If this is not specified, the default behavior is defined by gRPC.
                                         type: string
@@ -5583,6 +5816,7 @@ spec:
                                             - value
                                           type: object
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       path:
                                         description:
                                           Path to access on the HTTP server.
@@ -5688,7 +5922,6 @@ spec:
                                   The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container.
                                   If not set then the ephemeral container uses the namespaces configured in the Pod spec.
 
-
                                   The container runtime must implement support for this feature. If the runtime does not
                                   support namespace targeting then the result of setting this field is undefined.
                                 type: string
@@ -5742,6 +5975,9 @@ spec:
                                     - name
                                   type: object
                                 type: array
+                                x-kubernetes-list-map-keys:
+                                  - devicePath
+                                x-kubernetes-list-type: map
                               volumeMounts:
                                 description: |-
                                   Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers.
@@ -5762,6 +5998,8 @@ spec:
                                         to container and the other way around.
                                         When not set, MountPropagationNone is used.
                                         This field is beta in 1.10.
+                                        When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                        (which defaults to None).
                                       type: string
                                     name:
                                       description:
@@ -5772,6 +6010,25 @@ spec:
                                         Mounted read-only if true, read-write otherwise (false or unspecified).
                                         Defaults to false.
                                       type: boolean
+                                    recursiveReadOnly:
+                                      description: |-
+                                        RecursiveReadOnly specifies whether read-only mounts should be handled
+                                        recursively.
+
+                                        If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                        If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                        recursively read-only.  If this field is set to IfPossible, the mount is made
+                                        recursively read-only, if it is supported by the container runtime.  If this
+                                        field is set to Enabled, the mount is made recursively read-only if it is
+                                        supported by the container runtime, otherwise the pod will not be started and
+                                        an error will be generated to indicate the reason.
+
+                                        If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                        None (or be unspecified, which defaults to None).
+
+                                        If this field is not specified, it is treated as an equivalent of Disabled.
+                                      type: string
                                     subPath:
                                       description: |-
                                         Path within the volume from which the container's volume should be mounted.
@@ -5789,6 +6046,9 @@ spec:
                                     - name
                                   type: object
                                 type: array
+                                x-kubernetes-list-map-keys:
+                                  - mountPath
+                                x-kubernetes-list-type: map
                               workingDir:
                                 description: |-
                                   Container's working directory.
@@ -5800,9 +6060,12 @@ spec:
                               - name
                             type: object
                           type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
                         serviceAccount:
                           description: |-
-                            DeprecatedServiceAccount is a depreciated alias for ServiceAccountName.
+                            DeprecatedServiceAccount is a deprecated alias for ServiceAccountName.
                             Deprecated: Use serviceAccountName instead.
                           type: string
                         hostIPC:
@@ -5881,11 +6144,13 @@ spec:
                                                   items:
                                                     type: string
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                               required:
                                                 - key
                                                 - operator
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           matchFields:
                                             description:
                                               A list of node selector
@@ -5915,11 +6180,13 @@ spec:
                                                   items:
                                                     type: string
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                               required:
                                                 - key
                                                 - operator
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       weight:
@@ -5934,6 +6201,7 @@ spec:
                                       - weight
                                     type: object
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 requiredDuringSchedulingIgnoredDuringExecution:
                                   description: |-
                                     If the affinity requirements specified by this field are not met at
@@ -5981,11 +6249,13 @@ spec:
                                                   items:
                                                     type: string
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                               required:
                                                 - key
                                                 - operator
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           matchFields:
                                             description:
                                               A list of node selector
@@ -6015,14 +6285,17 @@ spec:
                                                   items:
                                                     type: string
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                               required:
                                                 - key
                                                 - operator
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       type: array
+                                      x-kubernetes-list-type: atomic
                                   required:
                                     - nodeSelectorTerms
                                   type: object
@@ -6093,11 +6366,13 @@ spec:
                                                       items:
                                                         type: string
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                     - key
                                                     - operator
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
@@ -6112,13 +6387,13 @@ spec:
                                             description: |-
                                               MatchLabelKeys is a set of pod label keys to select which pods will
                                               be taken into consideration. The keys are used to lookup values from the
-                                              incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                              incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
                                               to select the group of existing pods which pods will be taken into consideration
                                               for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
                                               pod labels will be ignored. The default value is empty.
-                                              The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                                              Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
-                                              This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                              The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                              Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                              This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                             items:
                                               type: string
                                             type: array
@@ -6127,13 +6402,13 @@ spec:
                                             description: |-
                                               MismatchLabelKeys is a set of pod label keys to select which pods will
                                               be taken into consideration. The keys are used to lookup values from the
-                                              incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                              incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
                                               to select the group of existing pods which pods will be taken into consideration
                                               for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
                                               pod labels will be ignored. The default value is empty.
-                                              The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
-                                              Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
-                                              This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                              The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                              Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                              This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                             items:
                                               type: string
                                             type: array
@@ -6176,11 +6451,13 @@ spec:
                                                       items:
                                                         type: string
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                     - key
                                                     - operator
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
@@ -6200,6 +6477,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           topologyKey:
                                             description: |-
                                               This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
@@ -6222,6 +6500,7 @@ spec:
                                       - weight
                                     type: object
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 requiredDuringSchedulingIgnoredDuringExecution:
                                   description: |-
                                     If the affinity requirements specified by this field are not met at
@@ -6274,11 +6553,13 @@ spec:
                                                   items:
                                                     type: string
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                               required:
                                                 - key
                                                 - operator
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           matchLabels:
                                             additionalProperties:
                                               type: string
@@ -6293,13 +6574,13 @@ spec:
                                         description: |-
                                           MatchLabelKeys is a set of pod label keys to select which pods will
                                           be taken into consideration. The keys are used to lookup values from the
-                                          incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
                                           to select the group of existing pods which pods will be taken into consideration
                                           for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
                                           pod labels will be ignored. The default value is empty.
-                                          The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                                          Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
-                                          This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                          The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                          Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                         items:
                                           type: string
                                         type: array
@@ -6308,13 +6589,13 @@ spec:
                                         description: |-
                                           MismatchLabelKeys is a set of pod label keys to select which pods will
                                           be taken into consideration. The keys are used to lookup values from the
-                                          incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
                                           to select the group of existing pods which pods will be taken into consideration
                                           for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
                                           pod labels will be ignored. The default value is empty.
-                                          The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
-                                          Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
-                                          This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                          The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                          Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                         items:
                                           type: string
                                         type: array
@@ -6356,11 +6637,13 @@ spec:
                                                   items:
                                                     type: string
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                               required:
                                                 - key
                                                 - operator
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           matchLabels:
                                             additionalProperties:
                                               type: string
@@ -6380,6 +6663,7 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       topologyKey:
                                         description: |-
                                           This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
@@ -6392,6 +6676,7 @@ spec:
                                       - topologyKey
                                     type: object
                                   type: array
+                                  x-kubernetes-list-type: atomic
                               type: object
                             podAntiAffinity:
                               description:
@@ -6458,11 +6743,13 @@ spec:
                                                       items:
                                                         type: string
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                     - key
                                                     - operator
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
@@ -6477,13 +6764,13 @@ spec:
                                             description: |-
                                               MatchLabelKeys is a set of pod label keys to select which pods will
                                               be taken into consideration. The keys are used to lookup values from the
-                                              incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                              incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
                                               to select the group of existing pods which pods will be taken into consideration
                                               for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
                                               pod labels will be ignored. The default value is empty.
-                                              The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                                              Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
-                                              This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                              The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                              Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                              This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                             items:
                                               type: string
                                             type: array
@@ -6492,13 +6779,13 @@ spec:
                                             description: |-
                                               MismatchLabelKeys is a set of pod label keys to select which pods will
                                               be taken into consideration. The keys are used to lookup values from the
-                                              incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                              incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
                                               to select the group of existing pods which pods will be taken into consideration
                                               for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
                                               pod labels will be ignored. The default value is empty.
-                                              The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
-                                              Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
-                                              This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                              The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                              Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                              This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                             items:
                                               type: string
                                             type: array
@@ -6541,11 +6828,13 @@ spec:
                                                       items:
                                                         type: string
                                                       type: array
+                                                      x-kubernetes-list-type: atomic
                                                   required:
                                                     - key
                                                     - operator
                                                   type: object
                                                 type: array
+                                                x-kubernetes-list-type: atomic
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
@@ -6565,6 +6854,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           topologyKey:
                                             description: |-
                                               This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
@@ -6587,6 +6877,7 @@ spec:
                                       - weight
                                     type: object
                                   type: array
+                                  x-kubernetes-list-type: atomic
                                 requiredDuringSchedulingIgnoredDuringExecution:
                                   description: |-
                                     If the anti-affinity requirements specified by this field are not met at
@@ -6639,11 +6930,13 @@ spec:
                                                   items:
                                                     type: string
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                               required:
                                                 - key
                                                 - operator
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           matchLabels:
                                             additionalProperties:
                                               type: string
@@ -6658,13 +6951,13 @@ spec:
                                         description: |-
                                           MatchLabelKeys is a set of pod label keys to select which pods will
                                           be taken into consideration. The keys are used to lookup values from the
-                                          incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
                                           to select the group of existing pods which pods will be taken into consideration
                                           for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
                                           pod labels will be ignored. The default value is empty.
-                                          The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                                          Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
-                                          This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                          The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                          Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                         items:
                                           type: string
                                         type: array
@@ -6673,13 +6966,13 @@ spec:
                                         description: |-
                                           MismatchLabelKeys is a set of pod label keys to select which pods will
                                           be taken into consideration. The keys are used to lookup values from the
-                                          incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
                                           to select the group of existing pods which pods will be taken into consideration
                                           for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
                                           pod labels will be ignored. The default value is empty.
-                                          The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
-                                          Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
-                                          This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                          The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                          Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                         items:
                                           type: string
                                         type: array
@@ -6721,11 +7014,13 @@ spec:
                                                   items:
                                                     type: string
                                                   type: array
+                                                  x-kubernetes-list-type: atomic
                                               required:
                                                 - key
                                                 - operator
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           matchLabels:
                                             additionalProperties:
                                               type: string
@@ -6745,6 +7040,7 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       topologyKey:
                                         description: |-
                                           This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
@@ -6757,6 +7053,7 @@ spec:
                                       - topologyKey
                                     type: object
                                   type: array
+                                  x-kubernetes-list-type: atomic
                               type: object
                           type: object
                         priority:
@@ -6783,11 +7080,7 @@ spec:
                             If schedulingGates is not empty, the pod will stay in the SchedulingGated state and the
                             scheduler will not attempt to schedule the pod.
 
-
                             SchedulingGates can only be set at pod creation time, and be removed only afterwards.
-
-
-                            This is a beta feature enabled by the PodSchedulingReadiness feature gate.
                           items:
                             description:
                               PodSchedulingGate is associated to a Pod to guard
@@ -6836,15 +7129,16 @@ spec:
                             will be made available to those containers which consume them
                             by name.
 
-
                             This is an alpha field and requires enabling the
                             DynamicResourceAllocation feature gate.
-
 
                             This field is immutable.
                           items:
                             description: |-
-                              PodResourceClaim references exactly one ResourceClaim through a ClaimSource.
+                              PodResourceClaim references exactly one ResourceClaim, either directly
+                              or by naming a ResourceClaimTemplate which is then turned into a ResourceClaim
+                              for the pod.
+
                               It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
                               Containers that need access to the ResourceClaim reference it with this name.
                             properties:
@@ -6853,34 +7147,32 @@ spec:
                                   Name uniquely identifies this resource claim inside the pod.
                                   This must be a DNS_LABEL.
                                 type: string
-                              source:
-                                description:
-                                  Source describes where to find the
+                              resourceClaimName:
+                                description: |-
+                                  ResourceClaimName is the name of a ResourceClaim object in the same
+                                  namespace as this pod.
+
+                                  Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                                  be set.
+                                type: string
+                              resourceClaimTemplateName:
+                                description: |-
+                                  ResourceClaimTemplateName is the name of a ResourceClaimTemplate
+                                  object in the same namespace as this pod.
+
+                                  The template will be used to create a new ResourceClaim, which will
+                                  be bound to this pod. When this pod is deleted, the ResourceClaim
+                                  will also be deleted. The pod name and resource name, along with a
+                                  generated component, will be used to form a unique name for the
+                                  ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+                                  This field is immutable and no changes will be made to the
+                                  corresponding ResourceClaim by the control plane after creating the
                                   ResourceClaim.
-                                properties:
-                                  resourceClaimName:
-                                    description: |-
-                                      ResourceClaimName is the name of a ResourceClaim object in the same
-                                      namespace as this pod.
-                                    type: string
-                                  resourceClaimTemplateName:
-                                    description: |-
-                                      ResourceClaimTemplateName is the name of a ResourceClaimTemplate
-                                      object in the same namespace as this pod.
 
-
-                                      The template will be used to create a new ResourceClaim, which will
-                                      be bound to this pod. When this pod is deleted, the ResourceClaim
-                                      will also be deleted. The pod name and resource name, along with a
-                                      generated component, will be used to form a unique name for the
-                                      ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
-
-
-                                      This field is immutable and no changes will be made to the
-                                      corresponding ResourceClaim by the control plane after creating the
-                                      ResourceClaim.
-                                    type: string
-                                type: object
+                                  Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                                  be set.
+                                type: string
                             required:
                               - name
                             type: object
@@ -6933,6 +7225,7 @@ spec:
                               - conditionType
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                         tolerations:
                           description: If specified, the pod's tolerations.
                           items:
@@ -6972,20 +7265,20 @@ spec:
                                 type: string
                             type: object
                           type: array
+                          x-kubernetes-list-type: atomic
                         os:
                           description: |-
                             Specifies the OS of the containers in the pod.
                             Some pod and container fields are restricted if this is set.
 
-
                             If the OS field is set to linux, the following fields must be unset:
                             -securityContext.windowsOptions
-
 
                             If the OS field is set to windows, following fields must be unset:
                             - spec.hostPID
                             - spec.hostIPC
                             - spec.hostUsers
+                            - spec.securityContext.appArmorProfile
                             - spec.securityContext.seLinuxOptions
                             - spec.securityContext.seccompProfile
                             - spec.securityContext.fsGroup
@@ -6995,6 +7288,8 @@ spec:
                             - spec.securityContext.runAsUser
                             - spec.securityContext.runAsGroup
                             - spec.securityContext.supplementalGroups
+                            - spec.securityContext.supplementalGroupsPolicy
+                            - spec.containers[*].securityContext.appArmorProfile
                             - spec.containers[*].securityContext.seLinuxOptions
                             - spec.containers[*].securityContext.seccompProfile
                             - spec.containers[*].securityContext.capabilities
@@ -7079,6 +7374,7 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                               command:
                                 description: |-
                                   Entrypoint array. Not executed within a shell.
@@ -7092,6 +7388,7 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                                x-kubernetes-list-type: atomic
                               env:
                                 description: |-
                                   List of environment variables to set in the container.
@@ -7132,10 +7429,13 @@ spec:
                                               description: The key to select.
                                               type: string
                                             name:
+                                              default: ''
                                               description: |-
                                                 Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description:
@@ -7206,10 +7506,13 @@ spec:
                                                 key.
                                               type: string
                                             name:
+                                              default: ''
                                               description: |-
                                                 Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description:
@@ -7225,6 +7528,9 @@ spec:
                                     - name
                                   type: object
                                 type: array
+                                x-kubernetes-list-map-keys:
+                                  - name
+                                x-kubernetes-list-type: map
                               envFrom:
                                 description: |-
                                   List of sources to populate environment variables in the container.
@@ -7242,10 +7548,13 @@ spec:
                                       description: The ConfigMap to select from
                                       properties:
                                         name:
+                                          default: ''
                                           description: |-
                                             Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
                                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                           type: string
                                         optional:
                                           description:
@@ -7264,10 +7573,13 @@ spec:
                                       description: The Secret to select from
                                       properties:
                                         name:
+                                          default: ''
                                           description: |-
                                             Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
                                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion, kind, uid?
                                           type: string
                                         optional:
                                           description:
@@ -7278,6 +7590,7 @@ spec:
                                       x-kubernetes-map-type: atomic
                                   type: object
                                 type: array
+                                x-kubernetes-list-type: atomic
                               image:
                                 description: |-
                                   Container image name.
@@ -7319,6 +7632,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       httpGet:
                                         description:
@@ -7354,6 +7668,7 @@ spec:
                                                 - value
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           path:
                                             description:
                                               Path to access on the HTTP server.
@@ -7440,6 +7755,7 @@ spec:
                                             items:
                                               type: string
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                         type: object
                                       httpGet:
                                         description:
@@ -7475,6 +7791,7 @@ spec:
                                                 - value
                                               type: object
                                             type: array
+                                            x-kubernetes-list-type: atomic
                                           path:
                                             description:
                                               Path to access on the HTTP server.
@@ -7557,6 +7874,7 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                     type: object
                                   failureThreshold:
                                     description: |-
@@ -7577,10 +7895,10 @@ spec:
                                         format: int32
                                         type: integer
                                       service:
+                                        default: ''
                                         description: |-
                                           Service is the name of the service to place in the gRPC HealthCheckRequest
                                           (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
 
                                           If this is not specified, the default behavior is defined by gRPC.
                                         type: string
@@ -7620,6 +7938,7 @@ spec:
                                             - value
                                           type: object
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       path:
                                         description:
                                           Path to access on the HTTP server.
@@ -7783,6 +8102,7 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                     type: object
                                   failureThreshold:
                                     description: |-
@@ -7803,10 +8123,10 @@ spec:
                                         format: int32
                                         type: integer
                                       service:
+                                        default: ''
                                         description: |-
                                           Service is the name of the service to place in the gRPC HealthCheckRequest
                                           (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
 
                                           If this is not specified, the default behavior is defined by gRPC.
                                         type: string
@@ -7846,6 +8166,7 @@ spec:
                                             - value
                                           type: object
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       path:
                                         description:
                                           Path to access on the HTTP server.
@@ -7964,10 +8285,8 @@ spec:
                                       Claims lists the names of resources, defined in spec.resourceClaims,
                                       that are used by this container.
 
-
                                       This is an alpha field and requires enabling the
                                       DynamicResourceAllocation feature gate.
-
 
                                       This field is immutable. It can only be set for containers.
                                     items:
@@ -7980,6 +8299,12 @@ spec:
                                             Name must match the name of one entry in pod.spec.resourceClaims of
                                             the Pod where this field is used. It makes that resource available
                                             inside a container.
+                                          type: string
+                                        request:
+                                          description: |-
+                                            Request is the name chosen for a request in the referenced claim.
+                                            If empty, everything from the claim is made available, otherwise
+                                            only the result of this request.
                                           type: string
                                       required:
                                         - name
@@ -8047,6 +8372,30 @@ spec:
                                       2) has CAP_SYS_ADMIN
                                       Note that this field cannot be set when spec.os.name is windows.
                                     type: boolean
+                                  appArmorProfile:
+                                    description: |-
+                                      appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                      overrides the pod's appArmorProfile.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    properties:
+                                      localhostProfile:
+                                        description: |-
+                                          localhostProfile indicates a profile loaded on the node that should be used.
+                                          The profile must be preconfigured on the node to work.
+                                          Must match the loaded name of the profile.
+                                          Must be set if and only if type is "Localhost".
+                                        type: string
+                                      type:
+                                        description: |-
+                                          type indicates which kind of AppArmor profile will be applied.
+                                          Valid options are:
+                                            Localhost - a profile pre-loaded on the node.
+                                            RuntimeDefault - the container runtime's default profile.
+                                            Unconfined - no AppArmor enforcement.
+                                        type: string
+                                    required:
+                                      - type
+                                    type: object
                                   capabilities:
                                     description: |-
                                       The capabilities to add/drop when running containers.
@@ -8061,6 +8410,7 @@ spec:
                                             capabilities type
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       drop:
                                         description: Removed capabilities
                                         items:
@@ -8069,6 +8419,7 @@ spec:
                                             capabilities type
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                     type: object
                                   privileged:
                                     description: |-
@@ -8080,7 +8431,7 @@ spec:
                                   procMount:
                                     description: |-
                                       procMount denotes the type of proc mount to use for the containers.
-                                      The default is DefaultProcMount which uses the container runtime defaults for
+                                      The default value is Default which uses the container runtime defaults for
                                       readonly paths and masked paths.
                                       This requires the ProcMountType feature flag to be enabled.
                                       Note that this field cannot be set when spec.os.name is windows.
@@ -8166,7 +8517,6 @@ spec:
                                           type indicates which kind of seccomp profile will be applied.
                                           Valid options are:
 
-
                                           Localhost - a profile defined in a file on the node should be used.
                                           RuntimeDefault - the container runtime default profile should be used.
                                           Unconfined - no profile should be applied.
@@ -8232,6 +8582,7 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                     type: object
                                   failureThreshold:
                                     description: |-
@@ -8252,10 +8603,10 @@ spec:
                                         format: int32
                                         type: integer
                                       service:
+                                        default: ''
                                         description: |-
                                           Service is the name of the service to place in the gRPC HealthCheckRequest
                                           (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-
 
                                           If this is not specified, the default behavior is defined by gRPC.
                                         type: string
@@ -8295,6 +8646,7 @@ spec:
                                             - value
                                           type: object
                                         type: array
+                                        x-kubernetes-list-type: atomic
                                       path:
                                         description:
                                           Path to access on the HTTP server.
@@ -8444,6 +8796,9 @@ spec:
                                     - name
                                   type: object
                                 type: array
+                                x-kubernetes-list-map-keys:
+                                  - devicePath
+                                x-kubernetes-list-type: map
                               volumeMounts:
                                 description: |-
                                   Pod volumes to mount into the container's filesystem.
@@ -8464,6 +8819,8 @@ spec:
                                         to container and the other way around.
                                         When not set, MountPropagationNone is used.
                                         This field is beta in 1.10.
+                                        When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                        (which defaults to None).
                                       type: string
                                     name:
                                       description:
@@ -8474,6 +8831,25 @@ spec:
                                         Mounted read-only if true, read-write otherwise (false or unspecified).
                                         Defaults to false.
                                       type: boolean
+                                    recursiveReadOnly:
+                                      description: |-
+                                        RecursiveReadOnly specifies whether read-only mounts should be handled
+                                        recursively.
+
+                                        If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                        If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                        recursively read-only.  If this field is set to IfPossible, the mount is made
+                                        recursively read-only, if it is supported by the container runtime.  If this
+                                        field is set to Enabled, the mount is made recursively read-only if it is
+                                        supported by the container runtime, otherwise the pod will not be started and
+                                        an error will be generated to indicate the reason.
+
+                                        If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                        None (or be unspecified, which defaults to None).
+
+                                        If this field is not specified, it is treated as an equivalent of Disabled.
+                                      type: string
                                     subPath:
                                       description: |-
                                         Path within the volume from which the container's volume should be mounted.
@@ -8491,6 +8867,9 @@ spec:
                                     - name
                                   type: object
                                 type: array
+                                x-kubernetes-list-map-keys:
+                                  - mountPath
+                                x-kubernetes-list-type: map
                               workingDir:
                                 description: |-
                                   Container's working directory.
@@ -8502,22 +8881,46 @@ spec:
                               - name
                             type: object
                           type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
                         securityContext:
                           description: |-
                             SecurityContext holds pod-level security attributes and common container settings.
                             Optional: Defaults to empty.  See type description for default values of each field.
                           properties:
+                            appArmorProfile:
+                              description: |-
+                                appArmorProfile is the AppArmor options to use by the containers in this pod.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              properties:
+                                localhostProfile:
+                                  description: |-
+                                    localhostProfile indicates a profile loaded on the node that should be used.
+                                    The profile must be preconfigured on the node to work.
+                                    Must match the loaded name of the profile.
+                                    Must be set if and only if type is "Localhost".
+                                  type: string
+                                type:
+                                  description: |-
+                                    type indicates which kind of AppArmor profile will be applied.
+                                    Valid options are:
+                                      Localhost - a profile pre-loaded on the node.
+                                      RuntimeDefault - the container runtime's default profile.
+                                      Unconfined - no AppArmor enforcement.
+                                  type: string
+                              required:
+                                - type
+                              type: object
                             fsGroup:
                               description: |-
                                 A special supplemental group that applies to all containers in a pod.
                                 Some volume types allow the Kubelet to change the ownership of that volume
                                 to be owned by the pod:
 
-
                                 1. The owning GID will be the FSGroup
                                 2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
                                 3. The permission bits are OR'd with rw-rw----
-
 
                                 If unset, the Kubelet will not modify the ownership and permissions of any volume.
                                 Note that this field cannot be set when spec.os.name is windows.
@@ -8609,7 +9012,6 @@ spec:
                                     type indicates which kind of seccomp profile will be applied.
                                     Valid options are:
 
-
                                     Localhost - a profile defined in a file on the node should be used.
                                     RuntimeDefault - the container runtime default profile should be used.
                                     Unconfined - no profile should be applied.
@@ -8619,17 +9021,28 @@ spec:
                               type: object
                             supplementalGroups:
                               description: |-
-                                A list of groups applied to the first process run in each container, in addition
-                                to the container's primary GID, the fsGroup (if specified), and group memberships
-                                defined in the container image for the uid of the container process. If unspecified,
-                                no additional groups are added to any container. Note that group memberships
-                                defined in the container image for the uid of the container process are still effective,
-                                even if they are not included in this list.
+                                A list of groups applied to the first process run in each container, in
+                                addition to the container's primary GID and fsGroup (if specified).  If
+                                the SupplementalGroupsPolicy feature is enabled, the
+                                supplementalGroupsPolicy field determines whether these are in addition
+                                to or instead of any group memberships defined in the container image.
+                                If unspecified, no additional groups are added, though group memberships
+                                defined in the container image may still be used, depending on the
+                                supplementalGroupsPolicy field.
                                 Note that this field cannot be set when spec.os.name is windows.
                               items:
                                 format: int64
                                 type: integer
                               type: array
+                              x-kubernetes-list-type: atomic
+                            supplementalGroupsPolicy:
+                              description: |-
+                                Defines how supplemental groups of the first container processes are calculated.
+                                Valid values are "Merge" and "Strict". If not specified, "Merge" is used.
+                                (Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled
+                                and the container runtime must implement support for this feature.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              type: string
                             sysctls:
                               description: |-
                                 Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
@@ -8650,6 +9063,7 @@ spec:
                                   - value
                                 type: object
                               type: array
+                              x-kubernetes-list-type: atomic
                             windowsOptions:
                               description: |-
                                 The Windows specific settings applied to all containers.

--- a/platform_umbrella/apps/common_core/priv/manifests/cloudnative_pg/scheduledbackups_postgresql_cnpg_io.yaml
+++ b/platform_umbrella/apps/common_core/priv/manifests/cloudnative_pg/scheduledbackups_postgresql_cnpg_io.yaml
@@ -79,11 +79,12 @@ spec:
                 method:
                   default: barmanObjectStore
                   description: |-
-                    The backup method to be used, possible options are `barmanObjectStore`
-                    and `volumeSnapshot`. Defaults to: `barmanObjectStore`.
+                    The backup method to be used, possible options are `barmanObjectStore`,
+                    `volumeSnapshot` or `plugin`. Defaults to: `barmanObjectStore`.
                   enum:
                     - barmanObjectStore
                     - volumeSnapshot
+                    - plugin
                   type: string
                 online:
                   description: |-

--- a/platform_umbrella/apps/common_core/priv/raw_files/cloudnative_pg/queries
+++ b/platform_umbrella/apps/common_core/priv/raw_files/cloudnative_pg/queries
@@ -74,6 +74,7 @@ pg_database:
       , pg_catalog.age(datfrozenxid) AS xid_age
       , pg_catalog.mxid_age(datminmxid) AS mxid_age
     FROM pg_catalog.pg_database
+    WHERE datallowconn
   metrics:
     - datname:
         usage: "LABEL"
@@ -237,6 +238,71 @@ pg_stat_bgwriter:
     - buffers_alloc:
         usage: "COUNTER"
         description: "Number of buffers allocated"
+
+pg_stat_bgwriter_17:
+  runonserver: ">=17.0.0"
+  name: pg_stat_bgwriter
+  query: |
+    SELECT buffers_clean
+      , maxwritten_clean
+      , buffers_alloc
+      , EXTRACT(EPOCH FROM stats_reset) AS stats_reset_time
+    FROM pg_catalog.pg_stat_bgwriter
+  metrics:
+    - buffers_clean:
+        usage: "COUNTER"
+        description: "Number of buffers written by the background writer"
+    - maxwritten_clean:
+        usage: "COUNTER"
+        description: "Number of times the background writer stopped a cleaning scan because it had written too many buffers"
+    - buffers_alloc:
+        usage: "COUNTER"
+        description: "Number of buffers allocated"
+    - stats_reset_time:
+        usage: "GAUGE"
+        description: "Time at which these statistics were last reset"
+
+pg_stat_checkpointer:
+  runonserver: ">=17.0.0"
+  query: |
+    SELECT num_timed AS checkpoints_timed
+      , num_requested AS checkpoints_req
+      , restartpoints_timed
+      , restartpoints_req
+      , restartpoints_done
+      , write_time
+      , sync_time
+      , buffers_written
+      , EXTRACT(EPOCH FROM stats_reset) AS stats_reset_time
+    FROM pg_catalog.pg_stat_checkpointer
+  metrics:
+    - checkpoints_timed:
+        usage: "COUNTER"
+        description: "Number of scheduled checkpoints that have been performed"
+    - checkpoints_req:
+        usage: "COUNTER"
+        description: "Number of requested checkpoints that have been performed"
+    - restartpoints_timed:
+        usage: "COUNTER"
+        description: "Number of scheduled restartpoints due to timeout or after a failed attempt to perform it"
+    - restartpoints_req:
+        usage: "COUNTER"
+        description: "Number of requested restartpoints that have been performed"
+    - restartpoints_done:
+        usage: "COUNTER"
+        description: "Number of restartpoints that have been performed"
+    - write_time:
+        usage: "COUNTER"
+        description: "Total amount of time that has been spent in the portion of processing checkpoints and restartpoints where files are written to disk, in milliseconds"
+    - sync_time:
+        usage: "COUNTER"
+        description: "Total amount of time that has been spent in the portion of processing checkpoints and restartpoints where files are synchronized to disk, in milliseconds"
+    - buffers_written:
+        usage: "COUNTER"
+        description: "Number of buffers written during checkpoints and restartpoints"
+    - stats_reset_time:
+        usage: "GAUGE"
+        description: "Time at which these statistics were last reset"
 
 pg_stat_database:
   query: |


### PR DESCRIPTION
Summary:
- Regenerate the resource module
- Use the new monitoring queries
- Use the newest CRD's
- Update the cluster role to allow more perms and the new names

Test Plan:
- bix bootstrap && bix dev
- CI
