### PR TITLE
fix: checkout release with history for changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,10 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
+        # See: https://goreleaser.com/errors/no-history/
+        # Leading to: https://goreleaser.com/ci/ |  https://goreleaser.com/ci/actions/#workflow
+        with:
+          fetch-depth: 0
 
       - name: Setup ASDF
         uses: asdf-vm/actions/setup@v3

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,7 +27,7 @@ builds:
     hooks:
       post: ./bin/clean-tmp
 archives:
-  - format: tar.gz
+  - formats: ['tar.gz']
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_ {{- title .Os }}_ {{- if eq .Arch "amd64" }}x86_64 {{-
@@ -37,7 +37,7 @@ archives:
     # use zip for windows archives
     format_overrides:
       - goos: windows
-        format: zip
+        formats: ['zip']
 
 changelog:
   sort: asc
@@ -45,6 +45,8 @@ changelog:
     exclude:
       - '^docs:'
       - '^test:'
+
+report_sizes: true
 
 snapshot:
   version_template: '{{ .Version }}-{{.ShortCommit}}'

--- a/.tool-versions
+++ b/.tool-versions
@@ -2,7 +2,7 @@ awscli 2.22.34
 elixir 1.18.1-otp-27
 erlang 27.1.2
 golang 1.23.4
-goreleaser 2.5.1
+goreleaser 2.6.1
 kind 0.26.0
 kubectl 1.32.0
 nodejs 22.13.0


### PR DESCRIPTION
Summary:
Releases were missing changelogs because GitHub does a shallow clone by default.

Test Plan:
- New release
