### PR TITLE
refactor: set SMTP4Dev as internal only to deprecate

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/catalog.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/catalog.ex
@@ -176,7 +176,8 @@ defmodule CommonCore.Batteries.Catalog do
       type: :smtp4dev,
       dependencies: [:battery_core, :istio_gateway],
       name: "SMTP4Dev",
-      description: "SMTP4Dev is a dummy SMTP server for development, testing, and debugging of email systems."
+      description: "SMTP4Dev is a dummy SMTP server for development, testing, and debugging of email systems.",
+      allowed_usages: ~w(internal_dev internal_int_test)a
     },
     # AI
     %CatalogBattery{


### PR DESCRIPTION
Summary:
- Hide it for now

Test Plan:
- Everything still passes
