### PR TITLE
chore(k8s): upgrade to 1.32

### DIFF
--- a/bi/pkg/cluster/kind/kind.go
+++ b/bi/pkg/cluster/kind/kind.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	KindImage         = "kindest/node:v1.31.2"
+	KindImage         = "kindest/node:v1.32.1"
 	NoisySocketsImage = "ghcr.io/noisysockets/nsh:v0.9.3"
 )
 

--- a/bi/pkg/cluster/pulumi.go
+++ b/bi/pkg/cluster/pulumi.go
@@ -81,7 +81,7 @@ func (p *pulumiProvider) configure(ctx context.Context) (auto.Workspace, error) 
 		"cluster:maxSize":        {Value: "4"},
 		"cluster:minSize":        {Value: "2"},
 		"cluster:name":           {Value: p.slug},
-		"cluster:version":        {Value: "1.31"},
+		"cluster:version":        {Value: "1.32"},
 		"cluster:volumeSize":     {Value: "20"},
 		"cluster:volumeType":     {Value: "gp3"},
 		"gateway:cidrBlock":      {Value: "100.64.250.0/24"},


### PR DESCRIPTION
Test plan:
- [x] spin up new 1.32 cluster
- [x] spin up 1.31 cluster, upgrade to 1.32