### PR TITLE
build: use upx and group changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-build-
 
+      - name: Install upx
+        run: sudo apt-get install upx zip -y
       - name: Release
         run: goreleaser release --clean --verbose -p 1
         env:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,6 +26,19 @@ builds:
 
     hooks:
       post: ./bin/clean-tmp
+upx:
+  - enabled: true
+    goos:
+      - linux
+    compress: '9'
+    lzma: true
+  - enabled: true
+    goos:
+      - windows
+    goarch:
+      - amd64
+    compress: '9'
+    lzma: true
 archives:
   - formats: ['tar.gz']
     # this name template makes the OS and Arch compatible with the results of `uname`.
@@ -38,16 +51,38 @@ archives:
     format_overrides:
       - goos: windows
         formats: ['zip']
-
 changelog:
   sort: asc
   filters:
     exclude:
+      # Docs are pushed on the master branch to netlify
+      # don't include them in the changelog
       - '^docs:'
-      - '^test:'
-
+  groups:
+    - title: New Features
+      regexp: '^.*feat[(\w)]*:+.*$'
+      order: 100
+    - title: Bug Fixes
+      regexp: '^.*fix[(\w)]*:+.*$'
+      order: 110
+    - title: Refactors/Improvements
+      regexp: '^.*refactor[(\w)]*:+.*$'
+      order: 120
+    - title: Performance
+      regexp: '^.*perf[(\w)]*:+.*$'
+      order: 130
+    - title: Style
+      regexp: '^.*style[(\w)]*:+.*$'
+      order: 140
+    - title: Tests
+      regexp: '^.test|tests|testing[(\w)]*:+.*$'
+      order: 150
+    - title: Build/CI
+      regexp: '^.*build|ci[(\w)]*:+.*$'
+      order: 160
+    - title: Chore
+      regexp: '^.*chore[(\w)]*:+.*$'
 report_sizes: true
-
 snapshot:
   version_template: '{{ .Version }}-{{.ShortCommit}}'
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json

--- a/bin/clean-tmp
+++ b/bin/clean-tmp
@@ -13,10 +13,32 @@ setup_colors
 setup_trace
 
 log "Cleaning /tmp/go-build* directories"
-rm -rf /tmp/go-build*
 
-# If there's a GOTEMPDIR, clean it
-if [[ -n "${GOTMPDIR:-}" ]]; then
-    log "Cleaning ${GOTMPDIR:?}/go-build* directories"
-    rm -rf "${GOTMPDIR:?}"/go-build*
+tryDelete() {
+    local basePath="$1"
+    local foundToDelete
+
+    foundToDelete=$(find "$basePath" -maxdepth 1 -iname "go-build*" -type d)
+    for dir in $foundToDelete; do
+        log "Deleting ${dir}"
+        rm -rf "${dir}"
+    done
+}
+
+# IF there's a GITHUB_JOB env var, we're in a GitHub Actions runner
+# so we can clean the /tmp directory and the GOTMPDIR
+#
+# That's because we build too many go binaries and their object files
+# fill up the meager Github Actions runner disk space.
+#
+# However I don't want this to be single threaded at home.
+if [[ -n "${GITHUB_JOB:-}" ]]; then
+    log "Cleaning /tmp/go-build* directories"
+    tryDelete "/tmp"
+
+    # If there's a GOTMPDIR, clean it
+    if [[ -n "${GOTMPDIR:-}" ]]; then
+        log "Cleaning ${GOTMPDIR:?}/go-build* directories"
+        tryDelete "${GOTMPDIR}"
+    fi
 fi


### PR DESCRIPTION
Summary:
- UPX makes binary size go from 99MB to 17MB
- Make the release notes have sub groups

Test Plan:
- goreleaser build --snapshot --clean
