### PR TITLE
chore: update to latest released kind node and aws kube

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -4,6 +4,6 @@ erlang 27.1
 golang 1.23.3
 goreleaser 2.4.4
 kind 0.25.0
-kubectl 1.31.2
+kubectl 1.32.0
 nodejs 22.11.0
 shfmt 3.10.0

--- a/bi/pkg/cluster/kind/kind.go
+++ b/bi/pkg/cluster/kind/kind.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	KindImage         = "kindest/node:v1.31.2"
+	KindImage         = "kindest/node:v1.32.0"
 	NoisySocketsImage = "ghcr.io/noisysockets/nsh:v0.9.3"
 )
 

--- a/bi/pkg/cluster/pulumi.go
+++ b/bi/pkg/cluster/pulumi.go
@@ -81,7 +81,7 @@ func (p *pulumiProvider) configure(ctx context.Context) (auto.Workspace, error) 
 		"cluster:maxSize":        {Value: "4"},
 		"cluster:minSize":        {Value: "2"},
 		"cluster:name":           {Value: p.slug},
-		"cluster:version":        {Value: "1.31"},
+		"cluster:version":        {Value: "1.32"},
 		"cluster:volumeSize":     {Value: "20"},
 		"cluster:volumeType":     {Value: "gp3"},
 		"gateway:cidrBlock":      {Value: "100.64.250.0/24"},


### PR DESCRIPTION
Summary:
v1.32.0 is the latest stable release hot off the presses, or atleast
that is what the banner in aws will not stop telling me.

Test Plan:
CI

bix bootstrap
