### PR TITLE
perf: don't subscribe to pubsub on deadview

### DIFF
--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/ferrretdb/show.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/ferrretdb/show.ex
@@ -14,7 +14,10 @@ defmodule ControlServerWeb.Live.FerretServiceShow do
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
-    :ok = KubeEventCenter.subscribe(:pod)
+    if connected?(socket) do
+      :ok = KubeEventCenter.subscribe(:pod)
+    end
+
     {:ok, assign_page_title(socket)}
   end
 

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/group_batteries/index.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/group_batteries/index.ex
@@ -7,7 +7,10 @@ defmodule ControlServerWeb.Live.GroupBatteriesIndex do
   alias EventCenter.Database, as: DatabaseEventCenter
 
   def mount(%{"group" => group}, _session, socket) do
-    :ok = DatabaseEventCenter.subscribe(:system_battery)
+    if connected?(socket) do
+      :ok = DatabaseEventCenter.subscribe(:system_battery)
+    end
+
     group = Catalog.group(group)
 
     {:ok,

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/data.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/data.ex
@@ -15,7 +15,9 @@ defmodule ControlServerWeb.Live.DataHome do
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
-    :ok = SystemStateSummaryEventCenter.subscribe()
+    if connected?(socket) do
+      :ok = SystemStateSummaryEventCenter.subscribe()
+    end
 
     {:ok,
      socket

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/devtools.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/devtools.ex
@@ -15,7 +15,9 @@ defmodule ControlServerWeb.Live.DevtoolsHome do
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
-    :ok = SystemStateSummaryEventCenter.subscribe()
+    if connected?(socket) do
+      :ok = SystemStateSummaryEventCenter.subscribe()
+    end
 
     {:ok,
      socket

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/magic.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/magic.ex
@@ -14,7 +14,9 @@ defmodule ControlServerWeb.Live.MagicHome do
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
-    :ok = SystemStateSummaryEventCenter.subscribe()
+    if connected?(socket) do
+      :ok = SystemStateSummaryEventCenter.subscribe()
+    end
 
     {:ok,
      socket

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/monitoring.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/monitoring.ex
@@ -12,7 +12,9 @@ defmodule ControlServerWeb.Live.MonitoringHome do
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
-    :ok = SystemStateSummaryEventCenter.subscribe()
+    if connected?(socket) do
+      :ok = SystemStateSummaryEventCenter.subscribe()
+    end
 
     {:ok,
      socket

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/net_sec.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/homes/net_sec.ex
@@ -19,7 +19,9 @@ defmodule ControlServerWeb.Live.NetSecHome do
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
-    :ok = SystemStateSummaryEventCenter.subscribe()
+    if connected?(socket) do
+      :ok = SystemStateSummaryEventCenter.subscribe()
+    end
 
     {:ok,
      socket

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/k8/deployment/show.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/k8/deployment/show.ex
@@ -16,7 +16,10 @@ defmodule ControlServerWeb.Live.DeploymentShow do
 
   @impl Phoenix.LiveView
   def mount(%{"name" => name, "namespace" => namespace}, _session, socket) do
-    :ok = KubeEventCenter.subscribe(@resource_type)
+    if connected?(socket) do
+      :ok = KubeEventCenter.subscribe(@resource_type)
+    end
+
     resource = get_resource!(namespace, name)
 
     {:ok,

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/k8/pod/show.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/k8/pod/show.ex
@@ -19,6 +19,10 @@ defmodule ControlServerWeb.Live.PodShow do
 
   @impl Phoenix.LiveView
   def mount(%{"name" => name, "namespace" => namespace}, _session, socket) do
+    if connected?(socket) do
+      :ok = KubeEventCenter.subscribe(@resource_type)
+    end
+
     {:ok,
      socket
      |> assign(
@@ -39,10 +43,6 @@ defmodule ControlServerWeb.Live.PodShow do
         _uri,
         %{assigns: %{live_action: :logs, name: name, namespace: namespace}} = socket
       ) do
-    if connected?(socket) do
-      :ok = KubeEventCenter.subscribe(@resource_type)
-    end
-
     # If this is a logs live_action and the container name was passed
     # Get the logs
     {:noreply, monitor_and_assign_logs(socket, namespace, name, container)}
@@ -62,8 +62,6 @@ defmodule ControlServerWeb.Live.PodShow do
   end
 
   def handle_params(_params, _uri, %{assigns: %{live_action: :events}} = socket) do
-    :ok = KubeEventCenter.subscribe(@resource_type)
-
     {:noreply, assign_events(socket)}
   end
 

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/k8/pod/show.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/k8/pod/show.ex
@@ -39,10 +39,12 @@ defmodule ControlServerWeb.Live.PodShow do
         _uri,
         %{assigns: %{live_action: :logs, name: name, namespace: namespace}} = socket
       ) do
+    if connected?(socket) do
+      :ok = KubeEventCenter.subscribe(@resource_type)
+    end
+
     # If this is a logs live_action and the container name was passed
     # Get the logs
-    :ok = KubeEventCenter.subscribe(@resource_type)
-
     {:noreply, monitor_and_assign_logs(socket, namespace, name, container)}
   end
 

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/k8/raw_resource.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/k8/raw_resource.ex
@@ -12,7 +12,10 @@ defmodule ControlServerWeb.Live.RawResource do
   @impl Phoenix.LiveView
   def mount(%{"resource_type" => rt, "name" => name} = params, _session, socket) do
     resource_type = String.to_existing_atom(rt)
-    subscribe(resource_type)
+
+    if connected?(socket) do
+      :ok = KubeEventCenter.subscribe(resource_type)
+    end
 
     namespace = Map.get(params, "namespace", nil)
 
@@ -38,10 +41,6 @@ defmodule ControlServerWeb.Live.RawResource do
   @impl Phoenix.LiveView
   def handle_params(params, _url, socket) do
     {:noreply, assign(socket, :path, Map.get(params, "path", []))}
-  end
-
-  defp subscribe(resource_type) do
-    :ok = KubeEventCenter.subscribe(resource_type)
   end
 
   @impl Phoenix.LiveView

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/k8/resources_list.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/k8/resources_list.ex
@@ -19,7 +19,10 @@ defmodule ControlServerWeb.Live.ResourceList do
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
     live_action = socket.assigns.live_action
-    subscribe(live_action)
+
+    if connected?(socket) do
+      :ok = KubeEventCenter.subscribe(live_action)
+    end
 
     {:ok,
      socket
@@ -70,10 +73,6 @@ defmodule ControlServerWeb.Live.ResourceList do
          Map.put(objects, type, type == live_action && objs)
        end)}
     end)
-  end
-
-  defp subscribe(resource_type) do
-    :ok = KubeEventCenter.subscribe(resource_type)
   end
 
   @impl Phoenix.LiveView

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/k8/service/show.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/k8/service/show.ex
@@ -14,7 +14,9 @@ defmodule ControlServerWeb.Live.ServiceShow do
 
   @impl Phoenix.LiveView
   def mount(%{"name" => name, "namespace" => namespace}, _session, socket) do
-    :ok = KubeEventCenter.subscribe(@resource_type)
+    if connected?(socket) do
+      :ok = KubeEventCenter.subscribe(@resource_type)
+    end
 
     {:ok,
      socket

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/k8/stateful_set/show.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/k8/stateful_set/show.ex
@@ -15,7 +15,10 @@ defmodule ControlServerWeb.Live.StatefulSetShow do
 
   @impl Phoenix.LiveView
   def mount(%{"name" => name, "namespace" => namespace}, _session, socket) do
-    :ok = KubeEventCenter.subscribe(@resource_type)
+    if connected?(socket) do
+      :ok = KubeEventCenter.subscribe(@resource_type)
+    end
+
     resource = get_resource!(namespace, name)
 
     {:ok,

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/keycloak/realm.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/keycloak/realm.ex
@@ -12,7 +12,10 @@ defmodule ControlServerWeb.Live.KeycloakRealm do
 
   @impl Phoenix.LiveView
   def mount(%{} = _params, _session, socket) do
-    :ok = EventCenter.Keycloak.subscribe(:create_user)
+    if connected?(socket) do
+      :ok = EventCenter.Keycloak.subscribe(:create_user)
+    end
+
     {:ok, socket |> assign_keycloak_url() |> assign_current_page()}
   end
 

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/knative/show.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/knative/show.ex
@@ -22,9 +22,11 @@ defmodule ControlServerWeb.Live.KnativeShow do
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
-    :ok = KubeEventCenter.subscribe(:pod)
-    :ok = KubeEventCenter.subscribe(:knative_service)
-    :ok = KubeEventCenter.subscribe(:knative_revision)
+    if connected?(socket) do
+      :ok = KubeEventCenter.subscribe(:pod)
+      :ok = KubeEventCenter.subscribe(:knative_service)
+      :ok = KubeEventCenter.subscribe(:knative_revision)
+    end
 
     {:ok,
      socket

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/postgres/show.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/postgres/show.ex
@@ -17,8 +17,11 @@ defmodule ControlServerWeb.Live.PostgresShow do
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
-    :ok = KubeEventCenter.subscribe(:pod)
-    :ok = KubeEventCenter.subscribe(:cloudnative_pg_cluster)
+    if connected?(socket) do
+      :ok = KubeEventCenter.subscribe(:pod)
+      :ok = KubeEventCenter.subscribe(:cloudnative_pg_cluster)
+    end
+
     {:ok, socket}
   end
 

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/redis/show.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/redis/show.ex
@@ -14,9 +14,11 @@ defmodule ControlServerWeb.Live.RedisShow do
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
-    :ok = KubeEventCenter.subscribe(:pod)
-    :ok = KubeEventCenter.subscribe(:service)
-    :ok = KubeEventCenter.subscribe(:redis_failover)
+    if connected?(socket) do
+      :ok = KubeEventCenter.subscribe(:pod)
+      :ok = KubeEventCenter.subscribe(:service)
+      :ok = KubeEventCenter.subscribe(:redis_failover)
+    end
 
     {:ok,
      socket

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/state_summary.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/state_summary.ex
@@ -6,7 +6,9 @@ defmodule ControlServerWeb.Live.StateSummary do
   alias EventCenter.SystemStateSummary, as: SummaryEventCenter
 
   def mount(_params, _session, socket) do
-    :ok = SummaryEventCenter.subscribe()
+    if connected?(socket) do
+      :ok = SummaryEventCenter.subscribe()
+    end
 
     {:ok, socket |> assign_state_summary() |> assign_page_title()}
   end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/timeline.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/timeline.ex
@@ -12,7 +12,10 @@ defmodule ControlServerWeb.Live.Timeline do
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
-    :ok = DatabaseEventCenter.subscribe(:timeline_event)
+    if connected?(socket) do
+      :ok = DatabaseEventCenter.subscribe(:timeline_event)
+    end
+
     {:ok, assign(socket, :events, events())}
   end
 

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/trivy_reports/index.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/trivy_reports/index.ex
@@ -15,17 +15,16 @@ defmodule ControlServerWeb.Live.TrivyReportsIndex do
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
     live_action = socket.assigns.live_action
-    subscribe(live_action)
+
+    if connected?(socket) do
+      :ok = KubeEventCenter.subscribe(live_action)
+    end
 
     {:ok,
      socket
      |> assign(:objects, objects(live_action))
      |> assign(:page_title, title_text(live_action))
      |> assign_current_page()}
-  end
-
-  defp subscribe(resource_type) do
-    :ok = KubeEventCenter.subscribe(resource_type)
   end
 
   defp assign_current_page(socket) do


### PR DESCRIPTION
Summary:
On the dead view render there's no need to subscribe. That won't get
updated. On re-connect we will then subscribe.

Test Plan:
- Noticed that pods still change
