### PR TITLE
feat: add the ability to apply a snapshot to a project

### DIFF
--- a/platform_umbrella/.credo.exs
+++ b/platform_umbrella/.credo.exs
@@ -68,7 +68,7 @@
         enabled: [
           #
           ## Consistency Checks
-          #
+
           {Credo.Check.Consistency.ExceptionNames, []},
           {Credo.Check.Consistency.LineEndings, []},
           {Credo.Check.Consistency.ParameterPatternMatching, []},
@@ -121,7 +121,7 @@
           {Credo.Check.Refactor.MapJoin, []},
           {Credo.Check.Refactor.NegatedConditionsInUnless, []},
           {Credo.Check.Refactor.NegatedConditionsWithElse, []},
-          {Credo.Check.Refactor.Nesting, []},
+          {Credo.Check.Refactor.Nesting, [max_nesting: 3]},
           {Credo.Check.Refactor.UnlessWithElse, []},
           {Credo.Check.Refactor.WithClauses, []},
           {Credo.Check.Refactor.FilterFilter, []},

--- a/platform_umbrella/apps/control_server/lib/control_server/projects/snapshotter.ex
+++ b/platform_umbrella/apps/control_server/lib/control_server/projects/snapshotter.ex
@@ -3,15 +3,21 @@ defmodule ControlServer.Projects.Snapshoter do
 
   use ControlServer, :context
 
+  alias CommonCore.FerretDB.FerretService
+  alias CommonCore.MetalLB.IPAddressPool
+  alias CommonCore.Notebooks.JupyterLabNotebook
+  alias CommonCore.Ollama.ModelInstance
+  alias CommonCore.Postgres.Cluster
   alias CommonCore.Projects.Project
   alias CommonCore.Projects.ProjectSnapshot
+  alias CommonCore.Redis.RedisInstance
   alias Ecto.Multi
 
   @spec take_snapshot(Project.t()) :: {:ok, ProjectSnapshot.t()} | {:error, any()}
 
   def take_snapshot(%Project{} = project) do
     # We will create a snapshot of the project
-    with {:ok, res} <- run_transaction(project) do
+    with {:ok, res} <- run_take_snap_transaction(project) do
       # Add some fields
       values =
         res
@@ -29,16 +35,20 @@ defmodule ControlServer.Projects.Snapshoter do
     end
   end
 
-  def apply_snapshot(_project, _snapshot) do
-    # take every part of the snapshot
-    # find the resulting part of the project
-    # then apply any updates that are needed
+  # For each resouce in the database that can have a row
+  # create a query to read all of the rows for that resource
+  # that are associated with the project
+  defp resource_type_to_read_query(type, project_id) do
+    case module_by_resouce_type(type) do
+      nil -> nil
+      module -> from(m in module, where: m.project_id == ^project_id)
+    end
   end
 
-  defp run_transaction(project) do
+  defp run_take_snap_transaction(project) do
     Project.resource_types()
     |> Enum.map(fn type ->
-      {type, type_to_query(type, project.id)}
+      {type, resource_type_to_read_query(type, project.id)}
     end)
     |> Enum.filter(fn {_, query} -> query != nil end)
     |> Enum.reduce(Multi.new(), fn {type, q}, multi ->
@@ -47,25 +57,112 @@ defmodule ControlServer.Projects.Snapshoter do
     |> Repo.transaction()
   end
 
-  defp type_to_query(:postgres_clusters, project_id), do: query(CommonCore.Postgres.Cluster, project_id)
+  @spec apply_snapshot(Project.t(), ProjectSnapshot.t(), Keyword.t()) ::
+          {:ok, any()} | {:error, any()}
+  def apply_snapshot(project, snapshot, opts \\ []) do
+    multi =
+      Project.resource_types()
+      |> Enum.reduce(Multi.new(), fn type, multi ->
+        Multi.all(multi, type, get_by_name(project, snapshot, type))
+      end)
+      |> Multi.merge(fn context ->
+        insert_multi(project, snapshot, context, opts)
+      end)
+      |> Multi.merge(fn context ->
+        update_multi(project, snapshot, context, opts)
+      end)
 
-  defp type_to_query(:redis_instances, project_id), do: query(CommonCore.Redis.RedisInstance, project_id)
-
-  defp type_to_query(:ferret_services, project_id), do: query(CommonCore.FerretDB.FerretService, project_id)
-
-  defp type_to_query(:jupyter_notebooks, project_id), do: query(CommonCore.Notebooks.JupyterLabNotebook, project_id)
-
-  defp type_to_query(:knative_services, project_id), do: query(CommonCore.Knative.Service, project_id)
-
-  defp type_to_query(:traditional_services, project_id), do: query(CommonCore.TraditionalServices.Service, project_id)
-
-  defp type_to_query(:model_instances, project_id), do: query(CommonCore.Ollama.ModelInstance, project_id)
-
-  defp type_to_query(:ip_address_pools, _), do: nil
-
-  defp type_to_query(_, _), do: nil
-
-  defp query(module, project_id) do
-    from(m in module, where: m.project_id == ^project_id)
+    Repo.transaction(multi)
   end
+
+  defp get_by_name(project, snapshot, type) do
+    case module_by_resouce_type(type) do
+      nil ->
+        []
+
+      module ->
+        # Since names are unique we use them rather than ids, since the snapshot could
+        # come from a different installation.
+        names =
+          snapshot
+          |> Map.get(type, [])
+          |> Enum.map(&Map.get(&1, :name))
+
+        from(m in module, where: m.project_id == ^project.id and m.name in ^names)
+    end
+  end
+
+  defp insert_multi(project, snapshot, context, _opts) do
+    Enum.reduce(Project.resource_types(), Multi.new(), fn type, multi ->
+      module = module_by_resouce_type(type)
+
+      if module do
+        # For this type we know all of the records by name
+        existing_by_name = context |> Map.get(type) |> Map.new(fn m -> {m.name, m} end)
+
+        snapshot
+        |> Map.get(type, [])
+        |> Enum.reject(fn m -> Map.has_key?(existing_by_name, m.name) end)
+        |> Enum.reduce(multi, fn attrs, inner_multi ->
+          attrs = attrs |> Map.put(:project_id, project.id) |> Map.put(:id, nil)
+
+          changeset =
+            apply(module, :changeset, [struct(module), prepare_for_insert(attrs, project)])
+
+          Multi.insert(inner_multi, "insert_#{type}_#{attrs.name}", changeset)
+        end)
+      else
+        multi
+      end
+    end)
+  end
+
+  defp update_multi(project, snapshot, context, _opts) do
+    Enum.reduce(Project.resource_types(), Multi.new(), fn type, multi ->
+      module = module_by_resouce_type(type)
+
+      if module do
+        # For this type we know all of the records by name
+        existing_by_name = context |> Map.get(type) |> Map.new(fn m -> {m.name, m} end)
+
+        snapshot
+        |> Map.get(type, [])
+        |> Enum.filter(fn m -> Map.has_key?(existing_by_name, m.name) end)
+        |> Enum.reduce(multi, fn attrs, inner_multi ->
+          existing = Map.get(existing_by_name, attrs.name)
+
+          changeset = apply(module, :changeset, [existing, prepare_for_insert(attrs, project)])
+          Multi.update(inner_multi, "update_#{type}_#{existing.name}", changeset)
+        end)
+      else
+        multi
+      end
+    end)
+  end
+
+  defp prepare_for_insert(attrs, project) do
+    attrs
+    |> Map.from_struct()
+    |> Map.put(:project_id, project.id)
+    |> Map.delete(:id)
+    |> Map.delete(:__meta__)
+  end
+
+  defp module_by_resouce_type(:postgres_clusters), do: Cluster
+
+  defp module_by_resouce_type(:redis_instances), do: RedisInstance
+
+  defp module_by_resouce_type(:ferret_services), do: FerretService
+
+  defp module_by_resouce_type(:jupyter_notebooks), do: JupyterLabNotebook
+
+  defp module_by_resouce_type(:knative_services), do: CommonCore.Knative.Service
+
+  defp module_by_resouce_type(:traditional_services), do: CommonCore.TraditionalServices.Service
+
+  defp module_by_resouce_type(:model_instances), do: ModelInstance
+
+  defp module_by_resouce_type(:ip_address_pools), do: IPAddressPool
+
+  defp module_by_resouce_type(_), do: nil
 end

--- a/platform_umbrella/apps/control_server/test/control_server/projects/project_snapshot_test.exs
+++ b/platform_umbrella/apps/control_server/test/control_server/projects/project_snapshot_test.exs
@@ -8,13 +8,18 @@ defmodule ControlServer.Projects.ProjectSnapshotTest do
   setup do
     full_project = insert(:project)
 
-    _ = insert(:postgres_cluster, project_id: full_project.id)
-    _ = insert(:traditional_service, project_id: full_project.id)
-    _ = insert(:traditional_service, project_id: full_project.id)
+    pg_cluster = insert(:postgres_cluster, project_id: full_project.id)
+    traditional_service_zero = insert(:traditional_service, project_id: full_project.id, virtual_size: "tiny")
+
+    traditional_service_one =
+      insert(:traditional_service, project_id: full_project.id, num_instances: 1, virtual_size: "small")
 
     %{
       empty_project: insert(:project),
-      non_empty_project: full_project
+      non_empty_project: full_project,
+      pg_cluster: pg_cluster,
+      traditional_service_zero: traditional_service_zero,
+      traditional_service_one: traditional_service_one
     }
   end
 
@@ -41,6 +46,35 @@ defmodule ControlServer.Projects.ProjectSnapshotTest do
 
       assert DateTime.compare(before_time, snapshot.captured_at) != :gt
       assert DateTime.compare(after_time, snapshot.captured_at) != :lt
+    end
+
+    test "should apply a captured_snapshot to a project", %{
+      non_empty_project: p,
+      pg_cluster: pg,
+      traditional_service_zero: ts_zero,
+      traditional_service_one: ts_one
+    } do
+      {:ok, snapshot} = Snapshoter.take_snapshot(p)
+
+      assert {:ok, _} = ControlServer.Postgres.delete_cluster(pg)
+      assert {:ok, _} = ControlServer.TraditionalServices.delete_service(ts_zero)
+
+      # rather than deleting the service we'll make some changes
+      assert {:ok, _} =
+               ControlServer.TraditionalServices.update_service(ts_one, %{num_instances: 420, virtual_size: "huge"})
+
+      assert {:ok, _} = Snapshoter.apply_snapshot(p, snapshot)
+
+      assert fetched = ControlServer.Projects.get_project(p.id)
+
+      assert fetched.postgres_clusters != []
+      assert 1 == length(fetched.postgres_clusters)
+
+      assert fetched.traditional_services != []
+      assert 2 == length(fetched.traditional_services)
+
+      # assert that the update changed the service back to its original state
+      assert ControlServer.TraditionalServices.get_service!(ts_one.id).num_instances == ts_one.num_instances
     end
   end
 end


### PR DESCRIPTION
Summary:
This PR does most of the work to allow applying a snapshot onto an
existing project.

- Rename to `Snapshotter`
- Read all the resources by name in a transaction
- Then insert the ones that aren't there
- Then update the ones that are there

This doesn't include the needed code to over-ride the virtual_size for
all resources but it's ready

Test Plan:
Tests included
bix ex-lint clean
