### PR TITLE
docs: sort docs categories and hide un-used sections

### DIFF
--- a/static/src/pages/docs/[...page].astro
+++ b/static/src/pages/docs/[...page].astro
@@ -57,55 +57,63 @@ const metadata = {
 
       <div class="space-y-16">
         <!-- Getting Started -->
-        <section>
-          <h2 class="text-2xl font-bold text-gray-900 mb-6">Getting Started</h2>
-          <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-            {
-              categorizedDocs.gettingStarted.map((doc) => (
-                <a
-                  href={getPermalink(doc.permalink, 'docs')}
-                  class="block p-6 bg-white rounded-lg shadow-sm hover:shadow-md transition-shadow duration-200">
-                  <h3 class="text-xl font-semibold mb-2">{doc.title}</h3>
-                  <p class="text-gray-600 text-sm">{doc.description}</p>
-                </a>
-              ))
-            }
-          </div>
-        </section>
+        {
+          categorizedDocs.gettingStarted.length != 0 && (
+            <section>
+              <h2 class="text-2xl font-bold text-gray-900 mb-6">
+                Getting Started
+              </h2>
+              <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+                {categorizedDocs.gettingStarted.map((doc) => (
+                  <a
+                    href={getPermalink(doc.permalink, 'docs')}
+                    class="block p-6 bg-white rounded-lg shadow-sm hover:shadow-md transition-shadow duration-200">
+                    <h3 class="text-xl font-semibold mb-2">{doc.title}</h3>
+                    <p class="text-gray-600 text-sm">{doc.description}</p>
+                  </a>
+                ))}
+              </div>
+            </section>
+          )
+        }
 
         <!-- Batteries -->
-        <section>
-          <h2 class="text-2xl font-bold text-gray-900 mb-6">Batteries</h2>
-          <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-            {
-              categorizedDocs.batteries.map((doc) => (
-                <a
-                  href={getPermalink(doc.permalink, 'docs')}
-                  class="block p-6 bg-white rounded-lg shadow-sm hover:shadow-md transition-shadow duration-200">
-                  <h3 class="text-xl font-semibold mb-2">{doc.title}</h3>
-                  <p class="text-gray-600 text-sm">{doc.description}</p>
-                </a>
-              ))
-            }
-          </div>
-        </section>
+        {
+          categorizedDocs.batteries.length != 0 && (
+            <section>
+              <h2 class="text-2xl font-bold text-gray-900 mb-6">Batteries</h2>
+              <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+                {categorizedDocs.batteries.map((doc) => (
+                  <a
+                    href={getPermalink(doc.permalink, 'docs')}
+                    class="block p-6 bg-white rounded-lg shadow-sm hover:shadow-md transition-shadow duration-200">
+                    <h3 class="text-xl font-semibold mb-2">{doc.title}</h3>
+                    <p class="text-gray-600 text-sm">{doc.description}</p>
+                  </a>
+                ))}
+              </div>
+            </section>
+          )
+        }
 
         <!-- Development -->
-        <section>
-          <h2 class="text-2xl font-bold text-gray-900 mb-6">Development</h2>
-          <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-            {
-              categorizedDocs.development.map((doc) => (
-                <a
-                  href={getPermalink(doc.permalink, 'docs')}
-                  class="block p-6 bg-white rounded-lg shadow-sm hover:shadow-md transition-shadow duration-200">
-                  <h3 class="text-xl font-semibold mb-2">{doc.title}</h3>
-                  <p class="text-gray-600 text-sm">{doc.description}</p>
-                </a>
-              ))
-            }
-          </div>
-        </section>
+        {
+          categorizedDocs.development.length != 0 && (
+            <section>
+              <h2 class="text-2xl font-bold text-gray-900 mb-6">Development</h2>
+              <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+                {categorizedDocs.development.map((doc) => (
+                  <a
+                    href={getPermalink(doc.permalink, 'docs')}
+                    class="block p-6 bg-white rounded-lg shadow-sm hover:shadow-md transition-shadow duration-200">
+                    <h3 class="text-xl font-semibold mb-2">{doc.title}</h3>
+                    <p class="text-gray-600 text-sm">{doc.description}</p>
+                  </a>
+                ))}
+              </div>
+            </section>
+          )
+        }
       </div>
 
       <div class="mt-12">

--- a/static/src/utils/docs.ts
+++ b/static/src/utils/docs.ts
@@ -67,7 +67,6 @@ const load = async function (): Promise<Array<Doc>> {
       const aCategory = categoryOrder.indexOf(a.category || 'uncategorized');
       const bCategory = categoryOrder.indexOf(b.category || 'uncategorized');
       if (aCategory === bCategory) {
-        console.log(a.category, b.category);
         return a.title.localeCompare(b.title);
       }
       return aCategory - bCategory;

--- a/static/src/utils/docs.ts
+++ b/static/src/utils/docs.ts
@@ -54,9 +54,25 @@ const load = async function (): Promise<Array<Doc>> {
 
   const normalizedDocs = docs.map(async (doc) => await getNormalizedDoc(doc));
 
-  const results = (await Promise.all(normalizedDocs)).filter(
-    (doc) => !doc.draft
-  );
+  const categoryOrder = [
+    'getting-started',
+    'batteries',
+    'development',
+    'uncategorized',
+  ];
+
+  const results = (await Promise.all(normalizedDocs))
+    .filter((doc) => !doc.draft)
+    .sort((a, b) => {
+
+      const aCategory = categoryOrder.indexOf(a.category || 'uncategorized');
+      const bCategory = categoryOrder.indexOf(b.category || 'uncategorized');
+      if (aCategory === bCategory) {
+        console.log(a.category, b.category);
+        return a.title.localeCompare(b.title);
+      }
+      return aCategory - bCategory;
+    });
 
   return results;
 };

--- a/static/src/utils/docs.ts
+++ b/static/src/utils/docs.ts
@@ -64,7 +64,6 @@ const load = async function (): Promise<Array<Doc>> {
   const results = (await Promise.all(normalizedDocs))
     .filter((doc) => !doc.draft)
     .sort((a, b) => {
-
       const aCategory = categoryOrder.indexOf(a.category || 'uncategorized');
       const bCategory = categoryOrder.indexOf(b.category || 'uncategorized');
       if (aCategory === bCategory) {


### PR DESCRIPTION
Summary:
As we add more docs we want the getting started to be first so lets
codify that now. With that there are usually empty getting started
sections on non starting pages. So hide those

Test Plan:
- Netlify
- Visual
![image](https://github.com/user-attachments/assets/b24b358d-ace1-4f7a-83f8-397333413c95)

