### PR TITLE
fix: bring back and fix the toggle btn for menu

### DIFF
--- a/static/src/components/common/BasicScripts.astro
+++ b/static/src/components/common/BasicScripts.astro
@@ -1,4 +1,27 @@
 <script is:inline>
+  // elements
+  const btnMenu = document.getElementById('btn-menu');
+  const btnClose = document.getElementById('btn-close');
+  const menu = document.getElementById('menu');
+
+  // functions
+  function openMenu() {
+    menu.classList.remove('-left-full');
+    menu.classList.add('left-0');
+  }
+
+  function closeMenu() {
+    menu.classList.remove('left-0');
+    menu.classList.add('-left-full');
+  }
+
+  // event listener
+
+  if (btnMenu && btnClose && menu) {
+    btnMenu.addEventListener('click', openMenu);
+    btnClose.addEventListener('click', closeMenu);
+  }
+
   function attachEvent(selector, event, fn) {
     const matches =
       typeof selector === 'string'
@@ -11,7 +34,7 @@
     }
   }
 
-  window.onload = function () {
+  window.addEventListener('DOMContentLoaded', function () {
     attachEvent('[data-aw-social-share]', 'click', function (_, elem) {
       const network = elem.getAttribute('data-aw-social-share');
       const url = encodeURIComponent(elem.getAttribute('data-aw-url'));
@@ -38,10 +61,11 @@
           return;
       }
 
+      // open new tab
       const newlink = document.createElement('a');
       newlink.target = '_blank';
       newlink.href = href;
       newlink.click();
     });
-  };
+  });
 </script>


### PR DESCRIPTION
Summary:

- I removed the btn code, but it was still used for mobile. So this
  reverts it.
- However it was not playing well with window.onload
- Also some pages might not have the menu, so this makes that not crash
  the scripts

Test:
- Tried locally on mobile
- CI
![image](https://github.com/user-attachments/assets/9559361c-fe85-41af-a843-04011ddd4ced)

![image](https://github.com/user-attachments/assets/71e0bebf-6a4b-4a2a-a44b-dec91fadf53f)

