### PR TITLE
chore: upgrade to k8s 1.32

### DIFF
--- a/bi/pkg/cluster/kind/kind.go
+++ b/bi/pkg/cluster/kind/kind.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	KindImage         = "kindest/node:v1.31.2"
+	KindImage         = "kindest/node:v1.32.1"
 	NoisySocketsImage = "ghcr.io/noisysockets/nsh:v0.9.3"
 )
 

--- a/bi/pkg/cluster/pulumi.go
+++ b/bi/pkg/cluster/pulumi.go
@@ -81,7 +81,7 @@ func (p *pulumiProvider) configure(ctx context.Context) (auto.Workspace, error) 
 		"cluster:maxSize":        {Value: "4"},
 		"cluster:minSize":        {Value: "2"},
 		"cluster:name":           {Value: p.slug},
-		"cluster:version":        {Value: "1.31"},
+		"cluster:version":        {Value: "1.32"},
 		"cluster:volumeSize":     {Value: "20"},
 		"cluster:volumeType":     {Value: "gp3"},
 		"gateway:cidrBlock":      {Value: "100.64.250.0/24"},


### PR DESCRIPTION
Cluster spun up and I was able to access UI.

![image](https://github.com/user-attachments/assets/825e11ab-f833-41d5-b59e-7cc42b3b27ff)
