### PR TITLE
feat: allow starting an ollama model in AI projects

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/defaults/images.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/defaults/images.ex
@@ -170,8 +170,8 @@ defmodule CommonCore.Defaults.Images do
     ollama:
       Image.new!(%{
         name: "ollama/ollama",
-        tags: ~w(0.3.9 0.3.10),
-        default_tag: "0.3.10"
+        tags: ~w(0.3.9 0.3.10 0.5.7),
+        default_tag: "0.5.7"
       }),
     oauth2_proxy:
       Image.new!(%{

--- a/platform_umbrella/apps/control_server/lib/control_server/ollama.ex
+++ b/platform_umbrella/apps/control_server/lib/control_server/ollama.ex
@@ -27,6 +27,21 @@ defmodule ControlServer.Ollama do
   end
 
   @doc """
+  Returns the list of model instance names and ids available for a project (not assigned to any project).
+
+  ## Examples
+
+      iex> model_instances_available_for_project()
+      [{_, _}, ...]
+
+  """
+  def model_instances_available_for_project do
+    from(c in ModelInstance, where: is_nil(c.project_id))
+    |> Repo.all()
+    |> Enum.map(&{&1.name, &1.id})
+  end
+
+  @doc """
   Gets a single model_instance.
 
   Raises `Ecto.NoResultsError` if the Model instance does not exist.

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/ollama/form_component.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/ollama/form_component.ex
@@ -1,10 +1,11 @@
-defmodule ControlServerWeb.Live.Ollama.FormComponent do
+defmodule ControlServerWeb.Live.OllamaFormComponent do
   @moduledoc false
 
   use ControlServerWeb, :live_component
 
+  import ControlServerWeb.OllamaFormSubcomponents
+
   alias CommonCore.Ollama.ModelInstance
-  alias CommonCore.Util.Memory
   alias ControlServer.Ollama
   alias ControlServer.Projects
   alias KubeServices.SystemState.SummaryBatteries
@@ -102,35 +103,10 @@ defmodule ControlServerWeb.Live.Ollama.FormComponent do
 
         <.grid columns={[sm: 1, lg: 2]}>
           <.panel>
-            <.grid columns={[sm: 1, lg: 2]} class="items-center">
-              <.input field={@form[:name]} label="Name" />
-              <.input
-                field={@form[:model]}
-                label="Model"
-                type="select"
-                placeholder="Select Model"
-                options={ModelInstance.model_options_for_select()}
-              />
-            </.grid>
+            <.model_form form={@form} action={@action} />
           </.panel>
           <.panel variant="gray">
-            <.flex column>
-              <.input
-                field={@form[:virtual_size]}
-                type="select"
-                label="Size"
-                placeholder="Choose a size"
-                options={ModelInstance.preset_options_for_select()}
-              />
-
-              <.data_list
-                variant="horizontal-bolded"
-                data={[
-                  {"Memory limits:", Memory.humanize(@form[:memory_limits].value)},
-                  {"CPU Request:", @form[:cpu_requested].value}
-                ]}
-              />
-            </.flex>
+            <.size_form form={@form} />
           </.panel>
         </.grid>
       </.form>

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/ollama/form_subcomponents.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/ollama/form_subcomponents.ex
@@ -1,0 +1,61 @@
+defmodule ControlServerWeb.OllamaFormSubcomponents do
+  @moduledoc false
+  use ControlServerWeb, :html
+
+  alias CommonCore.Ollama.ModelInstance
+  alias CommonCore.Util.Memory
+
+  attr :class, :any, default: nil
+  attr :form, :any, required: true
+  attr :action, :atom, default: nil
+
+  def model_form(assigns) do
+    dbg(assigns)
+
+    ~H"""
+    <.fieldset responsive class={@class}>
+      <.field>
+        <:label>Name</:label>
+        <.input field={@form[:name]} autofocus={@action == :new} disabled={@action != :new} />
+      </.field>
+
+      <.field>
+        <:label>Model</:label>
+        <.input
+          field={@form[:model]}
+          type="select"
+          placeholder="Select Model"
+          options={ModelInstance.model_options_for_select()}
+        />
+      </.field>
+    </.fieldset>
+    """
+  end
+
+  attr :class, :any, default: nil
+  attr :form, :any, required: true
+
+  def size_form(assigns) do
+    ~H"""
+    <.fieldset class={@class}>
+      <.field>
+        <:label>Size</:label>
+        <.input
+          field={@form[:virtual_size]}
+          type="select"
+          placeholder="Choose a size"
+          options={ModelInstance.preset_options_for_select()}
+        />
+      </.field>
+
+      <.data_list
+        variant="horizontal-bolded"
+        data={[
+          {"Memory limits:", Memory.humanize(@form[:memory_limits].value)},
+          {"CPU Request:", @form[:cpu_requested].value}
+        ]}
+      />
+    </.fieldset>
+    """
+  end
+end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/ollama/form_subcomponents.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/ollama/form_subcomponents.ex
@@ -10,8 +10,6 @@ defmodule ControlServerWeb.OllamaFormSubcomponents do
   attr :action, :atom, default: nil
 
   def model_form(assigns) do
-    dbg(assigns)
-
     ~H"""
     <.fieldset responsive class={@class}>
       <.field>

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/ai_form.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/ai_form.ex
@@ -130,15 +130,7 @@ defmodule ControlServerWeb.Projects.AIForm do
   def handle_event("save", params, socket) do
     params =
       params
-      |> Map.take([
-        "need_postgres",
-        "need_ollama",
-        "jupyter",
-        if(normalize_value("checkbox", params["need_postgres"]) && params["db_type"] == "new", do: "postgres"),
-        if(normalize_value("checkbox", params["need_postgres"]) && params["db_type"] == "existing", do: "postgres_ids"),
-        if(normalize_value("checkbox", params["need_ollama"]) && params["ollama_type"] == "new", do: "ollama"),
-        if(normalize_value("checkbox", params["need_ollama"]) && params["ollama_type"] == "existing", do: "ollama_ids")
-      ])
+      |> clean_params()
       |> Map.put("db_type", socket.assigns.db_type)
       |> Map.put("ollama_type", socket.assigns.ollama_type)
 
@@ -152,6 +144,18 @@ defmodule ControlServerWeb.Projects.AIForm do
     end
 
     {:noreply, socket}
+  end
+
+  defp clean_params(params) do
+    Map.take(params, [
+      "need_postgres",
+      "need_ollama",
+      "jupyter",
+      if(normalize_value("checkbox", params["need_postgres"]) && params["db_type"] == "new", do: "postgres"),
+      if(normalize_value("checkbox", params["need_postgres"]) && params["db_type"] == "existing", do: "postgres_ids"),
+      if(normalize_value("checkbox", params["need_ollama"]) && params["ollama_type"] == "new", do: "ollama"),
+      if(normalize_value("checkbox", params["need_ollama"]) && params["ollama_type"] == "existing", do: "ollama_ids")
+    ])
   end
 
   def render(assigns) do

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/batteries_form.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/batteries_form.ex
@@ -261,6 +261,7 @@ defmodule ControlServerWeb.Projects.BatteriesForm do
           "ferret" -> [:ferretdb]
           "jupyter" -> [:notebooks]
           "knative" -> [:knative]
+          "ollama" -> [:ollama]
           "traditional" -> [:traditional_services]
           _ -> nil
         end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/batteries_form.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/batteries_form.ex
@@ -251,26 +251,28 @@ defmodule ControlServerWeb.Projects.BatteriesForm do
   # This is recursive, so it will also get all the dependencies for each battery.
   defp required_batteries(data) do
     data
-    |> Enum.map(fn {_, v} ->
-      Enum.map(
-        Map.keys(v),
-        &case &1 do
-          "postgres" -> [:cloudnative_pg]
-          "postgres_ids" -> [:cloudnative_pg]
-          "redis" -> [:redis]
-          "ferret" -> [:ferretdb]
-          "jupyter" -> [:notebooks]
-          "knative" -> [:knative]
-          "ollama" -> [:ollama]
-          "traditional" -> [:traditional_services]
-          _ -> nil
-        end
-      )
-    end)
+    |> Enum.map(&required_from_step/1)
     |> List.flatten()
     |> Enum.filter(&(&1 != nil))
-    |> Enum.map(&Catalog.get_recursive/1)
-    |> List.flatten()
+    |> Enum.flat_map(&Catalog.get_recursive/1)
     |> Enum.uniq()
   end
+
+  # This takes a single step form and figured out the batteries needed for that step.
+  defp required_from_step({_, v}) do
+    Enum.map(Map.keys(v), &required_batteries_from_form_name/1)
+  end
+
+  # Take all the inner form keys and determine what batteries are needed to run those
+  # requested services.
+
+  defp required_batteries_from_form_name("postgres"), do: [:cloudnative_pg]
+  defp required_batteries_from_form_name("postgres_ids"), do: [:cloudnative_pg]
+  defp required_batteries_from_form_name("redis"), do: [:redis]
+  defp required_batteries_from_form_name("ferret"), do: [:ferretdb]
+  defp required_batteries_from_form_name("jupyter"), do: [:notebooks]
+  defp required_batteries_from_form_name("knative"), do: [:knative]
+  defp required_batteries_from_form_name("ollama"), do: [:ollama]
+  defp required_batteries_from_form_name("traditional"), do: [:traditional_services]
+  defp required_batteries_from_form_name(_), do: nil
 end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/ollama/edit.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/ollama/edit.ex
@@ -3,7 +3,7 @@ defmodule ControlServerWeb.Live.OllamaModelInstanceEdit do
   use ControlServerWeb, {:live_view, layout: :sidebar}
 
   alias ControlServer.Ollama
-  alias ControlServerWeb.Live.Ollama.FormComponent
+  alias ControlServerWeb.Live.OllamaFormComponent
 
   def mount(%{"id" => id}, _session, socket) do
     model_instance = Ollama.get_model_instance!(id, preload: [:project])
@@ -18,7 +18,7 @@ defmodule ControlServerWeb.Live.OllamaModelInstanceEdit do
   def render(assigns) do
     ~H"""
     <.live_component
-      module={FormComponent}
+      module={OllamaFormComponent}
       model_instance={@model_instance}
       id="model_instances-form"
       action={:edit}

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/ollama/new.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/ollama/new.ex
@@ -3,7 +3,7 @@ defmodule ControlServerWeb.Live.OllamaModelInstanceNew do
   use ControlServerWeb, {:live_view, layout: :sidebar}
 
   alias CommonCore.Ollama.ModelInstance
-  alias ControlServerWeb.Live.Ollama.FormComponent
+  alias ControlServerWeb.Live.OllamaFormComponent
   alias KubeServices.SmartBuilder
 
   def mount(params, _session, socket) do
@@ -21,7 +21,7 @@ defmodule ControlServerWeb.Live.OllamaModelInstanceNew do
   def render(assigns) do
     ~H"""
     <.live_component
-      module={FormComponent}
+      module={OllamaFormComponent}
       model_instance={@model_instance}
       id="model_instance-form"
       action={:new}

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/projects/new.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/projects/new.ex
@@ -14,6 +14,7 @@ defmodule ControlServerWeb.Live.ProjectsNew do
   alias ControlServer.FerretDB
   alias ControlServer.Knative
   alias ControlServer.Notebooks
+  alias ControlServer.Ollama
   alias ControlServer.Postgres
   alias ControlServer.Projects
   alias ControlServer.Redis
@@ -106,6 +107,7 @@ defmodule ControlServerWeb.Live.ProjectsNew do
          {:ok, _db_redis} <- create_redis(project, form_data[DatabaseForm]),
          {:ok, _db_ferret} <- create_ferret(project, form_data[DatabaseForm], db_pg),
          {:ok, ai_pg} <- create_postgres(project, form_data[AIForm]),
+         {:ok, _ai_ollama} <- create_ollama(project, form_data[AIForm]),
          {:ok, _ai_notebook} <- create_jupyter(project, form_data[AIForm], ai_pg),
          {:ok, web_pg} <- create_postgres(project, form_data[WebForm]),
          {:ok, web_redis} <- create_redis(project, form_data[WebForm]),
@@ -189,6 +191,14 @@ defmodule ControlServerWeb.Live.ProjectsNew do
   end
 
   defp create_ferret(_project, _ferret_data, _pg), do: {:ok, nil}
+
+  defp create_ollama(project, %{"ollama" => ollama_data}) do
+    ollama_data
+    |> Map.put("project_id", project.id)
+    |> Ollama.create_model_instance()
+  end
+
+  defp create_ollama(_project, _ollama_data), do: {:ok, nil}
 
   defp create_jupyter(project, %{"jupyter" => jupyter_data}, pg) do
     jupyter_data


### PR DESCRIPTION
Summary:
- Split the ModelInstance forms into sub forms usable in project flow
- Add the model instance form to the AI project steps.

Test Plan:
![image](https://github.com/user-attachments/assets/2da4f693-6519-4413-bb1d-edf3d34b9b8b)

