### PR TITLE
fix: don't push latest tag on tag releases

### DIFF
--- a/.github/workflows/bix_docker.yml
+++ b/.github/workflows/bix_docker.yml
@@ -72,7 +72,7 @@ jobs:
           echo "PUSH=true" >> "$GITHUB_ENV"
 
       # set ADDITIONAL_TAGS to either latest or the current tag
-      - if: ${{ fromJSON(env.PUSH) }}
+      - if: ${{ fromJSON(env.PUSH) && !startsWith(github.ref, 'refs/tags/') }}
         run: |
           echo "ADDITIONAL_TAGS=latest" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
Summary:
When releasing a version we push that. However there's already a latest
tag somewhere else. So we shouldn't make that tag regress.

This should fix: #1543

Test Plan:
-  CI ?
