### PR TITLE
chore: use the latest released bi

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/defaults/versions.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/defaults/versions.ex
@@ -2,5 +2,5 @@ defmodule CommonCore.Defaults.Versions do
   @moduledoc false
 
   @spec bi_stable_version() :: String.t()
-  def bi_stable_version, do: "0.41.0"
+  def bi_stable_version, do: "0.43.0"
 end


### PR DESCRIPTION
Summary:
- Use the new bi with the aws fix

Test Plan:
- Land after #1364 is in master and there's a release.
