### PR TITLE
chore: prepare for 0.56.0

### DIFF
--- a/bin/bix
+++ b/bin/bix
@@ -13,7 +13,7 @@ PORTFORWARD_ENABLED=1
 
 # If you are changing this also change the
 # version in mix.exs for all the apps in platform_umbrella
-BASE_VERSION="0.55.0"
+BASE_VERSION="0.56.0"
 
 # Make sure everything is build with this binary in the path
 export PATH="${ROOT_DIR}/bin:${PATH}"

--- a/platform_umbrella/apps/common_core/mix.exs
+++ b/platform_umbrella/apps/common_core/mix.exs
@@ -4,7 +4,7 @@ defmodule CommonCore.MixProject do
   def project do
     [
       app: :common_core,
-      version: "0.55.0",
+      version: "0.56.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/platform_umbrella/apps/common_ui/mix.exs
+++ b/platform_umbrella/apps/common_ui/mix.exs
@@ -4,7 +4,7 @@ defmodule CommonUI.MixProject do
   def project do
     [
       app: :common_ui,
-      version: "0.55.0",
+      version: "0.56.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/platform_umbrella/apps/control_server/mix.exs
+++ b/platform_umbrella/apps/control_server/mix.exs
@@ -4,7 +4,7 @@ defmodule ControlServer.MixProject do
   def project do
     [
       app: :control_server,
-      version: "0.55.0",
+      version: "0.56.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/platform_umbrella/apps/control_server_web/mix.exs
+++ b/platform_umbrella/apps/control_server_web/mix.exs
@@ -4,7 +4,7 @@ defmodule ControlServerWeb.MixProject do
   def project do
     [
       app: :control_server_web,
-      version: "0.55.0",
+      version: "0.56.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/platform_umbrella/apps/event_center/mix.exs
+++ b/platform_umbrella/apps/event_center/mix.exs
@@ -4,7 +4,7 @@ defmodule EventCenter.MixProject do
   def project do
     [
       app: :event_center,
-      version: "0.55.0",
+      version: "0.56.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/platform_umbrella/apps/home_base/mix.exs
+++ b/platform_umbrella/apps/home_base/mix.exs
@@ -4,7 +4,7 @@ defmodule HomeBase.MixProject do
   def project do
     [
       app: :home_base,
-      version: "0.55.0",
+      version: "0.56.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/platform_umbrella/apps/home_base_web/mix.exs
+++ b/platform_umbrella/apps/home_base_web/mix.exs
@@ -4,7 +4,7 @@ defmodule HomeBaseWeb.MixProject do
   def project do
     [
       app: :home_base_web,
-      version: "0.55.0",
+      version: "0.56.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/platform_umbrella/apps/kube_bootstrap/mix.exs
+++ b/platform_umbrella/apps/kube_bootstrap/mix.exs
@@ -4,7 +4,7 @@ defmodule KubeBootstrap.MixProject do
   def project do
     [
       app: :kube_bootstrap,
-      version: "0.55.0",
+      version: "0.56.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/platform_umbrella/apps/kube_services/mix.exs
+++ b/platform_umbrella/apps/kube_services/mix.exs
@@ -4,7 +4,7 @@ defmodule KubeServices.MixProject do
   def project do
     [
       app: :kube_services,
-      version: "0.55.0",
+      version: "0.56.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/platform_umbrella/apps/verify/mix.exs
+++ b/platform_umbrella/apps/verify/mix.exs
@@ -4,7 +4,7 @@ defmodule Verify.MixProject do
   def project do
     [
       app: :verify,
-      version: "0.55.0",
+      version: "0.56.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/platform_umbrella/mix.exs
+++ b/platform_umbrella/mix.exs
@@ -4,7 +4,7 @@ defmodule ControlServer.Umbrella.MixProject do
   def project do
     [
       apps_path: "apps",
-      version: "0.55.0",
+      version: "0.56.0",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       releases: releases(),


### PR DESCRIPTION
Summary:
- Version bump to release 1.32 Kube

Test Plan:
- CI
- Release
