### PR TITLE
feat: add ability to restrict batteries by usage

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/catalog.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/catalog.ex
@@ -354,6 +354,9 @@ defmodule CommonCore.Batteries.Catalog do
     Enum.filter(@all, &(&1.group == group))
   end
 
+  def all_for_usage(usage), do: Enum.filter(@all, &Enum.member?(&1.allowed_usages, usage))
+  def all_for_usage(usage, group), do: Enum.filter(all(group), &Enum.member?(&1.allowed_usages, usage))
+
   def get(type) when is_binary(type) do
     get(String.to_existing_atom(type))
   end

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/catalog_battery.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/catalog_battery.ex
@@ -4,6 +4,7 @@ defmodule CommonCore.Batteries.CatalogBattery do
 
   alias CommonCore.Batteries.SystemBattery
   alias CommonCore.Ecto.BatteryUUID
+  alias CommonCore.Installs.Options
 
   typedstruct do
     field :type, atom(), enforce: true
@@ -12,6 +13,7 @@ defmodule CommonCore.Batteries.CatalogBattery do
     field :name, String.t(), enforce: true
     field :description, String.t(), default: ""
     field :uninstallable, boolean(), default: true
+    field :allowed_usages, list(atom()), default: Keyword.values(Options.usages())
   end
 
   def to_fresh_args(%__MODULE__{} = catalog_battery) do

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/batteries_form.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/batteries_form.ex
@@ -15,12 +15,14 @@ defmodule ControlServerWeb.Projects.BatteriesForm do
 
   def mount(socket) do
     groups = Catalog.groups_for_projects()
+    core_battery = KubeServices.SystemState.SummaryBatteries.core_battery()
 
     {:ok,
      socket
      |> assign(:class, nil)
      |> assign(:tab, :required)
-     |> assign(:groups, groups)}
+     |> assign(:groups, groups)
+     |> assign(:usage, core_battery.config.usage)}
   end
 
   def update(assigns, socket) do
@@ -164,7 +166,10 @@ defmodule ControlServerWeb.Projects.BatteriesForm do
 
           <%= for group <- @groups do %>
             <.battery_toggle
-              :for={battery <- search_filter(Catalog.all(group.type), @form[:search].value)}
+              :for={
+                battery <-
+                  search_filter(Catalog.all_for_usage(@usage, group.type), @form[:search].value)
+              }
               :if={@tab == group.type}
               installed={has_battery?(@installed, battery)}
               required={has_battery?(@required, battery)}
@@ -174,7 +179,7 @@ defmodule ControlServerWeb.Projects.BatteriesForm do
           <% end %>
 
           <.battery_toggle
-            :for={battery <- search_filter(Catalog.all(), @form[:search].value)}
+            :for={battery <- search_filter(Catalog.all_for_usage(@usage), @form[:search].value)}
             :if={@tab == :all}
             installed={has_battery?(@installed, battery)}
             required={has_battery?(@required, battery)}

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/group_batteries/index.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/group_batteries/index.ex
@@ -12,13 +12,14 @@ defmodule ControlServerWeb.Live.GroupBatteriesIndex do
     end
 
     group = Catalog.group(group)
+    core_battery = KubeServices.SystemState.SummaryBatteries.core_battery()
 
     {:ok,
      socket
      |> assign(:group, group)
      |> assign(:current_page, group.type)
      |> assign(:page_title, "#{String.trim_trailing(group.name, "s")} Batteries")
-     |> assign(:catalog_batteries, Catalog.all(group.type))
+     |> assign(:catalog_batteries, Catalog.all_for_usage(core_battery.config.usage, group.type))
      |> assign_system_batteries(group)}
   end
 

--- a/platform_umbrella/apps/control_server_web/test/components/projects/batteries_form_test.exs
+++ b/platform_umbrella/apps/control_server_web/test/components/projects/batteries_form_test.exs
@@ -1,9 +1,17 @@
 defmodule ControlServerWeb.Projects.BatteriesFormTest do
-  use ExUnit.Case
+  use ControlServerWeb.ConnCase
 
   import Phoenix.LiveViewTest
 
+  alias ControlServer.Batteries.Installer
   alias ControlServerWeb.Projects.BatteriesForm
+  alias KubeServices.SystemState.Summarizer
+
+  setup do
+    Installer.install!(:battery_core)
+    Summarizer.new()
+    :ok
+  end
 
   test "should render project batteries form" do
     assert render_component(BatteriesForm, id: "project-batteries-form", inner_block: [], data: %{}) =~

--- a/platform_umbrella/apps/control_server_web/test/live/group_batteries/index_test.exs
+++ b/platform_umbrella/apps/control_server_web/test/live/group_batteries/index_test.exs
@@ -2,6 +2,15 @@ defmodule ControlServerWeb.GroupBatteries.IndexLiveTest do
   use Heyya.LiveCase
   use ControlServerWeb.ConnCase
 
+  alias ControlServer.Batteries.Installer
+  alias KubeServices.SystemState.Summarizer
+
+  setup ctx do
+    Installer.install!(:battery_core)
+    Summarizer.new()
+    ctx
+  end
+
   describe "magic group batteries" do
     test "can list the group batteries", %{conn: conn} do
       conn

--- a/platform_umbrella/apps/control_server_web/test/live/project_live_test.exs
+++ b/platform_umbrella/apps/control_server_web/test/live/project_live_test.exs
@@ -4,6 +4,9 @@ defmodule ControlServerWeb.ProjectLiveTest do
   import ControlServer.ProjectsFixtures
   import Phoenix.LiveViewTest
 
+  alias ControlServer.Batteries.Installer
+  alias KubeServices.SystemState.Summarizer
+
   setup do
     %{project: project_fixture()}
   end
@@ -21,6 +24,8 @@ defmodule ControlServerWeb.ProjectLiveTest do
   describe "/projects/new" do
     @tag :slow
     test "should go through the new project flow", %{conn: conn} do
+      Installer.install!(:battery_core)
+      Summarizer.new()
       {:ok, view, _html} = live(conn, ~p"/projects/new")
 
       assert view

--- a/platform_umbrella/apps/kube_services/lib/kube_services/system_state/summary_batteries.ex
+++ b/platform_umbrella/apps/kube_services/lib/kube_services/system_state/summary_batteries.ex
@@ -12,6 +12,9 @@ defmodule KubeServices.SystemState.SummaryBatteries do
 
   alias CommonCore.StateSummary
   alias CommonCore.StateSummary.Batteries
+  alias CommonCore.StateSummary.Core
+  alias CommonCore.StateSummary.Namespaces
+  alias CommonCore.StateSummary.SSL
   alias EventCenter.SystemStateSummary
   alias KubeServices.SystemState.Summarizer
 
@@ -71,28 +74,39 @@ defmodule KubeServices.SystemState.SummaryBatteries do
     {:reply, false, state}
   end
 
+  @impl GenServer
+  def handle_call(:core_battery, _from, %{summary: %StateSummary{} = summary} = state) do
+    {:reply, Core.get_battery_core(summary), state}
+  end
+
+  @impl GenServer
   def handle_call(:default_size, _, %{summary: %StateSummary{} = summary} = state) do
-    {:reply, StateSummary.Core.config_field(summary, :default_size) || :tiny, state}
+    {:reply, Core.config_field(summary, :default_size) || :tiny, state}
   end
 
+  @impl GenServer
   def handle_call(:ai_namespace, _from, %{summary: %StateSummary{} = summary} = state) do
-    {:reply, StateSummary.Namespaces.ai_namespace(summary), state}
+    {:reply, Namespaces.ai_namespace(summary), state}
   end
 
+  @impl GenServer
   def handle_call(:core_namespace, _from, %{summary: %StateSummary{} = summary} = state) do
-    {:reply, StateSummary.Namespaces.core_namespace(summary), state}
+    {:reply, Namespaces.core_namespace(summary), state}
   end
 
+  @impl GenServer
   def handle_call(:knative_namespace, _from, %{summary: %StateSummary{} = summary} = state) do
-    {:reply, StateSummary.Namespaces.knative_namespace(summary), state}
+    {:reply, Namespaces.knative_namespace(summary), state}
   end
 
+  @impl GenServer
   def handle_call(:traditional_namespace, _from, %{summary: %StateSummary{} = summary} = state) do
-    {:reply, StateSummary.Namespaces.traditional_namespace(summary), state}
+    {:reply, Namespaces.traditional_namespace(summary), state}
   end
 
+  @impl GenServer
   def handle_call(:ssl_enabled?, _from, %{summary: %StateSummary{} = summary} = state) do
-    {:reply, StateSummary.SSL.ssl_enabled?(summary), state}
+    {:reply, SSL.ssl_enabled?(summary), state}
   end
 
   # Is the battery installed?
@@ -109,6 +123,10 @@ defmodule KubeServices.SystemState.SummaryBatteries do
 
   def installed_batteries(target, group) do
     GenServer.call(target, {:installed_batteries, group})
+  end
+
+  def core_battery(target \\ @me) do
+    GenServer.call(target, :core_battery)
   end
 
   def default_size(target \\ @me) do


### PR DESCRIPTION
This filters out batteries from the UI if the install's usage isn't allowed. This is a form of course grained feature flagging so that we can work on features without them being generally available.

Does not currently restrict battery from being installed just removes it from the UI. We could always add that if needed.
Are there any other places where we should filter / hide these batteries?