### PR TITLE
style: use tab_bar more for navigation

### DIFF
--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/router.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/router.ex
@@ -109,6 +109,7 @@ defmodule ControlServerWeb.Router do
 
     live "/pod/:namespace/:name/events", Live.PodShow, :events
     live "/pod/:namespace/:name/labels", Live.PodShow, :labels
+    live "/pod/:namespace/:name/annotations", Live.PodShow, :annotations
     live "/pod/:namespace/:name/security", Live.PodShow, :security
     live "/pod/:namespace/:name/logs", Live.PodShow, :logs
     live "/pod/:namespace/:name/show", Live.PodShow, :index


### PR DESCRIPTION
Summary:
- Trying things out to get a more workable show page template for other
  kube based things.

- Separate the labels and annotations pages

Test Plan:

- Visual

![image](https://github.com/user-attachments/assets/b6409493-bb56-4421-899b-b18f7932d38d)

![image](https://github.com/user-attachments/assets/3df84c4a-ecef-45a3-a194-2b0d0554592c)

- CI
