### PR TITLE
feat(project): add initial export functionality to UI

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/projects/project.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/projects/project.ex
@@ -60,4 +60,18 @@ defmodule CommonCore.Projects.Project do
       :traditional_services
     ]
   end
+
+  def export(%__MODULE__{} = project) do
+    Jason.encode(project)
+  end
+
+  def export!(%__MODULE__{} = project) do
+    case export(project) do
+      {:ok, json} ->
+        json
+
+      {:error, err} ->
+        raise "Error exporting project: #{inspect(err)}"
+    end
+  end
 end

--- a/platform_umbrella/apps/common_core/test/common_core/projects/project_test.exs
+++ b/platform_umbrella/apps/common_core/test/common_core/projects/project_test.exs
@@ -1,0 +1,14 @@
+defmodule CommonCore.Projects.ProjectTest do
+  use ExUnit.Case
+
+  import CommonCore.Factory
+
+  alias CommonCore.Projects.Project
+
+  describe "export" do
+    test "export/1" do
+      assert {:ok, exp} = Project.export(build(:project))
+      assert is_binary(exp)
+    end
+  end
+end

--- a/platform_umbrella/apps/common_core/test/support/factory.ex
+++ b/platform_umbrella/apps/common_core/test/support/factory.ex
@@ -6,9 +6,12 @@ defmodule CommonCore.Factory do
   use ExMachina
 
   alias CommonCore.Ecto.BatteryUUID
+  alias CommonCore.FerretDB.FerretService
   alias CommonCore.Installs.Options
+  alias CommonCore.Notebooks.JupyterLabNotebook
   alias CommonCore.OpenAPI.KeycloakAdminSchema.ClientRepresentation
   alias CommonCore.OpenAPI.KeycloakAdminSchema.RealmRepresentation
+  alias CommonCore.Projects.Project
   alias CommonCore.StateSummary.KeycloakSummary
 
   # with Ecto
@@ -236,5 +239,63 @@ defmodule CommonCore.Factory do
 
   def client_factory do
     %ClientRepresentation{id: BatteryUUID.autogenerate(), name: sequence("keycloak-client")}
+  end
+
+  def project_factory do
+    %Project{
+      name: sequence("project-"),
+      type: sequence(:type, [:web, :ai, :db]),
+      description: sequence("description-"),
+      postgres_clusters: [build(:postgres)],
+      redis_instances: [build(:redis)],
+      ferret_services: [build(:ferret_service)],
+      jupyter_notebooks: [build(:jupyter_lab_notebook)],
+      knative_services: [build(:knative_service)],
+      traditional_services: [build(:traditional_service)]
+    }
+  end
+
+  def knative_service_factory do
+    %CommonCore.Knative.Service{
+      name: sequence("knative-service-"),
+      rollout_duration: sequence(:rollout_duration, ["10s", "1m", "2m", "10m", "20m", "30m"]),
+      oauth2_proxy: sequence(:oauth2_proxy, [true, false]),
+      keycloak_realm: sequence("realm_"),
+      containers: [build(:containers_container)],
+      env_values: [build(:containers_env_value), build(:containers_env_value)]
+    }
+  end
+
+  def traditional_service_factory do
+    %CommonCore.TraditionalServices.Service{
+      name: sequence("knative-service-"),
+      virtual_size: sequence(:virtual_size, ~w(tiny small medium large xlarge huge)),
+      kube_deployment_type: sequence(:kube_deployment_type, [:statefulset, :deployment]),
+      num_instances: sequence(:num_instances, [1, 2, 3, 4]),
+      containers: [build(:containers_container)],
+      env_values: [build(:containers_env_value), build(:containers_env_value)]
+    }
+  end
+
+  def jupyter_lab_notebook_factory do
+    %JupyterLabNotebook{
+      name: sequence("kube-notebook-"),
+      storage_size: 500 * 1024 * 1024,
+      storage_class: "default"
+    }
+  end
+
+  def ferret_service_factory do
+    %FerretService{
+      postgres_cluster: build(:postgres)
+    }
+  end
+
+  def containers_container_factory do
+    %CommonCore.Containers.Container{name: sequence("container-"), image: "nginx:latest"}
+  end
+
+  def containers_env_value_factory do
+    %CommonCore.Containers.EnvValue{name: sequence("env-value-"), value: "test", source_type: :value}
   end
 end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/projects/show.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/projects/show.ex
@@ -31,7 +31,8 @@ defmodule ControlServerWeb.Live.ProjectsShow do
      |> assign_project(id)
      |> assign_page_title()
      |> assign_pods()
-     |> assign_grafana_dashboard()}
+     |> assign_grafana_dashboard()
+     |> assign_export_enabled()}
   end
 
   defp assign_timeline_installed(socket) do
@@ -77,6 +78,10 @@ defmodule ControlServerWeb.Live.ProjectsShow do
       end
 
     assign(socket, :grafana_dashboard_url, url)
+  end
+
+  defp assign_export_enabled(socket) do
+    assign(socket, :export_enabled, SummaryBatteries.battery_installed(:project_export))
   end
 
   @impl Phoenix.LiveView
@@ -170,6 +175,18 @@ defmodule ControlServerWeb.Live.ProjectsShow do
           />
 
           <.button
+            :if={@export_enabled}
+            variant="icon"
+            icon={:arrow_down_tray}
+            id={"export_project_" <> @project.id}
+            phx-click={show_modal("project-export-modal-" <> @project.id)}
+          />
+
+          <.tooltip :if={@export_enabled} target_id={"export_project_" <> @project.id}>
+            Export Project
+          </.tooltip>
+
+          <.button
             id="delete-tooltip"
             variant="icon"
             icon={:trash}
@@ -249,6 +266,15 @@ defmodule ControlServerWeb.Live.ProjectsShow do
         <.pods_table pods={@pods} />
       </.panel>
     </.grid>
+    <.modal
+      :if={@export_enabled}
+      id={"project-export-modal-" <> @project.id}
+      size="lg"
+      class="p-2 pt-4"
+    >
+      <:title>Export project</:title>
+      <.script template="@src" src={Project.export!(@project)} link_url="#" />
+    </.modal>
     """
   end
 end


### PR DESCRIPTION
I tried to add the export button on the index pages as well but was running into a bunch of issues. This just adds the simplest export functionality (without any filtering) and makes it accessible through the UI if the feature is enabled.