### PR TITLE
feat: allow using deepseek r1 as a model in ollama

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/ollama/model_instance.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/ollama/model_instance.ex
@@ -80,6 +80,17 @@ defmodule CommonCore.Ollama.ModelInstance do
   end
 
   def model_options_for_select do
-    [{"Meta's Llama 3.1", "llama3.1"}, {"Google's Gemma 2", "gemma2"}, {"mxbai embed (Large)", "mxbai-embed-large"}]
+    [
+      {"Deepseek R1 1.5b (1.1GB)", "deepseek-r1:1.5b"},
+      {"Deepseek R1 7b (4.7GB)", "deepseek-r1:7b"},
+      {"Llama 3.2 3b (2.0GB)", "llama3.2:3b"},
+      {"Llama 3.2 1b (1.3GB)", "llama3.2:1b"},
+      {"Phi4 14b (9.1GB)", "phi4"},
+      {"Llama 3.1 8b (4.9GB)", "llama3.1:8b"},
+      {"Llama 3.1 70b (43GB)", "llama3.1:70b"},
+      {"Nomic embed-text 137m (274MB)", "nomic-embed-text"},
+      {"mxbai embed [Large] 335m (670MB)", "mxbai-embed-large"},
+      {"Snowflake Arctic Embed 2.0 568m (1.2GB)", "snowflake-arctic-embed2"}
+    ]
   end
 end

--- a/platform_umbrella/apps/common_core/lib/common_core/resources/ml/ollama.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/resources/ml/ollama.ex
@@ -38,6 +38,7 @@ defmodule CommonCore.Resources.Ollama do
     |> B.name("ollama-#{model_instance.name}")
     |> B.spec(spec)
     |> B.namespace(namespace)
+    |> B.add_owner(model_instance)
   end
 
   def deployment(model_instance, battery, state) do
@@ -79,7 +80,7 @@ defmodule CommonCore.Resources.Ollama do
       %{}
       |> B.spec(spec)
       |> B.app_labels(@app_name)
-      |> B.add_owner(battery)
+      |> B.add_owner(model_instance)
       |> B.label("battery/ollama", model_instance.name)
       |> B.label("battery/managed", "true")
 
@@ -97,7 +98,7 @@ defmodule CommonCore.Resources.Ollama do
     |> B.name("ollama-#{model_instance.name}")
     |> B.spec(spec)
     |> B.namespace(namespace)
-    |> B.label("battery/ollama", model_instance.name)
+    |> B.add_owner(model_instance)
   end
 
   defp resources(%{} = model_instance) do

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/ollama/model_instances_table.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/ollama/model_instances_table.ex
@@ -44,7 +44,6 @@ defmodule ControlServerWeb.ModelInstancesTable do
             link={show_url(model_instance)}
             icon={:eye}
             id={"model_instance_show_link_" <> model_instance.id}
-            class="sm:hidden"
           />
           <.tooltip target_id={"model_instance_show_link_" <> model_instance.id}>
             Show Ollama Model

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/ollama/show.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/ollama/show.ex
@@ -3,9 +3,17 @@ defmodule ControlServerWeb.Live.OllamaModelInstanceShow do
 
   use ControlServerWeb, {:live_view, layout: :sidebar}
 
+  import CommonCore.Resources.FieldAccessors
+  import ControlServerWeb.Audit.EditVersionsTable
+  import ControlServerWeb.PodsTable
+  import ControlServerWeb.ServicesTable
+
   alias CommonCore.Util.Memory
   alias ControlServer.Ollama
+  alias KubeServices.KubeState
+  alias KubeServices.SystemState.SummaryBatteries
 
+  @impl Phoenix.LiveView
   def mount(_, _session, socket) do
     {:ok,
      socket
@@ -13,11 +21,52 @@ defmodule ControlServerWeb.Live.OllamaModelInstanceShow do
      |> assign(:page_title, "Ollama Model Instances")}
   end
 
+  @impl Phoenix.LiveView
   def handle_params(%{"id" => id}, _, socket) do
-    model_instance = Ollama.get_model_instance!(id, preload: [:project])
-    {:noreply, assign(socket, model_instance: model_instance)}
+    {:noreply,
+     socket
+     |> assign_model_instance(id)
+     |> assign_main_k8s()
+     |> assign_timeline_installed()
+     |> maybe_assign_edit_versions()}
   end
 
+  defp assign_model_instance(socket, id) do
+    model_instance = Ollama.get_model_instance!(id, preload: [:project])
+    assign(socket, model_instance: model_instance)
+  end
+
+  defp assign_main_k8s(%{assigns: %{model_instance: %{id: id}}} = socket) do
+    assign(socket, k8_services: k8_services(id), k8_pods: k8_pods(id))
+  end
+
+  defp assign_timeline_installed(socket) do
+    assign(socket, :timeline_installed, SummaryBatteries.battery_installed(:timeline))
+  end
+
+  defp maybe_assign_edit_versions(
+         %{assigns: %{model_instance: model_instance, live_action: live_action, timeline_installed: timeline_installed}} =
+           socket
+       )
+       when live_action == :edit_versions and timeline_installed == true do
+    assign(socket, :edit_versions, ControlServer.Audit.history(model_instance))
+  end
+
+  defp maybe_assign_edit_versions(socket), do: socket
+
+  defp k8_services(id) do
+    :service
+    |> KubeState.get_all()
+    |> Enum.filter(fn pg -> id == labeled_owner(pg) end)
+  end
+
+  defp k8_pods(id) do
+    :pod
+    |> KubeState.get_all()
+    |> Enum.filter(fn pg -> id == labeled_owner(pg) end)
+  end
+
+  @impl Phoenix.LiveView
   def handle_event("delete", _params, socket) do
     case Ollama.delete_model_instance(socket.assigns.model_instance) do
       {:ok, _} ->
@@ -31,9 +80,15 @@ defmodule ControlServerWeb.Live.OllamaModelInstanceShow do
     end
   end
 
-  def render(assigns) do
+  defp show_url(model_instance), do: ~p"/model_instances/#{model_instance}/show"
+  defp pods_url(model_instance), do: ~p"/model_instances/#{model_instance}/pods"
+  defp services_url(model_instance), do: ~p"/model_instances/#{model_instance}/services"
+  defp edit_url(model_instance), do: ~p"/model_instances/#{model_instance}/edit"
+  defp edit_versions_url(model_instance), do: ~p"/model_instances/#{model_instance}/edit_versions"
+
+  defp header(assigns) do
     ~H"""
-    <.page_header title={"Ollama Model: #{@model_instance.name}"} back_link={~p"/notebooks"}>
+    <.page_header title={"Ollama Model: #{@model_instance.name}"} back_link={@back_link}>
       <:menu>
         <.badge :if={@model_instance.project_id}>
           <:item label="Project" navigate={~p"/projects/#{@model_instance.project_id}"}>
@@ -57,8 +112,35 @@ defmodule ControlServerWeb.Live.OllamaModelInstanceShow do
         </.flex>
       </.flex>
     </.page_header>
-    <.grid columns={%{sm: 1, lg: 2}}>
-      <.panel title="Details" variant="gray">
+    """
+  end
+
+  defp links_panel(assigns) do
+    ~H"""
+    <.panel variant="gray">
+      <.tab_bar variant="navigation">
+        <:tab selected={@live_action == :show} patch={show_url(@model_instance)}>Overview</:tab>
+        <:tab selected={@live_action == :pods} patch={pods_url(@model_instance)}>Pods</:tab>
+        <:tab selected={@live_action == :services} patch={services_url(@model_instance)}>
+          Services
+        </:tab>
+        <:tab
+          :if={@timeline_installed}
+          selected={@live_action == :edit_versions}
+          patch={edit_versions_url(@model_instance)}
+        >
+          Edit Versions
+        </:tab>
+      </.tab_bar>
+    </.panel>
+    """
+  end
+
+  def main_page(assigns) do
+    ~H"""
+    <.header model_instance={@model_instance} back_link={~p"/model_instances"} />
+    <.grid columns={%{sm: 1, lg: 4}} class="lg:template-rows-2">
+      <.panel title="Details" class="lg:col-span-3 lg:row-span-2">
         <.data_list>
           <:item title="Model">
             {@model_instance.model}
@@ -71,9 +153,95 @@ defmodule ControlServerWeb.Live.OllamaModelInstanceShow do
           </:item>
         </.data_list>
       </.panel>
+      <.links_panel
+        timeline_installed={@timeline_installed}
+        model_instance={@model_instance}
+        live_action={@live_action}
+      />
     </.grid>
     """
   end
 
-  defp edit_url(model_instance), do: ~p"/model_instances/#{model_instance}/edit"
+  defp pods_page(assigns) do
+    ~H"""
+    <.header model_instance={@model_instance} back_link={show_url(@model_instance)} />
+    <.grid columns={%{sm: 1, lg: 4}} class="lg:template-rows-2">
+      <.panel title="Pods" class="lg:col-span-3 lg:row-span-2">
+        <.pods_table pods={@k8_pods} />
+      </.panel>
+      <.links_panel
+        timeline_installed={@timeline_installed}
+        model_instance={@model_instance}
+        live_action={@live_action}
+      />
+    </.grid>
+    """
+  end
+
+  defp services_page(assigns) do
+    ~H"""
+    <.header model_instance={@model_instance} back_link={show_url(@model_instance)} />
+    <.grid columns={%{sm: 1, lg: 4}} class="lg:template-rows-2">
+      <.panel title="Services" class="lg:col-span-3 lg:row-span-2">
+        <.services_table services={@k8_services} />
+      </.panel>
+      <.links_panel
+        timeline_installed={@timeline_installed}
+        model_instance={@model_instance}
+        live_action={@live_action}
+      />
+    </.grid>
+    """
+  end
+
+  defp edit_versions_page(assigns) do
+    ~H"""
+    <.header model_instance={@model_instance} back_link={show_url(@model_instance)} />
+    <.grid columns={%{sm: 1, lg: 4}} class="lg:template-rows-2">
+      <.panel title="Edit History" class="lg:col-span-3 lg:row-span-2">
+        <.edit_versions_table rows={@edit_versions} abridged />
+      </.panel>
+      <.links_panel
+        timeline_installed={@timeline_installed}
+        model_instance={@model_instance}
+        live_action={@live_action}
+      />
+    </.grid>
+    """
+  end
+
+  @impl Phoenix.LiveView
+  def render(assigns) do
+    ~H"""
+    <%= case @live_action do %>
+      <% :show -> %>
+        <.main_page
+          model_instance={@model_instance}
+          timeline_installed={@timeline_installed}
+          live_action={@live_action}
+        />
+      <% :pods -> %>
+        <.pods_page
+          model_instance={@model_instance}
+          timeline_installed={@timeline_installed}
+          live_action={@live_action}
+          k8_pods={@k8_pods}
+        />
+      <% :services -> %>
+        <.services_page
+          model_instance={@model_instance}
+          timeline_installed={@timeline_installed}
+          live_action={@live_action}
+          k8_services={@k8_services}
+        />
+      <% :edit_versions -> %>
+        <.edit_versions_page
+          model_instance={@model_instance}
+          timeline_installed={@timeline_installed}
+          live_action={@live_action}
+          edit_versions={@edit_versions}
+        />
+    <% end %>
+    """
+  end
 end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/router.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/router.ex
@@ -229,7 +229,11 @@ defmodule ControlServerWeb.Router do
     live "/", Live.OllamaModelInstancesIndex
     live "/new", Live.OllamaModelInstanceNew
     live "/:id/edit", Live.OllamaModelInstanceEdit
-    live "/:id/show", Live.OllamaModelInstanceShow
+
+    live "/:id/show", Live.OllamaModelInstanceShow, :show
+    live "/:id/pods", Live.OllamaModelInstanceShow, :pods
+    live "/:id/services", Live.OllamaModelInstanceShow, :services
+    live "/:id/edit_versions", Live.OllamaModelInstanceShow, :edit_versions
   end
 
   scope "/history", ControlServerWeb do

--- a/platform_umbrella/config/config.exs
+++ b/platform_umbrella/config/config.exs
@@ -62,7 +62,8 @@ config :ex_audit,
     CommonCore.Knative.Service,
     CommonCore.MetalLB.IPAddressPool,
     CommonCore.Postgres.Cluster,
-    CommonCore.Redis.RedisInstance
+    CommonCore.Redis.RedisInstance,
+    CommonCore.Ollama.ModelInstance
   ],
   primitive_structs: [
     Date,


### PR DESCRIPTION
Summary:
- Change the show page UI
- Add model instances to edit versions
- update the recomended models

Test Plan:
- Visual
- Tried deepseek-r1:1.5b
