### PR TITLE
refactor: restructure the traditional services and knative show pages

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/resources/knative/services.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/resources/knative/services.ex
@@ -74,7 +74,7 @@ defmodule CommonCore.Resources.KnativeServices do
 
     container
     |> Map.from_struct()
-    |> Map.drop(["env_values", :env_values, "mounts", :mounts])
+    |> Map.drop(["env_values", :env_values, "mounts", :mounts, :path, "path"])
     |> Map.put("env", env)
   end
 

--- a/platform_umbrella/apps/common_core/lib/common_core/resources/traditional_services/traditional_services.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/resources/traditional_services/traditional_services.ex
@@ -108,6 +108,7 @@ defmodule CommonCore.Resources.TraditionalServices do
     |> B.name(service.name)
     |> B.namespace(battery.config.namespace)
     |> B.app_labels(service.name)
+    |> B.add_owner(service)
     |> B.component_labels(@app_name)
     |> B.spec(spec)
   end
@@ -129,6 +130,7 @@ defmodule CommonCore.Resources.TraditionalServices do
     |> B.namespace(battery.config.namespace)
     |> B.app_labels(service.name)
     |> B.component_labels(@app_name)
+    |> B.add_owner(service)
     |> B.spec(spec)
   end
 

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/containers/env_value_panel.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/containers/env_value_panel.ex
@@ -18,10 +18,11 @@ defmodule ControlServerWeb.Containers.EnvValuePanel do
   attr :editable, :boolean, default: false
   attr :env_values, :list, default: []
   attr :target, :any, default: nil
+  attr :variant, :string, default: "shadowed"
 
   def env_var_panel(%{editable: false} = assigns) do
     ~H"""
-    <.panel title="Environment Variables" class={@class}>
+    <.panel title="Environment Variables" class={@class} variant={@variant}>
       <.table id="env-var-table" rows={@env_values}>
         <:col :let={ev} label="Name">{ev.name}</:col>
         <:col :let={ev} label="Value"><.env_value_value env_value={ev} /></:col>

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/containers/env_value_panel.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/containers/env_value_panel.ex
@@ -18,7 +18,7 @@ defmodule ControlServerWeb.Containers.EnvValuePanel do
   attr :editable, :boolean, default: false
   attr :env_values, :list, default: []
   attr :target, :any, default: nil
-  attr :variant, :string, default: "shadowed"
+  attr :variant, :string, default: "gray"
 
   def env_var_panel(%{editable: false} = assigns) do
     ~H"""
@@ -33,7 +33,7 @@ defmodule ControlServerWeb.Containers.EnvValuePanel do
 
   def env_var_panel(%{editable: true} = assigns) do
     ~H"""
-    <.panel title="Environment Variables" class={@class}>
+    <.panel title="Environment Variables" class={@class} variant={@variant}>
       <:menu>
         <.button icon={:plus} phx-click="new_env_value" phx-target={@target}>
           Add Variable

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/k8/conditions_display.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/k8/conditions_display.ex
@@ -4,6 +4,8 @@ defmodule ControlServerWeb.ConditionsDisplay do
 
   attr :conditions, :list, required: true
   attr :empty, :boolean, default: nil, required: false
+  attr :variant, :string, default: "gray", required: false
+  attr :class, :string, default: nil, required: false
 
   def conditions_display(%{empty: nil} = assigns) do
     conditions = Map.get(assigns, :conditions, [])
@@ -23,7 +25,7 @@ defmodule ControlServerWeb.ConditionsDisplay do
 
   def conditions_display(%{conditions: []} = assigns) do
     ~H"""
-    <.panel variant="gray" title="Conditions">
+    <.panel variant={@variant} title="Conditions" class={@class}>
       <.light_text>No outstanding messages!</.light_text>
     </.panel>
     """
@@ -31,7 +33,7 @@ defmodule ControlServerWeb.ConditionsDisplay do
 
   def conditions_display(assigns) do
     ~H"""
-    <.panel variant="gray" title="Conditions">
+    <.panel variant={@variant} title="Conditions" class={@class}>
       <.table
         id="conditions-display-table"
         rows={Enum.sort_by(@conditions, &get_condition_time/1, :desc)}

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/knative/knative_services_table.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/knative/knative_services_table.ex
@@ -39,6 +39,7 @@ defmodule ControlServerWeb.KnativeServicesTable do
           </.tooltip>
 
           <.button
+            :if={!service.kube_internal}
             variant="minimal"
             link={service_url(service)}
             link_type="external"
@@ -47,7 +48,7 @@ defmodule ControlServerWeb.KnativeServicesTable do
             id={"open_service_" <> service.id}
           />
 
-          <.tooltip target_id={"open_service_" <> service.id}>
+          <.tooltip :if={!service.kube_internal} target_id={"open_service_" <> service.id}>
             Open Knative Service
           </.tooltip>
 
@@ -56,7 +57,6 @@ defmodule ControlServerWeb.KnativeServicesTable do
             link={show_url(service)}
             icon={:eye}
             id={"knative_service_show_link_" <> service.id}
-            class="sm:hidden"
           />
         </.flex>
       </:action>

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/traditional_services/traditional_services_table.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/traditional_services/traditional_services_table.ex
@@ -57,8 +57,8 @@ defmodule ControlServerWeb.TraditionalServicesTable do
             link={show_url(service)}
             icon={:eye}
             id={"traditional_service_show_link_" <> service.id}
-            class="sm:hidden"
           />
+
           <.tooltip target_id={"traditional_service_show_link_" <> service.id}>
             Show Service
           </.tooltip>

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/postgres/show.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/postgres/show.ex
@@ -387,7 +387,7 @@ defmodule ControlServerWeb.Live.PostgresShow do
       back_link={show_url(@cluster)}
     />
 
-    <.grid columns={%{sm: 1, lg: 4}} class="lg:template-rows-3">
+    <.grid columns={%{sm: 1, lg: 4}} class="lg:template-rows-2">
       <.panel title="Pods" class="lg:col-span-3 lg:row-span-2">
         <.pods_table pods={@k8_pods} />
       </.panel>

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/traditional_services/show.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/traditional_services/show.ex
@@ -2,22 +2,89 @@ defmodule ControlServerWeb.Live.TraditionalServicesShow do
   @moduledoc false
   use ControlServerWeb, {:live_view, layout: :sidebar}
 
+  import CommonCore.Resources.FieldAccessors
+  import ControlServerWeb.Audit.EditVersionsTable
   import ControlServerWeb.Containers.EnvValuePanel
+  import ControlServerWeb.PodsTable
   import ControlServerWeb.PortPanel
+  import ControlServerWeb.ResourceComponents
   import KubeServices.SystemState.SummaryHosts
 
   alias CommonCore.TraditionalServices.Service
   alias CommonCore.Util.Memory
   alias ControlServer.TraditionalServices
+  alias KubeServices.KubeState
+  alias KubeServices.SystemState.SummaryBatteries
 
   def mount(%{"id" => id}, _session, socket) do
-    service = TraditionalServices.get_service!(id, preload: [:project])
-
     {:ok,
      socket
      |> assign(:current_page, :devtools)
      |> assign(:page_title, "Traditional Service")
-     |> assign(:service, service)}
+     |> assign_all(id)}
+  end
+
+  def handle_params(%{"id" => id}, _, socket) do
+    {:noreply, assign_all(socket, id)}
+  end
+
+  defp assign_all(socket, id) do
+    socket
+    |> assign_service(id)
+    |> assign_k8_resource()
+    |> assign_timeline_installed()
+    |> maybe_assign_events()
+    |> maybe_assign_k8_pods()
+    |> maybe_assign_edit_versions()
+  end
+
+  defp assign_service(socket, id) do
+    assign(socket, :service, TraditionalServices.get_service!(id, preload: [:project]))
+  end
+
+  defp assign_k8_resource(%{assigns: %{service: %{kube_deployment_type: :statefulset, id: id}}} = socket) do
+    assign(socket, :k8_resource, find_k8_resource(id, :stateful_set))
+  end
+
+  defp assign_k8_resource(%{assigns: %{service: %{kube_deployment_type: :deployment, id: id}}} = socket) do
+    assign(socket, :k8_resource, find_k8_resource(id, :deployment))
+  end
+
+  defp maybe_assign_events(%{assigns: %{live_action: live_action, k8_resource: k8_resource}} = socket)
+       when live_action == :events do
+    assign(socket, :events, KubeState.get_events(k8_resource))
+  end
+
+  defp maybe_assign_events(socket), do: socket
+
+  defp maybe_assign_k8_pods(%{assigns: %{live_action: live_action, service: service}} = socket)
+       when live_action == :pods do
+    assign(socket, :k8_pods, find_k8_pods(service.id))
+  end
+
+  defp maybe_assign_k8_pods(socket), do: socket
+
+  defp maybe_assign_edit_versions(%{assigns: %{service: service, live_action: live_action}} = socket)
+       when live_action == :edit_versions do
+    assign(socket, :edit_versions, ControlServer.Audit.history(service))
+  end
+
+  defp maybe_assign_edit_versions(socket), do: socket
+
+  defp assign_timeline_installed(socket) do
+    assign(socket, :timeline_installed, SummaryBatteries.battery_installed(:timeline))
+  end
+
+  defp find_k8_resource(id, type) do
+    type
+    |> KubeState.get_all()
+    |> Enum.find(nil, fn pg -> id == labeled_owner(pg) end)
+  end
+
+  defp find_k8_pods(id) do
+    :pod
+    |> KubeState.get_all()
+    |> Enum.filter(fn pg -> id == labeled_owner(pg) end)
   end
 
   def handle_event("delete", _params, socket) do
@@ -29,9 +96,9 @@ defmodule ControlServerWeb.Live.TraditionalServicesShow do
      |> push_navigate(to: ~p"/traditional_services")}
   end
 
-  def render(assigns) do
+  defp traditional_service_page_header(assigns) do
     ~H"""
-    <.page_header title={"Traditional Service: #{@service.name}"} back_link={back_url()}>
+    <.page_header title={"Traditional Service: #{@service.name}"} back_link={@back_url}>
       <:menu>
         <.badge :if={@service.project_id}>
           <:item label="Project" navigate={~p"/projects/#{@service.project_id}"}>
@@ -55,9 +122,86 @@ defmodule ControlServerWeb.Live.TraditionalServicesShow do
         </.flex>
       </.flex>
     </.page_header>
+    """
+  end
 
-    <.grid columns={%{sm: 1, lg: 2}}>
-      <.panel title="Details" variant="gray">
+  defp links_panel(assigns) do
+    ~H"""
+    <.panel variant="gray">
+      <.tab_bar variant="navigation">
+        <:tab selected={@live_action == :show} patch={show_url(@service)}>Overview</:tab>
+        <:tab selected={@live_action == :events} patch={events_url(@service)}>Events</:tab>
+        <:tab selected={@live_action == :pods} patch={pods_url(@service)}>Pods</:tab>
+        <:tab
+          :if={@timeline_installed}
+          selected={@live_action == :edit_versions}
+          patch={edit_versions_url(@service)}
+        >
+          Edit Versions
+        </:tab>
+      </.tab_bar>
+      <.a variant="bordered" href={service_url(@service)}>
+        Running Service
+      </.a>
+    </.panel>
+    """
+  end
+
+  defp events_page(assigns) do
+    ~H"""
+    <.traditional_service_page_header service={@service} back_url={show_url(@service)} />
+
+    <.grid columns={%{sm: 1, lg: 4}} class="lg:template-rows-3">
+      <.events_panel class="lg:col-span-3  lg:row-span-2" events={@events} />
+      <.links_panel
+        service={@service}
+        live_action={@live_action}
+        timeline_installed={@timeline_installed}
+      />
+    </.grid>
+    """
+  end
+
+  defp pods_page(assigns) do
+    ~H"""
+    <.traditional_service_page_header service={@service} back_url={show_url(@service)} />
+
+    <.grid columns={%{sm: 1, lg: 4}} class="lg:template-rows-3">
+      <.panel title="Pods" class="lg:col-span-3 lg:row-span-2">
+        <.pods_table pods={@k8_pods} />
+      </.panel>
+      <.links_panel
+        service={@service}
+        live_action={@live_action}
+        timeline_installed={@timeline_installed}
+      />
+    </.grid>
+    """
+  end
+
+  defp edit_versions_page(assigns) do
+    ~H"""
+    <.traditional_service_page_header service={@service} back_url={show_url(@service)} />
+
+    <.grid columns={%{sm: 1, lg: 4}} class="lg:template-rows-3">
+      <.panel title="Edit History" class="lg:col-span-3 lg:row-span-2">
+        <.edit_versions_table rows={@edit_versions} abridged />
+      </.panel>
+      <.links_panel
+        service={@service}
+        timeline_installed={@timeline_installed}
+        live_action={@live_action}
+      />
+    </.grid>
+    """
+  end
+
+  defp main_page(assigns) do
+    ~H"""
+    <.traditional_service_page_header service={@service} back_url={~p"/traditional_services"} />
+
+    <.grid columns={%{sm: 1, lg: 4}} class="lg:template-rows-4">
+      <.panel title="Details" class="lg:col-span-3 lg:row-span-2">
         <.data_list>
           <:item title="Instances">
             {@service.num_instances}
@@ -73,18 +217,64 @@ defmodule ControlServerWeb.Live.TraditionalServicesShow do
           </:item>
         </.data_list>
       </.panel>
-
-      <.flex column class="justify-start">
-        <.a variant="bordered" href={service_url(@service)}>Running Service</.a>
-      </.flex>
-
-      <.env_var_panel env_values={@service.env_values} class="lg:col-span-1" />
-      <.port_panel ports={@service.ports} class="lg:col-span-1" />
+      <.links_panel
+        service={@service}
+        live_action={@live_action}
+        timeline_installed={@timeline_installed}
+      />
+      <.env_var_panel
+        :if={!Enum.empty?(@service.env_values || [])}
+        env_values={@service.env_values || []}
+        class="lg:col-span-4"
+        variant="gray"
+      />
+      <.port_panel
+        :if={!Enum.empty?(@service.ports || [])}
+        ports={@service.ports || []}
+        class="lg:col-span-4"
+      />
     </.grid>
     """
   end
 
-  defp back_url, do: ~p"/traditional_services"
+  def render(assigns) do
+    ~H"""
+    <%= case @live_action do %>
+      <% :show -> %>
+        <.main_page
+          live_action={@live_action}
+          service={@service}
+          timeline_installed={@timeline_installed}
+        />
+      <% :events -> %>
+        <.events_page
+          live_action={@live_action}
+          service={@service}
+          events={@events}
+          timeline_installed={@timeline_installed}
+        />
+      <% :pods -> %>
+        <.pods_page
+          live_action={@live_action}
+          service={@service}
+          k8_pods={@k8_pods}
+          timeline_installed={@timeline_installed}
+        />
+      <% :edit_versions -> %>
+        <.edit_versions_page
+          live_action={@live_action}
+          service={@service}
+          edit_versions={@edit_versions}
+          timeline_installed={@timeline_installed}
+        />
+    <% end %>
+    """
+  end
+
+  defp show_url(service), do: ~p"/traditional_services/#{service}/show"
+  defp events_url(service), do: ~p"/traditional_services/#{service}/events"
+  defp pods_url(service), do: ~p"/traditional_services/#{service}/pods"
   defp edit_url(service), do: ~p"/traditional_services/#{service}/edit"
+  defp edit_versions_url(service), do: ~p"/traditional_services/#{service}/edit_versions"
   defp service_url(%Service{} = service), do: "//#{traditional_host(service)}"
 end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/router.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/router.ex
@@ -168,9 +168,12 @@ defmodule ControlServerWeb.Router do
 
     live "/services", Live.KnativeIndex, :index
     live "/services/new", Live.KnativeNew, :new
+
     live "/services/:id/edit", Live.KnativeEdit, :edit
     live "/services/:id/show", Live.KnativeShow, :show
-    live "/services/:id/env_vars", Live.KnativeShow, :env_vars
+    live "/services/:id/events", Live.KnativeShow, :events
+    live "/services/:id/pods", Live.KnativeShow, :pods
+    live "/services/:id/deployments", Live.KnativeShow, :deployments
     live "/services/:id/edit_versions", Live.KnativeShow, :edit_versions
   end
 

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/router.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/router.ex
@@ -180,7 +180,11 @@ defmodule ControlServerWeb.Router do
     live "/", Live.TraditionalServicesIndex, :index
     live "/new", Live.TraditionalServicesNew, :new
     live "/:id/edit", Live.TraditionalServicesEdit, :edit
+
     live "/:id/show", Live.TraditionalServicesShow, :show
+    live "/:id/edit_versions", Live.TraditionalServicesShow, :edit_versions
+    live "/:id/events", Live.TraditionalServicesShow, :events
+    live "/:id/pods", Live.TraditionalServicesShow, :pods
   end
 
   scope "/trivy_reports", ControlServerWeb do


### PR DESCRIPTION
Summary:
- Split the menu as before
- Add events and pods to the traditional services page
- Add events, pods, and deployments to the knative page
- add edit versions

Test Plan:
- Visual
![image](https://github.com/user-attachments/assets/eb6f42c5-b167-4f2c-aef6-2ed1d81d75f9)
![image](https://github.com/user-attachments/assets/492433f6-d557-4b70-9650-913a9053ff25)
![image](https://github.com/user-attachments/assets/d5aaacf1-6346-452f-aee1-cb82df67483e)

