### PR TITLE
fix: roll back k8s version update

### DIFF
--- a/bi/pkg/cluster/kind/kind.go
+++ b/bi/pkg/cluster/kind/kind.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	KindImage         = "kindest/node:v1.32.0"
+	KindImage         = "kindest/node:v1.31.2"
 	NoisySocketsImage = "ghcr.io/noisysockets/nsh:v0.9.3"
 )
 

--- a/bi/pkg/cluster/pulumi.go
+++ b/bi/pkg/cluster/pulumi.go
@@ -81,7 +81,7 @@ func (p *pulumiProvider) configure(ctx context.Context) (auto.Workspace, error) 
 		"cluster:maxSize":        {Value: "4"},
 		"cluster:minSize":        {Value: "2"},
 		"cluster:name":           {Value: p.slug},
-		"cluster:version":        {Value: "1.32"},
+		"cluster:version":        {Value: "1.31"},
 		"cluster:volumeSize":     {Value: "20"},
 		"cluster:volumeType":     {Value: "gp3"},
 		"gateway:cidrBlock":      {Value: "100.64.250.0/24"},


### PR DESCRIPTION
1.32 isn't available in EKS yet (at least for new clusters).

`InvalidParameterException: unsupported Kubernetes version 1.32`

![image](https://github.com/user-attachments/assets/abb9c795-e0dc-433d-bef2-ce1aab26b5f2)
