### PR TITLE
Documentation page restructure/overhaul

### DIFF
--- a/static/src/content/config.ts
+++ b/static/src/content/config.ts
@@ -67,6 +67,7 @@ const postCollection = defineCollection({
 const docCollection = defineCollection({
   schema: z.object({
     title: z.string(),
+    description: z.string().optional(),
     draft: z.boolean().optional(),
     category: z.string().optional(),
     tags: z.array(z.string()).optional(),

--- a/static/src/content/doc/build_and_packaging.md
+++ b/static/src/content/doc/build_and_packaging.md
@@ -1,8 +1,7 @@
 ---
 title: 'Build/Packaging Our Software'
 description:
-  Guide to building and packaging platform components with Docker and Mix
-  releases.
+  How the platform handles building and packaging with Docker and Mix releases.
 tags: ['overview', 'code', 'production', 'build']
 draft: false
 ---

--- a/static/src/content/doc/build_and_packaging.md
+++ b/static/src/content/doc/build_and_packaging.md
@@ -1,5 +1,8 @@
 ---
 title: 'Build/Packaging Our Software'
+description:
+  Guide to building and packaging platform components with Docker and Mix
+  releases.
 tags: ['overview', 'code', 'production', 'build']
 draft: false
 ---

--- a/static/src/content/doc/gen_resource.md
+++ b/static/src/content/doc/gen_resource.md
@@ -1,5 +1,6 @@
 ---
 title: 'Gen Resource - Yaml to Elixir'
+description: Convert Kubernetes YAML definitions into Elixir source modules.
 tags: ['overview', 'code', 'control-server', 'yaml']
 draft: false
 ---

--- a/static/src/content/doc/gen_resource.md
+++ b/static/src/content/doc/gen_resource.md
@@ -1,6 +1,8 @@
 ---
 title: 'Gen Resource - Yaml to Elixir'
-description: Convert Kubernetes YAML definitions into Elixir source modules.
+description:
+  Internal conversion mechanism for transforming Kubernetes YAML into platform
+  Elixir modules.
 tags: ['overview', 'code', 'control-server', 'yaml']
 draft: false
 ---

--- a/static/src/content/doc/major_parts_install.md
+++ b/static/src/content/doc/major_parts_install.md
@@ -1,5 +1,7 @@
 ---
 title: 'Major Parts Tour via Install'
+description:
+  Overview of platform architecture components and installation process.
 tags: ['overview', 'code', 'install', 'control-server', 'home-base']
 draft: false
 ---

--- a/static/src/content/doc/monitoring.md
+++ b/static/src/content/doc/monitoring.md
@@ -1,8 +1,8 @@
 ---
 title: Monitoring
 description:
-  Learn how to set up and use monitoring tools like Grafana and VictoriaMetrics
-  in Batteries Included.
+  Set up comprehensive monitoring using Grafana and VictoriaMetrics in your
+  cluster.
 tags: ['monitoring', 'grafana', 'victoriametrics']
 draft: false
 ---

--- a/static/src/content/doc/our_tools.md
+++ b/static/src/content/doc/our_tools.md
@@ -1,5 +1,6 @@
 ---
 title: 'Internal Dev Tools'
+description: Development tools and utilities for working with the platform.
 tags: ['code', 'tools', 'internal']
 draft: false
 ---

--- a/static/src/content/doc/our_tools.md
+++ b/static/src/content/doc/our_tools.md
@@ -1,6 +1,7 @@
 ---
 title: 'Internal Dev Tools'
-description: Development tools and utilities for working with the platform.
+description:
+  Overview of development tools and utilities in the platform codebase.
 tags: ['code', 'tools', 'internal']
 draft: false
 ---

--- a/static/src/content/doc/pgvector.md
+++ b/static/src/content/doc/pgvector.md
@@ -1,0 +1,295 @@
+---
+title: 'PGVector and PostgreSQL'
+description:
+  Learn how to create AI applications using PostgreSQL and PGVector with Jupyter
+  Notebooks.
+tags: ['AI', 'Postgres', 'PGVector', 'Jupyter Notebooks']
+draft: false
+---
+
+In the realm of artificial intelligence, the ability to efficiently store and
+retrieve high-dimensional data has become increasingly pertinent. As a result,
+it's only natural that database systems have evolved to meet these needs. Enter
+`pgvector` -- a powerful extension for Postgres that brings vector similarity
+search capabilities to an industry-standard database system.
+
+In this article, we'll explore how we can leverage `pgvector` and Postgres
+together with the OpenAI API in order to create AI-driven applications. Along
+the way, we'll briefly explain key concepts such as embeddings and vector
+similarity search.
+
+## Understanding PostgreSQL and `pgvector`
+
+_PostgreSQL_, also known as _Postgres_, is an open-source object-relational
+database system with over 30 years of active development. Known for reliability,
+a wide range of features, and performance, Postgres is a popular choice for any
+application, from small projects to large enterprise software.
+
+`pgvector` is a Postgres extension that adds vector similarity search
+capabilities to the database. In AI, vector similarity search is crucial for
+many applications, including recommendation systems, natural language
+processing, image recognition, and more. `pgvector` allows you to both store and
+query high-dimensional vectors efficiently within your Postgres database.
+
+## The Power of Embeddings in AI
+
+_Embeddings_ are at the heart of many modern AI applications. They are vector
+representations of data that capture semantic meaning and relationships.
+Embeddings measure how related text strings are, allowing for more nuanced
+comparisons than simple text matching.
+
+An embedding is essentially just a list (vector) of floating-point numbers. The
+distance between two vectors measures their relatedness. Small distances suggest
+high relatedness, while large distances suggest low relatedness. This makes
+embeddings incredibly useful for tasks like semantic search, recommendation
+systems, and content-based filtering.
+
+## Why Vector Databases Matter
+
+Vector databases, like Postgres with `pgvector`, offer significant advantages in
+AI applications:
+
+1. **Efficient Similarity Search**: They excel at finding "similar" items, which
+   is often more valuable than exact matches in AI applications.
+
+2. **Handling High-Dimensional Data**: They're optimized for storing and
+   querying high-dimensional vectors produced by machine learning models.
+
+3. **Scalability**: Specialized indexing methods allow for quick queries even
+   with millions of vectors.
+
+4. **Semantic Understanding**: They enable context-aware searches, understanding
+   the meaning behind queries.
+
+These capabilities make vector databases ideal for various AI applications,
+including:
+
+- Recommendation systems
+- Semantic search engines
+- Content-based filtering
+- Image and audio similarity search
+- Natural language processing tasks
+
+By augmenting Postgres with `pgvector`, developers can leverage these powerful
+capabilities while still benefiting from the robustness and extensive feature
+set of a mature relational database system.
+
+## Starting an AI Project with Batteries Included
+
+Batteries Included offers a streamlined approach to working with AI projects,
+complete with integrated database support. We'll be using _Jupyter Notebooks_ to
+run Python code and interact with both the OpenAI API as well as a Postgres
+database.
+
+Jupyter Notebooks provide an interactive environment where you can write and
+execute code, visualize data, and document your work all in one place. This
+makes them ideal for exploratory data analysis, prototyping AI models, and
+sharing results with others.
+
+Let's get started!
+
+### Step 1: Install the Jupyter Notebook Battery
+
+First, we need to install the Battery that allows us to create Jupyter
+Notebooks:
+
+1. Open the control server and navigate to the `AI` section.
+2. Install the `Jupyter Notebook` Battery, granting us the ability to create
+   Notebooks.
+
+<video src="/videos/pgvector/ai-battery-creation.webm" controls></video>
+
+### Step 2: Create a PostgreSQL Cluster
+
+Next up, we need the actual database we will use together with the Jupyter
+Notebook. Batteries Included makes this easy:
+
+1. Navigate to the `Datastores` section.
+2. Click on `New PostgreSQL` to begin creation.
+3. Add or modify a user to be in the `battery-ai` namespace. This will store the
+   user credentials in a secret that is accessible by the AI Battery.
+4. Click `Save Postgres Cluster` to finalize creation.
+
+<video src="/videos/pgvector/creating-database.webm" controls></video>
+
+### Step 3: Set Up the Jupyter Notebook
+
+Lastly, we need to create the Jupyter Notebook itself:
+
+1. Let's navigate back to the `AI` tab.
+2. There should be a `Jupyter Notebooks` section available now. Click on
+   `New Notebook` to begin creation.
+3. We're going to go ahead and add two environment variables:
+
+   - `OPENAI_KEY`: We'll be using OpenAI to generate embeddings, so we need an
+     API key to authenticate.
+   - `DATABASE_URL`: Navigate to the `Secret` tab, and point this to the `DSN`
+     secret created by the Postgres cluster in the previous step.
+
+4. Click `Save Notebook` to finalize creation.
+
+<video src="/videos/pgvector/jupyter-creation.webm" controls></video>
+
+> **Note:** It might take a few moments for the Notebook to finish initializing.
+
+### Locally Accessing the Database
+
+For local development or when you want to use your own tools to set up the
+database with embeddings, you can use the `bi` CLI tool to get a connection
+string for your PC:
+
+```bash
+export DATABASE_URL=$(bi postgres access-info mycluster myusername --localhost)
+```
+
+This command retrieves the connection information for your Postgres cluster,
+which you can then use with e.g. PgAdmin or DBeaver. You can skip this step if
+you're only using the Jupyter Notebook or connecting remotely.
+
+> **Note:** The `app` database is used by default.
+
+### Step 4: Initializing the Jupyter Notebook
+
+Go ahead and open up the Jupyter instance and start a Python 3 Notebook.
+
+<video src="/videos/pgvector/notebook-creation.webm" controls></video>
+
+Now we're ready write code. Let's begin by installing the packages we'll be
+using:
+
+```python
+!pip install psycopg2-binary
+!pip install openai
+!pip install pgvector
+```
+
+`psycopg2` is a PostgreSQL adapter for Python, `openai` is the official Python
+client for the OpenAI API, and `pgvector` is needed to interface with the
+pgvector extension in our Python code.
+
+Now, connect to the database using the `DATABASE_URL` environment variable:
+
+```python
+import psycopg2
+import os
+
+conn = psycopg2.connect(os.environ['DATABASE_URL'])
+cur = conn.cursor()
+```
+
+### Step 5: Set Up `pgvector` and Create the Documents Table
+
+Next, we'll set up `pgvector` and create a table to store our documents and
+their embeddings:
+
+```python
+import openai
+import numpy as np
+import psycopg2
+from pgvector.psycopg2 import register_vector
+from openai import OpenAI
+
+# Set up OpenAI API
+client = OpenAI(api_key=os.environ['OPENAI_KEY'])
+
+# Install pgvector
+cur.execute("CREATE EXTENSION IF NOT EXISTS vector;")
+conn.commit()
+
+register_vector(conn)
+
+# Create a table to store documents and their embeddings
+cur.execute("""
+CREATE TABLE IF NOT EXISTS documents (
+    id SERIAL PRIMARY KEY,
+    content TEXT,
+    embedding VECTOR(1536)
+);
+""")
+
+conn.commit()
+```
+
+### Step 6: Import Example Dataset and Create Embeddings
+
+Now, let's create an example dataset and generate some embeddings:
+
+```python
+# Sample documents
+documents = [
+    "Foxes are great night-time predators",
+    "Foxes can make over 40 different sounds",
+    "Foxes make use of the earth's magnetic field to hunt",
+    "Baby foxes are unable to see, walk or thermoregulate when they are born",
+]
+
+for doc in documents:
+    # Generate embedding using OpenAI
+    response = client.embeddings.create(input=doc, model="text-embedding-ada-002")
+    embedding = response.data[0].embedding
+
+    # Insert document + embedding into the database
+    cur.execute("INSERT INTO documents (content, embedding) VALUES (%s, %s);", (doc, embedding))
+    conn.commit()
+```
+
+## Leveraging `pgvector`
+
+Now that we have our environment set up and data stored, let's explore how we
+can use `pgvector` in our AI applications.
+
+1. **Indexing**: Let's start by creating an index on the embedding column to
+   speed up similarity searches:
+
+```python
+cur.execute("CREATE INDEX ON documents USING ivfflat (embedding vector_l2_ops);")
+conn.commit()
+```
+
+2. **Similarity Search**: When a query comes in, let's generate an embedding for
+   the query and use pgvector's similarity search capabilities to find the
+   nearest row in your database:
+
+```python
+def find_similar_document(query):
+    # Generate embedding for the query
+    response = client.embeddings.create(input=query, model="text-embedding-ada-002")
+    query_embedding = response.data[0].embedding
+
+    # Perform similarity search
+    cur.execute("""
+    SELECT content, embedding <-> %s::vector AS distance
+    FROM documents
+    ORDER BY distance
+    LIMIT 1;
+    """, (query_embedding,))
+
+    return cur.fetchone()
+
+# Example usage
+similar_doc = find_similar_document("I was wondering, how many sounds can foxes make?")
+if similar_doc:
+    doc, distance = similar_doc
+    print(f"Distance: {distance:.4f}, Content: {doc}")
+else:
+    print("No similar document found.")
+```
+
+This function will return the most similar document to the given query, along
+with its distance score.
+
+For example, performing a vector similarity search with the string:
+
+`I was wondering, how many sounds can foxes make?`
+
+Yields:
+
+`Distance: 0.4075, Content: Foxes can make over 40 different sounds`
+
+## Wrapping Up
+
+And that's really it! As your projects grow, you can effortlessly manage
+millions of vectors while maintaining swift query times, thanks to Postgres and
+`pgvector`'s efficient indexing. Whether you're developing a cutting-edge
+recommendation system or diving into novel AI applications, this combination
+offers a flexible and powerful platform to realize your ideas.

--- a/static/src/content/doc/pgvector.md
+++ b/static/src/content/doc/pgvector.md
@@ -1,19 +1,18 @@
 ---
 title: 'PGVector and PostgreSQL'
 description:
-  Learn how to create AI applications using PostgreSQL and PGVector with Jupyter
-  Notebooks.
+  Create AI applications using PostgreSQL and PGVector with Jupyter Notebooks.
 tags: ['AI', 'Postgres', 'PGVector', 'Jupyter Notebooks']
 draft: false
 ---
 
 In the realm of artificial intelligence, the ability to efficiently store and
-retrieve high-dimensional data has become increasingly pertinent. As a result,
-it's only natural that database systems have evolved to meet these needs. Enter
-`pgvector` -- a powerful extension for Postgres that brings vector similarity
-search capabilities to an industry-standard database system.
+retrieve high-dimensional data is increasingly pertinent. As a result, it's only
+natural that database systems have evolved to meet these needs. Enter `pgvector`
+-- a powerful extension for Postgres that brings vector similarity search
+capabilities to an industry-standard database system.
 
-In this article, we'll explore how we can leverage `pgvector` and Postgres
+In this guide, we'll explore how we can leverage `pgvector` and Postgres
 together with the OpenAI API in order to create AI-driven applications. Along
 the way, we'll briefly explain key concepts such as embeddings and vector
 similarity search.

--- a/static/src/content/doc/postgres.md
+++ b/static/src/content/doc/postgres.md
@@ -1,7 +1,6 @@
 ---
 title: PostgreSQL
-description:
-  Learn how to start and manage a PostgreSQL database with Batteries Included.
+description: Start and manage a PostgreSQL database with Batteries Included.
 tags: ['database', 'postgres', 'datastore']
 draft: false
 ---

--- a/static/src/content/doc/resource_hashing.md
+++ b/static/src/content/doc/resource_hashing.md
@@ -1,7 +1,8 @@
 ---
 title: 'Resource Hashing'
 description:
-  Track and compare Kubernetes resource changes using cryptographic hashing.
+  Implementation of cryptographic hashing for tracking and comparing resources
+  in the control system.
 tags: ['overview', 'code', 'control-server', 'kubernetes']
 draft: false
 ---

--- a/static/src/content/doc/resource_hashing.md
+++ b/static/src/content/doc/resource_hashing.md
@@ -1,5 +1,7 @@
 ---
 title: 'Resource Hashing'
+description:
+  Track and compare Kubernetes resource changes using cryptographic hashing.
 tags: ['overview', 'code', 'control-server', 'kubernetes']
 draft: false
 ---

--- a/static/src/content/doc/snapshot_apply.md
+++ b/static/src/content/doc/snapshot_apply.md
@@ -1,5 +1,6 @@
 ---
 title: 'Snapshot Apply'
+description: Implement repeatable system state changes across your cluster.
 tags: ['overview', 'code', 'control-server', 'kubernetes', 'keycloak']
 draft: false
 ---

--- a/static/src/content/doc/snapshot_apply.md
+++ b/static/src/content/doc/snapshot_apply.md
@@ -1,6 +1,8 @@
 ---
 title: 'Snapshot Apply'
-description: Implement repeatable system state changes across your cluster.
+description:
+  Internal process for managing system state changes and applying them across
+  the cluster.
 tags: ['overview', 'code', 'control-server', 'kubernetes', 'keycloak']
 draft: false
 ---

--- a/static/src/content/doc/system_state.md
+++ b/static/src/content/doc/system_state.md
@@ -1,5 +1,6 @@
 ---
 title: 'System State Overview'
+description: Understanding the platform's system state management and caching.
 tags: ['overview', 'code', 'control-server']
 draft: false
 ---

--- a/static/src/content/doc/system_state.md
+++ b/static/src/content/doc/system_state.md
@@ -1,6 +1,7 @@
 ---
 title: 'System State Overview'
-description: Understanding the platform's system state management and caching.
+description:
+  Internal system state management and caching mechanisms of the platform.
 tags: ['overview', 'code', 'control-server']
 draft: false
 ---

--- a/static/src/content/doc/ubuntu.md
+++ b/static/src/content/doc/ubuntu.md
@@ -1,6 +1,7 @@
 ---
 title: 'Ubuntu Dev prepare'
-description: Set up an Ubuntu development environment for platform development.
+description:
+  Setting up an Ubuntu development environment for platform development.
 tags: ['code', 'tools', 'internal']
 ---
 

--- a/static/src/content/doc/ubuntu.md
+++ b/static/src/content/doc/ubuntu.md
@@ -1,5 +1,6 @@
 ---
 title: 'Ubuntu Dev prepare'
+description: Set up an Ubuntu development environment for platform development.
 tags: ['code', 'tools', 'internal']
 ---
 

--- a/static/src/data/navigation.ts
+++ b/static/src/data/navigation.ts
@@ -204,6 +204,10 @@ export const headerData = [
     ],
   },
   {
+    label: 'Docs',
+    link: '/docs',
+  },
+  {
     label: 'Pricing',
     link: '/pricing',
   },

--- a/static/src/pages/docs/[...page].astro
+++ b/static/src/pages/docs/[...page].astro
@@ -17,23 +17,9 @@ type Props = InferGetStaticPropsType<typeof getStaticPaths>;
 const { page } = Astro.props;
 const currentPage = page.currentPage ?? 1;
 
-// Organize docs into categories
 const categorizedDocs = {
   gettingStarted: page.data.filter((doc) =>
     ['postgres', 'monitoring', 'pgvector'].includes(doc.slug)
-  ),
-
-  development: page.data.filter((doc) =>
-    [
-      'major_parts_install',
-      'build_and_packaging',
-      'gen_resource',
-      'resource_hashing',
-      'snapshot_apply',
-      'system_state',
-      'our_tools',
-      'ubuntu',
-    ].includes(doc.slug)
   ),
 
   batteries: page.data.filter((doc) =>
@@ -47,6 +33,19 @@ const categorizedDocs = {
       'keycloak',
       'knative',
       'victoria-metrics',
+    ].includes(doc.slug)
+  ),
+
+  development: page.data.filter((doc) =>
+    [
+      'major_parts_install',
+      'build_and_packaging',
+      'gen_resource',
+      'resource_hashing',
+      'snapshot_apply',
+      'system_state',
+      'our_tools',
+      'ubuntu',
     ].includes(doc.slug)
   ),
 };
@@ -101,12 +100,12 @@ const metadata = {
           </div>
         </section>
 
-        <!-- Development -->
+        <!-- Batteries -->
         <section>
-          <h2 class="text-2xl font-bold text-gray-900 mb-6">Development</h2>
+          <h2 class="text-2xl font-bold text-gray-900 mb-6">Batteries</h2>
           <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
             {
-              categorizedDocs.development.map((doc) => (
+              categorizedDocs.batteries.map((doc) => (
                 <a
                   href={getPermalink(doc.permalink, 'docs')}
                   class="block p-6 bg-white rounded-lg shadow-sm hover:shadow-md transition-shadow duration-200">
@@ -118,12 +117,12 @@ const metadata = {
           </div>
         </section>
 
-        <!-- Batteries -->
+        <!-- Development -->
         <section>
-          <h2 class="text-2xl font-bold text-gray-900 mb-6">Batteries</h2>
+          <h2 class="text-2xl font-bold text-gray-900 mb-6">Development</h2>
           <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
             {
-              categorizedDocs.batteries.map((doc) => (
+              categorizedDocs.development.map((doc) => (
                 <a
                   href={getPermalink(doc.permalink, 'docs')}
                   class="block p-6 bg-white rounded-lg shadow-sm hover:shadow-md transition-shadow duration-200">

--- a/static/src/pages/docs/[...page].astro
+++ b/static/src/pages/docs/[...page].astro
@@ -17,6 +17,40 @@ type Props = InferGetStaticPropsType<typeof getStaticPaths>;
 const { page } = Astro.props;
 const currentPage = page.currentPage ?? 1;
 
+// Organize docs into categories
+const categorizedDocs = {
+  gettingStarted: page.data.filter((doc) =>
+    ['postgres', 'monitoring', 'pgvector'].includes(doc.slug)
+  ),
+
+  development: page.data.filter((doc) =>
+    [
+      'major_parts_install',
+      'build_and_packaging',
+      'gen_resource',
+      'resource_hashing',
+      'snapshot_apply',
+      'system_state',
+      'our_tools',
+      'ubuntu',
+    ].includes(doc.slug)
+  ),
+
+  batteries: page.data.filter((doc) =>
+    [
+      'postgres',
+      'alertmanager',
+      'cert-manager',
+      'cloud-nativ',
+      'grafana',
+      'istio',
+      'keycloak',
+      'knative',
+      'victoria-metrics',
+    ].includes(doc.slug)
+  ),
+};
+
 const metadata = {
   title: `Docs${currentPage > 1 ? ` — Page ${currentPage}` : ''}`,
   robots: {
@@ -37,25 +71,71 @@ const metadata = {
   </div>
   <div class="py-12 lg:py-16">
     <div class="u-container">
-      <div>
+      <div class="max-w-3xl mb-12">
         <h1
-          class="font-bold leading-tighter tracking-tighter font-heading text-heading text-3xl lg:text-4xl xl:text-5xl">
-          Docs
+          class="font-bold ding-tighter tracking-tighter font-heading text-heading text-3xl lg:text-4xl xl:text-5xl mb-4">
+          Documentation
         </h1>
+        <p class="text-lg text-gray-600">
+          Everything you need to know about deploying and managing your
+          infrastructure with Batteries Included, from getting started to
+          technical deep dives.
+        </p>
       </div>
-      <ul>
-        {
-          page.data.map((doc, i) => (
-            <li key={doc.slug}>
-              <a
-                href={getPermalink(doc.permalink, 'docs')}
-                class="block py-4 cursor-pointer hover:text-primary hover:underline transition-colors duration-600 ease-in-out">
-                <h2 class="text-xl font-bold">{doc.title}</h2>
-              </a>
-            </li>
-          ))
-        }
-      </ul>
+
+      <div class="space-y-16">
+        <!-- Getting Started -->
+        <section>
+          <h2 class="text-2xl font-bold text-gray-900 mb-6">Getting Started</h2>
+          <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+            {
+              categorizedDocs.gettingStarted.map((doc) => (
+                <a
+                  href={getPermalink(doc.permalink, 'docs')}
+                  class="block p-6 bg-white rounded-lg shadow-sm hover:shadow-md transition-shadow duration-200">
+                  <h3 class="text-xl font-semibold mb-2">{doc.title}</h3>
+                  <p class="text-gray-600 text-sm">{doc.description}</p>
+                </a>
+              ))
+            }
+          </div>
+        </section>
+
+        <!-- Development -->
+        <section>
+          <h2 class="text-2xl font-bold text-gray-900 mb-6">Development</h2>
+          <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+            {
+              categorizedDocs.development.map((doc) => (
+                <a
+                  href={getPermalink(doc.permalink, 'docs')}
+                  class="block p-6 bg-white rounded-lg shadow-sm hover:shadow-md transition-shadow duration-200">
+                  <h3 class="text-xl font-semibold mb-2">{doc.title}</h3>
+                  <p class="text-gray-600 text-sm">{doc.description}</p>
+                </a>
+              ))
+            }
+          </div>
+        </section>
+
+        <!-- Batteries -->
+        <section>
+          <h2 class="text-2xl font-bold text-gray-900 mb-6">Batteries</h2>
+          <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+            {
+              categorizedDocs.batteries.map((doc) => (
+                <a
+                  href={getPermalink(doc.permalink, 'docs')}
+                  class="block p-6 bg-white rounded-lg shadow-sm hover:shadow-md transition-shadow duration-200">
+                  <h3 class="text-xl font-semibold mb-2">{doc.title}</h3>
+                  <p class="text-gray-600 text-sm">{doc.description}</p>
+                </a>
+              ))
+            }
+          </div>
+        </section>
+      </div>
+
       <div class="mt-12">
         <Pagination
           prevUrl={page.url.prev}

--- a/static/src/types.d.ts
+++ b/static/src/types.d.ts
@@ -56,6 +56,8 @@ export interface Doc {
   /**  */
   title: string;
   /**  */
+  description?: string;
+  /**  */
   category?: string;
   /**  */
   tags?: Array<string>;

--- a/static/src/utils/docs.ts
+++ b/static/src/utils/docs.ts
@@ -9,12 +9,14 @@ const getNormalizedDoc = async (doc: CollectionEntry<'doc'>): Promise<Doc> => {
 
   const {
     title,
+    description,
     tags: rawTags = [],
     category: rawCategory,
     draft = false,
     metadata = {},
   } = data as {
     title: string;
+    description?: string;
     tags?: string[];
     category?: string;
     draft?: boolean;
@@ -33,6 +35,7 @@ const getNormalizedDoc = async (doc: CollectionEntry<'doc'>): Promise<Doc> => {
     permalink: '/docs/' + slug,
 
     title: title,
+    description: description,
     category: category,
     tags: tags,
 


### PR DESCRIPTION
This PR restructures the docs page so it's split by categories and looks nicer/more welcoming.

Before:
![image](https://github.com/user-attachments/assets/3e11d8f1-17d6-4987-bbc0-304f7a8e1e68)

After:
![image](https://github.com/user-attachments/assets/d1098f18-c90e-4b8e-badc-79d4bd8e6f4c)

There are currently 3 categories: 

- Getting Started: General documentation/guides aimed at new users.
- Batteries: Docs dedicated to individual batteries. Currently only the PG one is undrafted, we should flesh out the rest.
- Development: Concerns BI-related development/architecture docs.