### PR TITLE
feat: allow setting TRACE for install script

### DIFF
--- a/platform_umbrella/apps/home_base_web/priv/raw_files/install_script.sh
+++ b/platform_umbrella/apps/home_base_web/priv/raw_files/install_script.sh
@@ -101,4 +101,4 @@ else
 fi
 
 # start install
-"${INSTALL_DIR}/${BI}" start -v=info "${INSTALL_SPEC_URL}"
+"${INSTALL_DIR}/${BI}" start ${TRACE:+-v=debug} "${INSTALL_SPEC_URL}"


### PR DESCRIPTION
Summary:
TRACE means debug logging everywhere else. This makes that hold for the
install script

Fixes: #1351

Test Plan:
- CI
