### PR TITLE
refactor: restructur the postgres show page to allow more subpages

### DIFF
--- a/platform_umbrella/apps/common_ui/lib/common_ui/components/data_list.ex
+++ b/platform_umbrella/apps/common_ui/lib/common_ui/components/data_list.ex
@@ -3,7 +3,10 @@ defmodule CommonUI.Components.DataList do
   use CommonUI, :component
 
   import CommonUI.Components.Container
+  import CommonUI.Components.Icon
+  import CommonUI.Components.Tooltip
   import CommonUI.Components.Typography
+  import CommonUI.IDHelpers
 
   attr :variant, :string, values: ["horizontal-plain", "horizontal-bolded"]
   attr :data, :list, doc: "data to display. A list of tuples: [{key, value}, {key, value}]"
@@ -14,6 +17,7 @@ defmodule CommonUI.Components.DataList do
 
   slot :item do
     attr :title, :string, required: true
+    attr :help, :string
   end
 
   def data_list(%{variant: "horizontal-plain"} = assigns) do
@@ -47,6 +51,8 @@ defmodule CommonUI.Components.DataList do
   end
 
   def data_list(assigns) do
+    assigns = provide_id(assigns)
+
     ~H"""
     <div
       class={[
@@ -55,9 +61,21 @@ defmodule CommonUI.Components.DataList do
       ]}
       {@rest}
     >
-      <%= for item <- @item do %>
+      <%= for {item, idx} <- Enum.with_index(@item) do %>
         <div class="text-gray-light text-md font-medium leading-5">
           {item.title}
+          <div :if={item[:help]} class="inline-block ml-1 align-middle">
+            <.icon
+              solid
+              id={"#{@id}-#{idx}-help"}
+              name={:question_mark_circle}
+              class="size-5 opacity-30 hover:opacity-100"
+            />
+
+            <.tooltip target_id={"#{@id}-#{idx}-help"}>
+              {item.help}
+            </.tooltip>
+          </div>
         </div>
 
         <div class="text-base leading-5">

--- a/platform_umbrella/apps/common_ui/storybook/components/data_list.story.exs
+++ b/platform_umbrella/apps/common_ui/storybook/components/data_list.story.exs
@@ -12,7 +12,7 @@ defmodule Storybook.Components.DataList do
         slots: [
           ~s|<:item title="First">Main Text</:item>|,
           ~s|<:item title="Field Name">More Text</:item>|,
-          ~s|<:item title="Views">200</:item>|
+          ~s|<:item title="Views" help="The total views bots have driven to twitter">200B</:item>|
         ]
       },
       %Variation{

--- a/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/data_list_test/test_default_datalist_with_help.heyya_snap
+++ b/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/data_list_test/test_default_datalist_with_help.heyya_snap
@@ -33,8 +33,20 @@
     </div>
   
     <div class="text-gray-light text-md font-medium leading-5">
-      Anohter
-      
+      Another
+      <div class="inline-block ml-1 align-middle">
+        <svg xmlns="http://www.w3.org/2000/svg" id="my-datalist-2-help" class="size-5 opacity-30 hover:opacity-100" aria-hidden="true" fill="currentColor" viewBox="0 0 24 24">
+  <path fill-rule="evenodd" d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm11.378-3.917c-.89-.777-2.366-.777-3.255 0a.75.75 0 0 1-.988-1.129c1.454-1.272 3.776-1.272 5.23 0 1.513 1.324 1.513 3.518 0 4.842a3.75 3.75 0 0 1-.837.552c-.676.328-1.028.774-1.028 1.152v.75a.75.75 0 0 1-1.5 0v-.75c0-1.279 1.06-2.107 1.875-2.502.182-.088.351-.199.503-.331.83-.727.83-1.857 0-2.584ZM12 18a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z" clip-rule="evenodd"/>
+</svg>
+
+        <div class="hidden" id="tooltip-my-datalist-2-help" phx-hook="Tooltip" data-target="my-datalist-2-help" data-tippy-options="{}">
+  <div>
+    
+          More help here
+        
+  </div>
+</div>
+      </div>
     </div>
 
     <div class="text-base leading-5">

--- a/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/data_list_test/test_default_datalist_with_help.heyya_snap
+++ b/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/data_list_test/test_default_datalist_with_help.heyya_snap
@@ -1,0 +1,46 @@
+<div class="grid grid-cols-[auto,1fr] items-start text-darker dark:text-gray-lighter gap-x-12 gap-y-4 " id="my-datalist">
+  
+    <div class="text-gray-light text-md font-medium leading-5">
+      Number 1
+      <div class="inline-block ml-1 align-middle">
+        <svg xmlns="http://www.w3.org/2000/svg" id="my-datalist-0-help" class="size-5 opacity-30 hover:opacity-100" aria-hidden="true" fill="currentColor" viewBox="0 0 24 24">
+  <path fill-rule="evenodd" d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm11.378-3.917c-.89-.777-2.366-.777-3.255 0a.75.75 0 0 1-.988-1.129c1.454-1.272 3.776-1.272 5.23 0 1.513 1.324 1.513 3.518 0 4.842a3.75 3.75 0 0 1-.837.552c-.676.328-1.028.774-1.028 1.152v.75a.75.75 0 0 1-1.5 0v-.75c0-1.279 1.06-2.107 1.875-2.502.182-.088.351-.199.503-.331.83-.727.83-1.857 0-2.584ZM12 18a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z" clip-rule="evenodd"/>
+</svg>
+
+        <div class="hidden" id="tooltip-my-datalist-0-help" phx-hook="Tooltip" data-target="my-datalist-0-help" data-tippy-options="{}">
+  <div>
+    
+          Some text to make this easy
+        
+  </div>
+</div>
+      </div>
+    </div>
+
+    <div class="text-base leading-5">
+      
+    Something that needs to be explained
+  
+    </div>
+  
+    <div class="text-gray-light text-md font-medium leading-5">
+      Fact
+      
+    </div>
+
+    <div class="text-base leading-5">
+      Not everything needs a help text
+    </div>
+  
+    <div class="text-gray-light text-md font-medium leading-5">
+      Anohter
+      
+    </div>
+
+    <div class="text-base leading-5">
+      
+    it can be up to the developer where to use the help
+  
+    </div>
+  
+</div>

--- a/platform_umbrella/apps/common_ui/test/common_ui/components/data_list_test.exs
+++ b/platform_umbrella/apps/common_ui/test/common_ui/components/data_list_test.exs
@@ -24,7 +24,7 @@ defmodule CommonUI.Components.DataListTest do
         Something that needs to be explained
       </:item>
       <:item title="Fact">Not everything needs a help text</:item>
-      <:item title="Anohter" hel="More help here">
+      <:item title="Another" help="More help here">
         it can be up to the developer where to use the help
       </:item>
     </.data_list>

--- a/platform_umbrella/apps/common_ui/test/common_ui/components/data_list_test.exs
+++ b/platform_umbrella/apps/common_ui/test/common_ui/components/data_list_test.exs
@@ -15,6 +15,22 @@ defmodule CommonUI.Components.DataListTest do
     """
   end
 
+  component_snapshot_test "default datalist with help" do
+    assigns = %{}
+
+    ~H"""
+    <.data_list id="my-datalist">
+      <:item title="Number 1" help="Some text to make this easy">
+        Something that needs to be explained
+      </:item>
+      <:item title="Fact">Not everything needs a help text</:item>
+      <:item title="Anohter" hel="More help here">
+        it can be up to the developer where to use the help
+      </:item>
+    </.data_list>
+    """
+  end
+
   component_snapshot_test "horizontal-plain datalist" do
     assigns = %{}
 

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/router.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/router.ex
@@ -136,6 +136,8 @@ defmodule ControlServerWeb.Router do
     live "/new", Live.PostgresNew, :new
     live "/:id/edit", Live.PostgresEdit, :edit
     live "/:id/show", Live.PostgresShow, :show
+    live "/:id/events", Live.PostgresShow, :events
+    live "/:id/pods", Live.PostgresShow, :pods
     live "/:id/users", Live.PostgresShow, :users
     live "/:id/services", Live.PostgresShow, :services
     live "/:id/edit_versions", Live.PostgresShow, :edit_versions

--- a/platform_umbrella/apps/control_server_web/test/live/postgres/postgres_live_test.exs
+++ b/platform_umbrella/apps/control_server_web/test/live/postgres/postgres_live_test.exs
@@ -1,5 +1,5 @@
 defmodule ControlServerWeb.PostgresLiveTest do
-  use Heyya.LiveCase
+  use Heyya.LiveCase, async: false
   use ControlServerWeb.ConnCase
 
   import ControlServer.Factory
@@ -265,11 +265,17 @@ defmodule ControlServerWeb.PostgresLiveTest do
 
     setup [:create_cluster]
 
-    test "show cluster page", %{conn: conn, cluster: cluster, pod: pod} do
+    test "show cluster page", %{conn: conn, cluster: cluster} do
       conn
       |> start(~p"/postgres/#{cluster.id}/show")
       |> assert_html("Postgres Cluster: ")
       |> assert_html(cluster.name)
+    end
+
+    test "show cluster page with pod", %{conn: conn, cluster: cluster, pod: pod} do
+      conn
+      |> start(~p"/postgres/#{cluster.id}/pods")
+      |> assert_html("Pods")
       |> assert_html(FieldAccessors.name(pod))
     end
   end


### PR DESCRIPTION
Summary:
- Use the right side nav style from kubernetes page
- Add events page
- Add a pods page
- Add an internal/standard type. Closing #461

Test Plan:
- Test added
- Tests updated

![image](https://github.com/user-attachments/assets/987d94f3-d5c6-46d6-947d-8aac6e412688)
![image](https://github.com/user-attachments/assets/a0db93f2-e217-4ad7-b005-ab06bbf14dc2)

