### PR TITLE
ci: upgrade asdf and pin version

### DIFF
--- a/.github/workflows/bix.yml
+++ b/.github/workflows/bix.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - master
 
+env:
+  ASDF_BRANCH: v0.15.0
+
 jobs:
   check-fmt:
     runs-on: ubuntu-latest
@@ -16,6 +19,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup ASDF
         uses: asdf-vm/actions/setup@v3
+        with:
+          asdf_branch: ${{ env.ASDF_BRANCH }}
+
       - name: Cache ASDF
         uses: actions/cache@v4
         id: asdf-cache
@@ -32,7 +38,7 @@ jobs:
         # See https://github.com/asdf-vm/actions/issues/445
         if: ${{ steps.asdf-cache.outputs.cache-hit != 'true' }}
         with:
-          asdf_branch: v0.14.1
+          asdf_branch: ${{ env.ASDF_BRANCH }}
 
       - name: Reshim ASDF
         shell: bash

--- a/.github/workflows/bix_docker.yml
+++ b/.github/workflows/bix_docker.yml
@@ -17,6 +17,7 @@ permissions:
 
 env:
   PUSH: 'false'
+  ASDF_BRANCH: v0.15.0
 
 jobs:
   build-images:
@@ -26,6 +27,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup ASDF
         uses: asdf-vm/actions/setup@v3
+        with:
+          asdf_branch: ${{ env.ASDF_BRANCH }}
       - name: Cache ASDF
         uses: actions/cache@v4
         id: asdf-cache
@@ -42,7 +45,7 @@ jobs:
         # See https://github.com/asdf-vm/actions/issues/445
         if: ${{ steps.asdf-cache.outputs.cache-hit != 'true' }}
         with:
-          asdf_branch: v0.14.1
+          asdf_branch: ${{ env.ASDF_BRANCH }}
 
       - name: Reshim ASDF
         shell: bash

--- a/.github/workflows/bix_elixir.yml
+++ b/.github/workflows/bix_elixir.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - master
 
+env:
+  ASDF_BRANCH: v0.15.0
+
 jobs:
   elixir-test:
     runs-on: ubuntu-latest
@@ -30,6 +33,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup ASDF
         uses: asdf-vm/actions/setup@v3
+        with:
+          asdf_branch: ${{ env.ASDF_BRANCH }}
       - name: Cache ASDF
         uses: actions/cache@v4
         id: asdf-cache
@@ -46,7 +51,7 @@ jobs:
         # See https://github.com/asdf-vm/actions/issues/445
         if: ${{ steps.asdf-cache.outputs.cache-hit != 'true' }}
         with:
-          asdf_branch: v0.14.1
+          asdf_branch: ${{ env.ASDF_BRANCH }}
       - name: Reshim ASDF
         shell: bash
         run: asdf reshim
@@ -79,6 +84,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup ASDF
         uses: asdf-vm/actions/setup@v3
+        with:
+          asdf_branch: ${{ env.ASDF_BRANCH }}
       - name: Cache ASDF
         uses: actions/cache@v4
         id: asdf-cache
@@ -95,7 +102,7 @@ jobs:
         # See https://github.com/asdf-vm/actions/issues/445
         if: ${{ steps.asdf-cache.outputs.cache-hit != 'true' }}
         with:
-          asdf_branch: v0.14.1
+          asdf_branch: ${{ env.ASDF_BRANCH }}
 
       - name: Reshim ASDF
         shell: bash
@@ -122,6 +129,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup ASDF
         uses: asdf-vm/actions/setup@v3
+        with:
+          asdf_branch: ${{ env.ASDF_BRANCH }}
       - name: Cache ASDF
         uses: actions/cache@v4
         id: asdf-cache
@@ -139,7 +148,7 @@ jobs:
         # See https://github.com/asdf-vm/actions/issues/445
         if: ${{ steps.asdf-cache.outputs.cache-hit != 'true' }}
         with:
-          asdf_branch: v0.14.1
+          asdf_branch: ${{ env.ASDF_BRANCH }}
 
       - name: Reshim ASDF
         shell: bash

--- a/.github/workflows/bix_go.yml
+++ b/.github/workflows/bix_go.yml
@@ -11,6 +11,7 @@ on:
 env:
   GOCACHE: /home/runner/.cache/go-cache
   GOMODCACHE: /home/runner/.cache/go-mod
+  ASDF_BRANCH: v0.15.0
 
 jobs:
   go-test:
@@ -20,6 +21,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup ASDF
         uses: asdf-vm/actions/setup@v3
+        with:
+          asdf_branch: ${{ env.ASDF_BRANCH }}
+
       - name: Cache ASDF
         uses: actions/cache@v4
         id: asdf-cache
@@ -36,7 +40,7 @@ jobs:
         # See https://github.com/asdf-vm/actions/issues/445
         if: ${{ steps.asdf-cache.outputs.cache-hit != 'true' }}
         with:
-          asdf_branch: v0.14.1
+          asdf_branch: ${{ env.ASDF_BRANCH }}
 
       - name: Reshim ASDF
         shell: bash
@@ -64,6 +68,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup ASDF
         uses: asdf-vm/actions/setup@v3
+        with:
+          asdf_branch: ${{ env.ASDF_BRANCH }}
+
       - name: Cache ASDF
         uses: actions/cache@v4
         id: asdf-cache
@@ -80,7 +87,7 @@ jobs:
         # See https://github.com/asdf-vm/actions/issues/445
         if: ${{ steps.asdf-cache.outputs.cache-hit != 'true' }}
         with:
-          asdf_branch: v0.14.1
+          asdf_branch: ${{ env.ASDF_BRANCH }}
 
       - name: Reshim ASDF
         shell: bash
@@ -108,6 +115,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup ASDF
         uses: asdf-vm/actions/setup@v3
+        with:
+          asdf_branch: ${{ env.ASDF_BRANCH }}
+
       - name: Cache ASDF
         uses: actions/cache@v4
         id: asdf-cache
@@ -124,7 +134,7 @@ jobs:
         # See https://github.com/asdf-vm/actions/issues/445
         if: ${{ steps.asdf-cache.outputs.cache-hit != 'true' }}
         with:
-          asdf_branch: v0.14.1
+          asdf_branch: ${{ env.ASDF_BRANCH }}
 
       - name: Reshim ASDF
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ permissions:
 env:
   GOCACHE: /home/runner/.cache/go-cache
   GOMODCACHE: /home/runner/.cache/go-mod
+  ASDF_BRANCH: v0.15.0
 
 jobs:
   release:
@@ -27,6 +28,8 @@ jobs:
 
       - name: Setup ASDF
         uses: asdf-vm/actions/setup@v3
+        with:
+          asdf_branch: ${{ env.ASDF_BRANCH }}
 
       - name: Cache ASDF
         uses: actions/cache@v4
@@ -44,7 +47,7 @@ jobs:
         # See https://github.com/asdf-vm/actions/issues/445
         if: ${{ steps.asdf-cache.outputs.cache-hit != 'true' }}
         with:
-          asdf_branch: v0.14.1
+          asdf_branch: ${{ env.ASDF_BRANCH }}
 
       - name: Reshim ASDF
         shell: bash


### PR DESCRIPTION
This gets rid of the warning spam about upgrade to 0.16.x. The actions don't currently support it so pin 1 version back and we can upgrade again once the actions are ready.