### PR TITLE
fix(control_server): de-flake list_cluster test

### DIFF
--- a/platform_umbrella/apps/control_server/test/control_server/postgres_test.exs
+++ b/platform_umbrella/apps/control_server/test/control_server/postgres_test.exs
@@ -40,12 +40,21 @@ defmodule ControlServer.PostgresTest do
       assert Postgres.list_clusters() == [cluster]
     end
 
+    # create a number of clusters with a unique name pattern
+    # find clusters matching that pattern 1 at a time
+    # ensure we can fetch e.g. first and last "page"
     test "list_clusters/1 returns paginated clusters" do
-      cluster1 = cluster_fixture()
-      _cluster2 = cluster_fixture(%{name: "another-name"})
+      name_prefix = "list-clusters-pagination-test"
+      params = %{order_by: [:id], filters: [%{field: :name, op: :ilike, value: "#{name_prefix}-"}]}
+      created = Enum.map(0..9, fn i -> cluster_fixture(%{name: "#{name_prefix}-#{i}"}) end)
 
-      assert {:ok, {[cluster], _}} = Postgres.list_clusters(%{limit: 1})
-      assert cluster.id == cluster1.id
+      assert {:ok, {[first], meta}} = Postgres.list_clusters(Map.put(params, :first, 1))
+      assert created |> List.first() |> Map.get(:id) == first.id
+      assert {false, true} = {meta.has_previous_page?, meta.has_next_page?}
+
+      assert {:ok, {[last], meta}} = Postgres.list_clusters(Map.put(params, :last, 1))
+      assert created |> List.last() |> Map.get(:id) == last.id
+      assert {true, false} = {meta.has_previous_page?, meta.has_next_page?}
     end
 
     test "get_cluster!/1 returns the cluster with given id" do

--- a/platform_umbrella/apps/control_server/test/control_server/redis_test.exs
+++ b/platform_umbrella/apps/control_server/test/control_server/redis_test.exs
@@ -18,11 +18,17 @@ defmodule ControlServer.RedisTest do
     end
 
     test "list_redis_instances/1 returns paginated failover clusters" do
-      redis_instance1 = redis_instance_fixture()
-      _redis_instance2 = redis_instance_fixture()
+      name_prefix = "list-redis-instances-pagination-test"
+      params = %{order_by: [:id], filters: [%{field: :name, op: :ilike, value: "#{name_prefix}-"}]}
+      created = Enum.map(0..9, fn i -> redis_instance_fixture(%{name: "#{name_prefix}-#{i}"}) end)
 
-      assert {:ok, {[redis_instance], _}} = Redis.list_redis_instances(%{limit: 1})
-      assert redis_instance.id == redis_instance1.id
+      assert {:ok, {[first], meta}} = Redis.list_redis_instances(Map.put(params, :first, 1))
+      assert created |> List.first() |> Map.get(:id) == first.id
+      assert {false, true} = {meta.has_previous_page?, meta.has_next_page?}
+
+      assert {:ok, {[last], meta}} = Redis.list_redis_instances(Map.put(params, :last, 1))
+      assert created |> List.last() |> Map.get(:id) == last.id
+      assert {true, false} = {meta.has_previous_page?, meta.has_next_page?}
     end
 
     test "get_redis_instance!/1 returns the redis_instance with given id" do


### PR DESCRIPTION
closes: #1421 

This changes the list_cluster pagination test to ignore clusters that may have been created in other tests or via backgound installer. This should keep it from being flakey.