### PR TITLE
chore(karpenter): enable gpu support for nvidia nodes

### DIFF
--- a/bootstrap/dev.install.json
+++ b/bootstrap/dev.install.json
@@ -1,13 +1,13 @@
 {
-  "id": "batt_0195159a772f78f394ea727b3e49c6f4",
+  "id": "batt_01951a63718f7542ac3a63ad8d3a5430",
   "usage": "internal_dev",
-  "team_id": "batt_0195159a772b7010add2b1c0a2ff1e8e",
+  "team_id": "batt_01951a63718c7afdb0feca073c30d586",
   "default_size": "tiny",
   "control_jwk": {
     "crv": "Ed25519",
-    "d": "Q0a7QjuroVZqV4xkd7ZYNyQLJoGyK5ZYmaNuV5Pkf5g",
+    "d": "C4JhIvtGdbf0ZQtG_Mtlmy9p8sQ2iKC1uqY8AZZjWg0",
     "kty": "OKP",
-    "x": "eS2X2Qy2XpVHU6fn_iMwUHWbI3RMXDATf7pIh7oijPY"
+    "x": "_yVRqEdZW9vv-qC9_bBLOyCJmM4u0Fbk2NnLGfStiTE"
   },
   "inserted_at": null,
   "updated_at": null,

--- a/bootstrap/dev.spec.json
+++ b/bootstrap/dev.spec.json
@@ -9,7 +9,7 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_0195159a77a9746797f7d50e92f5677d",
+        "id": "batt_01951a6371f2761da75f5c2aaac4ca1b",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -24,7 +24,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195159a77a97bd0b827980baa56f3ed",
+        "id": "batt_01951a6371f27f02854ba1cb15f46ae8",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -37,7 +37,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195159a77a97d0299a437a255e2f7cb",
+        "id": "batt_01951a6371f27a33b065634656fb3331",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -49,12 +49,12 @@
           "ai_namespace": "battery-ai",
           "default_size": "tiny",
           "cluster_name": "dev",
-          "install_id": "batt_0195159a772f78f394ea727b3e49c6f4",
+          "install_id": "batt_01951a63718f7542ac3a63ad8d3a5430",
           "control_jwk": {
             "crv": "Ed25519",
-            "d": "Q0a7QjuroVZqV4xkd7ZYNyQLJoGyK5ZYmaNuV5Pkf5g",
+            "d": "C4JhIvtGdbf0ZQtG_Mtlmy9p8sQ2iKC1uqY8AZZjWg0",
             "kty": "OKP",
-            "x": "eS2X2Qy2XpVHU6fn_iMwUHWbI3RMXDATf7pIh7oijPY"
+            "x": "_yVRqEdZW9vv-qC9_bBLOyCJmM4u0Fbk2NnLGfStiTE"
           },
           "upgrade_days_of_week": [
             true,
@@ -79,7 +79,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195159a77a9710f8a9317e8fb9fa33c",
+        "id": "batt_01951a6371f2721c8e2db1da02c76ef5",
         "type": "metallb",
         "config": {
           "type": "metallb",
@@ -99,7 +99,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195159a77a9744a8451ad4a35af5fee",
+        "id": "batt_01951a6371f27b3b821a6de60cf61d9b",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
@@ -115,7 +115,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195159a77a977aa9bcdcbbc6f05da8c",
+        "id": "batt_01951a6371f27dfb8942244999530a3d",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -171,7 +171,7 @@
           {
             "version": 2,
             "username": "battery-control-user",
-            "password": "ZUDHL666HQCIFAB372HJRUHY"
+            "password": "BBHGG26VXHFAQXXJ2HCBP2QK"
           },
           {
             "version": 1,
@@ -202,7 +202,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "PAVWADNLHKBOZNWNEYVKPMHVKO4XQQEPLGHRYIPLKFCIQH3RGYQA===="
+          "battery/hash": "EULFD7SO44RHYSZ54TZ5MPLODXSS4FNR7PVU4OCZORFXEQIC7ROQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -212,7 +212,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195159a77a97d0299a437a255e2f7cb",
+          "battery/owner": "batt_01951a6371f27a33b065634656fb3331",
           "istio-injection": "enabled",
           "version": "latest"
         },

--- a/bootstrap/int-prod.install.json
+++ b/bootstrap/int-prod.install.json
@@ -1,13 +1,13 @@
 {
-  "id": "batt_0195159a77a272e790eda75fbf9ec926",
+  "id": "batt_01951a6371ec7893876d5f088c08c2e0",
   "usage": "internal_prod",
-  "team_id": "batt_0195159a772b7010add2b1c0a2ff1e8e",
+  "team_id": "batt_01951a63718c7afdb0feca073c30d586",
   "default_size": "medium",
   "control_jwk": {
     "crv": "Ed25519",
-    "d": "ac4tTWXKkLxn65GaZxgrveDTq9V9FtWPWi2PTKHPQlA",
+    "d": "b6CwkF04GLsoeWddT68Har4KChox08tcfpsJ6P-5ADc",
     "kty": "OKP",
-    "x": "d0TWdYKroyiGgpclwY3ujLwxtmapT1H7UyZD_e_KY9I"
+    "x": "LfvYWItObOzK_MtD91jCnS_JPYgVYmEtoU3DIrc23wI"
   },
   "inserted_at": null,
   "updated_at": null,

--- a/bootstrap/int-prod.spec.json
+++ b/bootstrap/int-prod.spec.json
@@ -9,7 +9,7 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_0195159a77ae7a709732ced4f5694dfb",
+        "id": "batt_01951a6371f671febab11615c873c04e",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -21,12 +21,12 @@
           "ai_namespace": "battery-ai",
           "default_size": "medium",
           "cluster_name": "int-prod",
-          "install_id": "batt_0195159a77a272e790eda75fbf9ec926",
+          "install_id": "batt_01951a6371ec7893876d5f088c08c2e0",
           "control_jwk": {
             "crv": "Ed25519",
-            "d": "ac4tTWXKkLxn65GaZxgrveDTq9V9FtWPWi2PTKHPQlA",
+            "d": "b6CwkF04GLsoeWddT68Har4KChox08tcfpsJ6P-5ADc",
             "kty": "OKP",
-            "x": "d0TWdYKroyiGgpclwY3ujLwxtmapT1H7UyZD_e_KY9I"
+            "x": "LfvYWItObOzK_MtD91jCnS_JPYgVYmEtoU3DIrc23wI"
           },
           "upgrade_days_of_week": [
             true,
@@ -51,7 +51,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195159a77ae769c816e4ae6680a333d",
+        "id": "batt_01951a6371f676c89b36d4897024a789",
         "type": "cert_manager",
         "config": {
           "type": "cert_manager",
@@ -63,21 +63,21 @@
           "webhook_image": "quay.io/jetstack/cert-manager-webhook:v1.15.4",
           "acmesolver_image_name_override": null,
           "acmesolver_image_tag_override": null,
-          "cainjector_image_name_override": null,
-          "cainjector_image_tag_override": null,
           "controller_image_name_override": null,
           "controller_image_tag_override": null,
-          "ctl_image_name_override": null,
-          "ctl_image_tag_override": null,
           "webhook_image_name_override": null,
-          "webhook_image_tag_override": null
+          "webhook_image_tag_override": null,
+          "cainjector_image_name_override": null,
+          "cainjector_image_tag_override": null,
+          "ctl_image_name_override": null,
+          "ctl_image_tag_override": null
         },
         "group": "net_sec",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0195159a77ae7bff89d431a65023b31a",
+        "id": "batt_01951a6371f6775d94c4ebcefb0cca07",
         "type": "battery_ca",
         "config": {
           "type": "battery_ca"
@@ -87,7 +87,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195159a77ae7418b04d720c8de63f70",
+        "id": "batt_01951a6371f6757aa43c0028132ff7d7",
         "type": "karpenter",
         "config": {
           "type": "karpenter",
@@ -96,16 +96,18 @@
           "queue_name": null,
           "node_role_name": null,
           "ami_alias": "al2@v20250212",
+          "bottlerocket_ami_alias": "bottlerocket@v1.32.0",
           "image_tag_override": null,
           "image_name_override": null,
-          "ami_alias_override": null
+          "ami_alias_override": null,
+          "bottlerocket_ami_alias_override": null
         },
         "group": "magic",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0195159a77ae7038995006bd63a9c198",
+        "id": "batt_01951a6371f67e26b00032c6c8491c90",
         "type": "aws_load_balancer_controller",
         "config": {
           "type": "aws_load_balancer_controller",
@@ -121,7 +123,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195159a77ae797a8502ceed763f0c7b",
+        "id": "batt_01951a6371f6710daed32301eb5809cc",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
@@ -137,7 +139,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195159a77ae7b2aafd116f6619f337b",
+        "id": "batt_01951a6371f6796bb4d696fc08ac10c1",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -152,7 +154,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195159a77ae7c148129a4fde98c5a64",
+        "id": "batt_01951a6371f6700f84204f4ed3429187",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -165,7 +167,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195159a77ae7173b45e81f90b0b8ae8",
+        "id": "batt_01951a6371f674afab77418991c40a01",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -177,7 +179,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195159a77ae7b719bd6c970eb2eda14",
+        "id": "batt_01951a6371f671c5b4bfd21fe2e950bc",
         "type": "ferretdb",
         "config": {
           "type": "ferretdb",
@@ -190,7 +192,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195159a77ae70ba8f801a0f90c05bc5",
+        "id": "batt_01951a6371f77d308656fafef57879ab",
         "type": "traditional_services",
         "config": {
           "type": "traditional_services",
@@ -201,7 +203,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195159a77ae7480adffd6a22e82a7a1",
+        "id": "batt_01951a6371f7767b9b915cd641b0e9a2",
         "type": "vm_agent",
         "config": {
           "type": "vm_agent",
@@ -213,11 +215,11 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195159a77ae7a59b342df18f140cfc6",
+        "id": "batt_01951a6371f77ef6842e0bf1821cbaaa",
         "type": "victoria_metrics",
         "config": {
           "type": "victoria_metrics",
-          "cookie_secret": "WW5iKMCjl454r24kx0lO96nM0JUPjwxRI0BzcMdxkZ0=",
+          "cookie_secret": "Hb73io5sXOTOx9wJ8q1_IAXK_lZwqGs2a-qbYW-phQs=",
           "replication_factor": 1,
           "operator_image": "victoriametrics/operator:v0.44.0",
           "vmselect_volume_size": 536870912,
@@ -229,16 +231,16 @@
           "virtual_size": "tiny",
           "virtual_vmselect_volume_size_range": 5035931120,
           "virtual_vmstorage_volume_size_range": 219902325555,
+          "cluster_image_tag_override": null,
           "operator_image_name_override": null,
-          "operator_image_tag_override": null,
-          "cluster_image_tag_override": null
+          "operator_image_tag_override": null
         },
         "group": "monitoring",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0195159a77af72d8a112c322bb0b56fd",
+        "id": "batt_01951a6371f77187aa56f3861499eece",
         "type": "grafana",
         "config": {
           "type": "grafana",
@@ -270,7 +272,7 @@
         "env_values": [
           {
             "name": "SECRET_KEY_BASE",
-            "value": "LNT5O4Q77W23MSCZJNGMNH55TESQGNFHI66IWPENXCGXEQNSRVXOTMHCX46FKACM",
+            "value": "P46BTCMWCSP3VOWH6SWD2ISQSSJ55Y3HLBIRPPAYBCY5Y3QDCXX7C5XSKZGOLNCW",
             "source_name": null,
             "source_type": "value",
             "source_key": null,
@@ -569,7 +571,7 @@
           {
             "version": 1,
             "username": "battery-control-user",
-            "password": "5ZSUHDGV3KNYSSXKBFXOPCOB"
+            "password": "5M6QU2NCLXKYL5DXGB3ODALX"
           }
         ],
         "cpu_requested": 4000,
@@ -610,7 +612,7 @@
           {
             "version": 1,
             "username": "home-base",
-            "password": "77WXLPFMDSUOJNZZS5UB43PI"
+            "password": "C36V26UUGFPKENLE6WQFQCOM"
           }
         ],
         "cpu_requested": 4000,
@@ -651,7 +653,7 @@
           {
             "version": 1,
             "username": "cla",
-            "password": "GOIUB4C3N4OTXDQH3BJTRYYN"
+            "password": "7AINHEAYWVYVNMD43RZH72T5"
           }
         ],
         "cpu_requested": 4000,
@@ -677,7 +679,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "ZFYHAG7P6HWLGUJZZ5J7PMYDHPKJMXJBY7FNUNCCTDSW7VHV2SCQ===="
+          "battery/hash": "R7WUXFUTDFPTBUBKK7MZNPYZHWNWIUO42PFZ7FZCS24NEE3YU5NA===="
         },
         "labels": {
           "app": "battery-core",
@@ -687,7 +689,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195159a77ae7a709732ced4f5694dfb",
+          "battery/owner": "batt_01951a6371f671febab11615c873c04e",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -708,17 +710,17 @@
     "/config_map/home_base_seed_data": {
       "apiVersion": "v1",
       "data": {
-        "batt_0195159a772b7010add2b1c0a2ff1e8e.team.json": "{\"id\":\"batt_0195159a772b7010add2b1c0a2ff1e8e\",\"name\":\"Batteries Included Team\",\"inserted_at\":null,\"updated_at\":null,\"op_email\":\"elliott@batteriesincl.com\",\"deleted_at\":null}",
-        "dev.install.json": "{\"id\":\"batt_0195159a772f78f394ea727b3e49c6f4\",\"usage\":\"internal_dev\",\"team_id\":\"batt_0195159a772b7010add2b1c0a2ff1e8e\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"Q0a7QjuroVZqV4xkd7ZYNyQLJoGyK5ZYmaNuV5Pkf5g\",\"kty\":\"OKP\",\"x\":\"eS2X2Qy2XpVHU6fn_iMwUHWbI3RMXDATf7pIh7oijPY\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"dev\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
-        "int-prod.install.json": "{\"id\":\"batt_0195159a77a272e790eda75fbf9ec926\",\"usage\":\"internal_prod\",\"team_id\":\"batt_0195159a772b7010add2b1c0a2ff1e8e\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"ac4tTWXKkLxn65GaZxgrveDTq9V9FtWPWi2PTKHPQlA\",\"kty\":\"OKP\",\"x\":\"d0TWdYKroyiGgpclwY3ujLwxtmapT1H7UyZD_e_KY9I\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"aws\",\"slug\":\"int-prod\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
-        "int-test.install.json": "{\"id\":\"batt_0195159a77a276bca239779a64991b44\",\"usage\":\"internal_int_test\",\"team_id\":\"batt_0195159a772b7010add2b1c0a2ff1e8e\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"01JsRvEjo6YcYTfWe3kP0mCXp1NDFvAtThex1lYRmmQ\",\"kty\":\"OKP\",\"x\":\"gcJgJEUSJ-D-XHJ89i4oEunRMwZcuMCtQugPwbC2SWo\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"int-test\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
-        "jason.install.json": "{\"id\":\"batt_0195159a77a27ea586e856c9c1247cf5\",\"usage\":\"development\",\"team_id\":\"batt_0195159a772b7010add2b1c0a2ff1e8e\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"rL0bImNMvJNvUzoMv_k9PPqo4diRoqiXSFPjVlNtikE\",\"kty\":\"OKP\",\"x\":\"9lUjcy2XnrXXkkTAhRM4Pyc7ktkEYoFqe_gaCfrVK_Y\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"aws\",\"slug\":\"jason\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
-        "local.install.json": "{\"id\":\"batt_0195159a77a275dfb24f503ea1cc2286\",\"usage\":\"development\",\"team_id\":\"batt_0195159a772b7010add2b1c0a2ff1e8e\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"BbMKraSikUwpX-DZAgfNjcftR8NyLnX8jr9YiACMWU0\",\"kty\":\"OKP\",\"x\":\"YWAt17CTfuf_1PPqvH-R8CsbmlE3BDFOkdFe4DelWrg\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"local\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}"
+        "batt_01951a63718c7afdb0feca073c30d586.team.json": "{\"id\":\"batt_01951a63718c7afdb0feca073c30d586\",\"name\":\"Batteries Included Team\",\"inserted_at\":null,\"updated_at\":null,\"op_email\":\"elliott@batteriesincl.com\",\"deleted_at\":null}",
+        "dev.install.json": "{\"id\":\"batt_01951a63718f7542ac3a63ad8d3a5430\",\"usage\":\"internal_dev\",\"team_id\":\"batt_01951a63718c7afdb0feca073c30d586\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"C4JhIvtGdbf0ZQtG_Mtlmy9p8sQ2iKC1uqY8AZZjWg0\",\"kty\":\"OKP\",\"x\":\"_yVRqEdZW9vv-qC9_bBLOyCJmM4u0Fbk2NnLGfStiTE\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"dev\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
+        "int-prod.install.json": "{\"id\":\"batt_01951a6371ec7893876d5f088c08c2e0\",\"usage\":\"internal_prod\",\"team_id\":\"batt_01951a63718c7afdb0feca073c30d586\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"b6CwkF04GLsoeWddT68Har4KChox08tcfpsJ6P-5ADc\",\"kty\":\"OKP\",\"x\":\"LfvYWItObOzK_MtD91jCnS_JPYgVYmEtoU3DIrc23wI\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"aws\",\"slug\":\"int-prod\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
+        "int-test.install.json": "{\"id\":\"batt_01951a6371ec7a76bb6fbbdf8b0ebc0f\",\"usage\":\"internal_int_test\",\"team_id\":\"batt_01951a63718c7afdb0feca073c30d586\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"asy3U2FlkqRXszdcfFSFF0iQw2L1psCROoWOrjXl8ds\",\"kty\":\"OKP\",\"x\":\"xHvgnQDCSodjVykFlm46aq9-ET9SGNj_5kshIPe2Zxw\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"int-test\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
+        "jason.install.json": "{\"id\":\"batt_01951a6371ec7b0d9ef241459d5e794a\",\"usage\":\"development\",\"team_id\":\"batt_01951a63718c7afdb0feca073c30d586\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"4JGcLgyigm0keUMSp5VyLbO3KMV3vv1gqA3s_0rXwW4\",\"kty\":\"OKP\",\"x\":\"AshGSGuoscEXmnuHjo7vW88oCuDjxA5B8FEDdG8P5Mw\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"aws\",\"slug\":\"jason\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
+        "local.install.json": "{\"id\":\"batt_01951a6371ec769886f2a074e6a5af0c\",\"usage\":\"development\",\"team_id\":\"batt_01951a63718c7afdb0feca073c30d586\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"IgZlCJzfaxieWzpqUeqMuJvE8mP0bvhpDuml1z_E9Is\",\"kty\":\"OKP\",\"x\":\"To3OhTjw5t70TvtnjTLvAKbICA2yQ__hOqKTyW3Jt_Y\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"local\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}"
       },
       "kind": "ConfigMap",
       "metadata": {
         "annotations": {
-          "battery/hash": "MGNYLJIVUC67LNWBKQMMGSIKE532RSUZXF2U6AIMSLBIIYSOABZQ===="
+          "battery/hash": "X6MDT6YBAN7VKUYZEBEEYPA6HKDGI226UZM4LRW3S2OEFV6HM5PA===="
         },
         "labels": {
           "app": "traditional-services",
@@ -728,7 +730,7 @@
           "battery/app": "traditional-services",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195159a77ae70ba8f801a0f90c05bc5",
+          "battery/owner": "batt_01951a6371f77d308656fafef57879ab",
           "version": "latest"
         },
         "name": "home-base-seed-data",
@@ -740,7 +742,7 @@
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "DXJAKJVKVVTYSBAP2JELCBFIRFRKQSKN7GENIQYZGRZEXTW2OILQ===="
+          "battery/hash": "UYHZXXJYU5VGAWHTQERCXP7YYNXH2UHA4JMEHZ6EWUGZGJFWZSOQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -750,7 +752,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195159a77ae7a709732ced4f5694dfb",
+          "battery/owner": "batt_01951a6371f671febab11615c873c04e",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -774,7 +776,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_0195159a77ae7a709732ced4f5694dfb",
+              "battery/owner": "batt_01951a6371f671febab11615c873c04e",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -787,7 +789,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "NLVS65ML6QM33DXRFYRKOXTFDQWGMI7DOBKQB32GT7QEDG6625UVSRAPK3OJGHWA"
+                    "value": "CD2GAS3GMQYAMTXTOZNB5MKU7EEXQ3TYXQNJ2B7XN5IKHZHZBTRA7EVYFXUNHDX4"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -835,7 +837,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "G2P3MQTRRT6LX26W2KRVCO7ZZDXX25KC4GTM3G6DPFMOH364AIRA===="
+          "battery/hash": "RBGF76QTYHW4RHR5AODIFHRQJXR7YONR4UCIASLDLQPHYOFYJKPA===="
         },
         "labels": {
           "app": "battery-core",
@@ -845,7 +847,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195159a77ae7a709732ced4f5694dfb",
+          "battery/owner": "batt_01951a6371f671febab11615c873c04e",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -857,7 +859,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "TQEMCIO6UUZCKEQVTTOC5H3J6ZVG3UJZ7MJOB64EAGEZLBR22GYQ===="
+          "battery/hash": "267IJBVDBVIXZJNHJE4SM5ZSKU3TCPFDNKT72WFVPPSUQ2Z5ZS7Q===="
         },
         "labels": {
           "app": "traditional-services",
@@ -867,7 +869,7 @@
           "battery/app": "traditional-services",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195159a77ae70ba8f801a0f90c05bc5",
+          "battery/owner": "batt_01951a6371f77d308656fafef57879ab",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -879,7 +881,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "FJEOFBS44J6Q6FTDEMI4WSOE6DSK7XEGB42LKILMTL2OVNW6RFNQ===="
+          "battery/hash": "Z7CDKF44EY3OI3FEQ3M4IJT5HWVB6AWC4JOV2NQILBS2ZORVLTYQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -889,7 +891,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195159a77ae7a709732ced4f5694dfb",
+          "battery/owner": "batt_01951a6371f671febab11615c873c04e",
           "version": "latest"
         },
         "name": "bootstrap",
@@ -902,7 +904,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "COAY3PYAIMFQLMT7T5CMEEYQP7TOOQ6PXR7BEKQP6GHG3UNO2Z4Q====",
+          "battery/hash": "QK4TZZS2NYSTGKP7QCHFJZ2XNNROHKBBTZKQ3ACT4ZBVCELM4MFA====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -913,7 +915,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195159a77ae7a709732ced4f5694dfb",
+          "battery/owner": "batt_01951a6371f671febab11615c873c04e",
           "version": "latest"
         },
         "name": "gp2"
@@ -928,7 +930,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "S6VX2PA2OHCIR4G5VW2WDYW6KYICRFKOSKYU5W3O5WKYU75MK5JA====",
+          "battery/hash": "3IQMFKHCQFOKIR3QOQOK3PIK55EFEA3QFGUIN3MKHE57RJRCIMUQ====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -939,7 +941,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195159a77ae7a709732ced4f5694dfb",
+          "battery/owner": "batt_01951a6371f671febab11615c873c04e",
           "version": "latest"
         },
         "name": "gp2-90032408"
@@ -959,7 +961,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "T2FV52TVSKF3OBYQYUCMWXDPYXE7SJPM7PSTFKG6JKSYP5JMJT4A====",
+          "battery/hash": "KKKMFXL2CD6R4Y42TY5T763BXNSHR3LFDV2JQ4DCXSGAKUWYDLVQ====",
           "storageclass.kubernetes.io/is-default-class": "true"
         },
         "labels": {
@@ -970,7 +972,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195159a77ae7a709732ced4f5694dfb",
+          "battery/owner": "batt_01951a6371f671febab11615c873c04e",
           "version": "latest"
         },
         "name": "gp3-105457460"

--- a/bootstrap/int-test.install.json
+++ b/bootstrap/int-test.install.json
@@ -1,13 +1,13 @@
 {
-  "id": "batt_0195159a77a276bca239779a64991b44",
+  "id": "batt_01951a6371ec7a76bb6fbbdf8b0ebc0f",
   "usage": "internal_int_test",
-  "team_id": "batt_0195159a772b7010add2b1c0a2ff1e8e",
+  "team_id": "batt_01951a63718c7afdb0feca073c30d586",
   "default_size": "medium",
   "control_jwk": {
     "crv": "Ed25519",
-    "d": "01JsRvEjo6YcYTfWe3kP0mCXp1NDFvAtThex1lYRmmQ",
+    "d": "asy3U2FlkqRXszdcfFSFF0iQw2L1psCROoWOrjXl8ds",
     "kty": "OKP",
-    "x": "gcJgJEUSJ-D-XHJ89i4oEunRMwZcuMCtQugPwbC2SWo"
+    "x": "xHvgnQDCSodjVykFlm46aq9-ET9SGNj_5kshIPe2Zxw"
   },
   "inserted_at": null,
   "updated_at": null,

--- a/bootstrap/int-test.spec.json
+++ b/bootstrap/int-test.spec.json
@@ -9,7 +9,7 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_0195159a77ac7a13a65941e8930ec247",
+        "id": "batt_01951a6371f57959a929e7548d2984f7",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -21,12 +21,12 @@
           "ai_namespace": "battery-ai",
           "default_size": "medium",
           "cluster_name": "int-test",
-          "install_id": "batt_0195159a77a276bca239779a64991b44",
+          "install_id": "batt_01951a6371ec7a76bb6fbbdf8b0ebc0f",
           "control_jwk": {
             "crv": "Ed25519",
-            "d": "01JsRvEjo6YcYTfWe3kP0mCXp1NDFvAtThex1lYRmmQ",
+            "d": "asy3U2FlkqRXszdcfFSFF0iQw2L1psCROoWOrjXl8ds",
             "kty": "OKP",
-            "x": "gcJgJEUSJ-D-XHJ89i4oEunRMwZcuMCtQugPwbC2SWo"
+            "x": "xHvgnQDCSodjVykFlm46aq9-ET9SGNj_5kshIPe2Zxw"
           },
           "upgrade_days_of_week": [
             true,
@@ -51,7 +51,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195159a77ac7eb6adb2fc44bf8624ef",
+        "id": "batt_01951a6371f57765bba686ca28ae96aa",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
@@ -67,7 +67,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195159a77ac776c941b0901ecef8b1c",
+        "id": "batt_01951a6371f57f9184524b8009a47948",
         "type": "ferretdb",
         "config": {
           "type": "ferretdb",
@@ -80,7 +80,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195159a77ac72b8a8411061cbf5da0a",
+        "id": "batt_01951a6371f57cbcb83d737807ad51d8",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -95,7 +95,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195159a77ac76d8b9c51bede07b1a6a",
+        "id": "batt_01951a6371f572aaa2cd0e47214a5965",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -108,7 +108,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195159a77ad7c15b56f8356d945d20a",
+        "id": "batt_01951a6371f57774bbc860e7521f3d49",
         "type": "metallb",
         "config": {
           "type": "metallb",
@@ -128,7 +128,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195159a77ad7551be906a5df700e404",
+        "id": "batt_01951a6371f575219b61e23937cd55f1",
         "type": "traditional_services",
         "config": {
           "type": "traditional_services",
@@ -155,7 +155,7 @@
         "env_values": [
           {
             "name": "SECRET_KEY_BASE",
-            "value": "SLJKUQHLFTXXAAHULYQSIVTNERBPSFKBYDZ2RDNUU5F4VOWKQBWQICT55H4PLSNW",
+            "value": "JPZHHXPEVKCRP56VZHTO6LNKVOSXNSNYCFQXB75RN4DMYYYN4VXZYOALBJ5QA4ER",
             "source_name": null,
             "source_type": "value",
             "source_key": null,
@@ -465,7 +465,7 @@
           {
             "version": 2,
             "username": "battery-control-user",
-            "password": "CK6W7AEOXCVG4SHCWRSISKLG"
+            "password": "EHY4L6KZ7ATLOV6JF7JFLU3G"
           },
           {
             "version": 1,
@@ -511,7 +511,7 @@
           {
             "version": 1,
             "username": "home-base",
-            "password": "E6TSIYBVV57R2YU2KB2LHEP2"
+            "password": "QKVFCGMF6SS6JVMHAVS47FFU"
           }
         ],
         "cpu_requested": 4000,
@@ -552,7 +552,7 @@
           {
             "version": 1,
             "username": "cla",
-            "password": "6QSDTCEFW42HK6NUJGA62CD7"
+            "password": "CRR3G2K5O5RPB2Q65MRHEBNK"
           }
         ],
         "cpu_requested": 4000,
@@ -578,7 +578,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "EOTYLGXC5EEIMOZ5FYNDC4H7MTOJZCG5DKOLW3PLETDF56RH23LQ===="
+          "battery/hash": "FE62OT2YM5T2CWQUEVJYSLZQLXO4UQYB6O2VBLGGF7MP5L6OV2CQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -588,7 +588,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195159a77ac7a13a65941e8930ec247",
+          "battery/owner": "batt_01951a6371f57959a929e7548d2984f7",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -609,17 +609,17 @@
     "/config_map/home_base_seed_data": {
       "apiVersion": "v1",
       "data": {
-        "batt_0195159a772b7010add2b1c0a2ff1e8e.team.json": "{\"id\":\"batt_0195159a772b7010add2b1c0a2ff1e8e\",\"name\":\"Batteries Included Team\",\"inserted_at\":null,\"updated_at\":null,\"op_email\":\"elliott@batteriesincl.com\",\"deleted_at\":null}",
-        "dev.install.json": "{\"id\":\"batt_0195159a772f78f394ea727b3e49c6f4\",\"usage\":\"internal_dev\",\"team_id\":\"batt_0195159a772b7010add2b1c0a2ff1e8e\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"Q0a7QjuroVZqV4xkd7ZYNyQLJoGyK5ZYmaNuV5Pkf5g\",\"kty\":\"OKP\",\"x\":\"eS2X2Qy2XpVHU6fn_iMwUHWbI3RMXDATf7pIh7oijPY\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"dev\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
-        "int-prod.install.json": "{\"id\":\"batt_0195159a77a272e790eda75fbf9ec926\",\"usage\":\"internal_prod\",\"team_id\":\"batt_0195159a772b7010add2b1c0a2ff1e8e\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"ac4tTWXKkLxn65GaZxgrveDTq9V9FtWPWi2PTKHPQlA\",\"kty\":\"OKP\",\"x\":\"d0TWdYKroyiGgpclwY3ujLwxtmapT1H7UyZD_e_KY9I\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"aws\",\"slug\":\"int-prod\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
-        "int-test.install.json": "{\"id\":\"batt_0195159a77a276bca239779a64991b44\",\"usage\":\"internal_int_test\",\"team_id\":\"batt_0195159a772b7010add2b1c0a2ff1e8e\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"01JsRvEjo6YcYTfWe3kP0mCXp1NDFvAtThex1lYRmmQ\",\"kty\":\"OKP\",\"x\":\"gcJgJEUSJ-D-XHJ89i4oEunRMwZcuMCtQugPwbC2SWo\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"int-test\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
-        "jason.install.json": "{\"id\":\"batt_0195159a77a27ea586e856c9c1247cf5\",\"usage\":\"development\",\"team_id\":\"batt_0195159a772b7010add2b1c0a2ff1e8e\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"rL0bImNMvJNvUzoMv_k9PPqo4diRoqiXSFPjVlNtikE\",\"kty\":\"OKP\",\"x\":\"9lUjcy2XnrXXkkTAhRM4Pyc7ktkEYoFqe_gaCfrVK_Y\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"aws\",\"slug\":\"jason\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
-        "local.install.json": "{\"id\":\"batt_0195159a77a275dfb24f503ea1cc2286\",\"usage\":\"development\",\"team_id\":\"batt_0195159a772b7010add2b1c0a2ff1e8e\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"BbMKraSikUwpX-DZAgfNjcftR8NyLnX8jr9YiACMWU0\",\"kty\":\"OKP\",\"x\":\"YWAt17CTfuf_1PPqvH-R8CsbmlE3BDFOkdFe4DelWrg\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"local\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}"
+        "batt_01951a63718c7afdb0feca073c30d586.team.json": "{\"id\":\"batt_01951a63718c7afdb0feca073c30d586\",\"name\":\"Batteries Included Team\",\"inserted_at\":null,\"updated_at\":null,\"op_email\":\"elliott@batteriesincl.com\",\"deleted_at\":null}",
+        "dev.install.json": "{\"id\":\"batt_01951a63718f7542ac3a63ad8d3a5430\",\"usage\":\"internal_dev\",\"team_id\":\"batt_01951a63718c7afdb0feca073c30d586\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"C4JhIvtGdbf0ZQtG_Mtlmy9p8sQ2iKC1uqY8AZZjWg0\",\"kty\":\"OKP\",\"x\":\"_yVRqEdZW9vv-qC9_bBLOyCJmM4u0Fbk2NnLGfStiTE\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"dev\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
+        "int-prod.install.json": "{\"id\":\"batt_01951a6371ec7893876d5f088c08c2e0\",\"usage\":\"internal_prod\",\"team_id\":\"batt_01951a63718c7afdb0feca073c30d586\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"b6CwkF04GLsoeWddT68Har4KChox08tcfpsJ6P-5ADc\",\"kty\":\"OKP\",\"x\":\"LfvYWItObOzK_MtD91jCnS_JPYgVYmEtoU3DIrc23wI\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"aws\",\"slug\":\"int-prod\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
+        "int-test.install.json": "{\"id\":\"batt_01951a6371ec7a76bb6fbbdf8b0ebc0f\",\"usage\":\"internal_int_test\",\"team_id\":\"batt_01951a63718c7afdb0feca073c30d586\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"asy3U2FlkqRXszdcfFSFF0iQw2L1psCROoWOrjXl8ds\",\"kty\":\"OKP\",\"x\":\"xHvgnQDCSodjVykFlm46aq9-ET9SGNj_5kshIPe2Zxw\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"int-test\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
+        "jason.install.json": "{\"id\":\"batt_01951a6371ec7b0d9ef241459d5e794a\",\"usage\":\"development\",\"team_id\":\"batt_01951a63718c7afdb0feca073c30d586\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"4JGcLgyigm0keUMSp5VyLbO3KMV3vv1gqA3s_0rXwW4\",\"kty\":\"OKP\",\"x\":\"AshGSGuoscEXmnuHjo7vW88oCuDjxA5B8FEDdG8P5Mw\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"aws\",\"slug\":\"jason\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
+        "local.install.json": "{\"id\":\"batt_01951a6371ec769886f2a074e6a5af0c\",\"usage\":\"development\",\"team_id\":\"batt_01951a63718c7afdb0feca073c30d586\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"Ed25519\",\"d\":\"IgZlCJzfaxieWzpqUeqMuJvE8mP0bvhpDuml1z_E9Is\",\"kty\":\"OKP\",\"x\":\"To3OhTjw5t70TvtnjTLvAKbICA2yQ__hOqKTyW3Jt_Y\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"local\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}"
       },
       "kind": "ConfigMap",
       "metadata": {
         "annotations": {
-          "battery/hash": "JFXV7O2I74EU4YXAGNOYTMQOJE3AH3FZO7FQAUJEJSEVRKZYFOTQ===="
+          "battery/hash": "EDM4CKMEFKDJUACFUK32N7OGE2X7ZXSMW6EEQQ3ZAVZGAVR2YP7Q===="
         },
         "labels": {
           "app": "traditional-services",
@@ -629,7 +629,7 @@
           "battery/app": "traditional-services",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195159a77ad7551be906a5df700e404",
+          "battery/owner": "batt_01951a6371f575219b61e23937cd55f1",
           "version": "latest"
         },
         "name": "home-base-seed-data",
@@ -641,7 +641,7 @@
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "FDPZKEWYDFLZYDESMFGYHQI2R7Q6FTMOHYB52XPRDKEUVGL4VOVQ===="
+          "battery/hash": "34LLZGZ3VAP56UA4X7RILAIFQJPCJSIR3GGX5O4HBJ6CNOJL5EPA===="
         },
         "labels": {
           "app": "battery-core",
@@ -651,7 +651,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195159a77ac7a13a65941e8930ec247",
+          "battery/owner": "batt_01951a6371f57959a929e7548d2984f7",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -675,7 +675,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_0195159a77ac7a13a65941e8930ec247",
+              "battery/owner": "batt_01951a6371f57959a929e7548d2984f7",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -688,7 +688,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "C7SFVEMFEHX4NN2SRE4RVCKBNPMOQKK7YZV2PRJDCUWXC27IYF3BJYVXYTVT6DAP"
+                    "value": "FZPQE62GHJDJUTHFZJRESZK7HX7DWL6IT64HVQCZC47DKRXPXEWGVP5CNN3D657Y"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -736,7 +736,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "QEXITQ7WHXUBP6GVDKN5KSLGLMNGIXRX4MR3YZS2DUJ3DHD4WPZA===="
+          "battery/hash": "22UMA7BK3CUXYJZLYTR5HWNIPEPFDASJAT5ORHQ2VYDHD5KEQ5OQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -746,7 +746,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195159a77ac7a13a65941e8930ec247",
+          "battery/owner": "batt_01951a6371f57959a929e7548d2984f7",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -758,7 +758,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "7GFYHSFKQ2KPUKNNZK7YZZSFVNQAHIDIDOZJI265G55IVSOFVMAQ===="
+          "battery/hash": "NY77RASGK5BDMX6PSMO5EY534GN7IQUOIRMQZR3SF3EBEPP4BSFA===="
         },
         "labels": {
           "app": "traditional-services",
@@ -768,7 +768,7 @@
           "battery/app": "traditional-services",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195159a77ad7551be906a5df700e404",
+          "battery/owner": "batt_01951a6371f575219b61e23937cd55f1",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -780,7 +780,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "E6YRPTOGITB2MNHC2W3CEH4ZEK44W5FCKLPARWCV3PZYNWOCLWJA===="
+          "battery/hash": "YMI3ZWHE6ZBDKZKIAS5DD7E3C63VJB5GXYOVJIFNGN5ZJFCW6KKQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -790,7 +790,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195159a77ac7a13a65941e8930ec247",
+          "battery/owner": "batt_01951a6371f57959a929e7548d2984f7",
           "version": "latest"
         },
         "name": "bootstrap",

--- a/bootstrap/jason.install.json
+++ b/bootstrap/jason.install.json
@@ -1,13 +1,13 @@
 {
-  "id": "batt_0195159a77a27ea586e856c9c1247cf5",
+  "id": "batt_01951a6371ec7b0d9ef241459d5e794a",
   "usage": "development",
-  "team_id": "batt_0195159a772b7010add2b1c0a2ff1e8e",
+  "team_id": "batt_01951a63718c7afdb0feca073c30d586",
   "default_size": "small",
   "control_jwk": {
     "crv": "Ed25519",
-    "d": "rL0bImNMvJNvUzoMv_k9PPqo4diRoqiXSFPjVlNtikE",
+    "d": "4JGcLgyigm0keUMSp5VyLbO3KMV3vv1gqA3s_0rXwW4",
     "kty": "OKP",
-    "x": "9lUjcy2XnrXXkkTAhRM4Pyc7ktkEYoFqe_gaCfrVK_Y"
+    "x": "AshGSGuoscEXmnuHjo7vW88oCuDjxA5B8FEDdG8P5Mw"
   },
   "inserted_at": null,
   "updated_at": null,

--- a/bootstrap/jason.spec.json
+++ b/bootstrap/jason.spec.json
@@ -9,7 +9,7 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_0195159a77b17b82b8555d3c05a7bfc0",
+        "id": "batt_01951a6371f973d59108fae4758aa120",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -21,12 +21,12 @@
           "ai_namespace": "battery-ai",
           "default_size": "small",
           "cluster_name": "jason",
-          "install_id": "batt_0195159a77a27ea586e856c9c1247cf5",
+          "install_id": "batt_01951a6371ec7b0d9ef241459d5e794a",
           "control_jwk": {
             "crv": "Ed25519",
-            "d": "rL0bImNMvJNvUzoMv_k9PPqo4diRoqiXSFPjVlNtikE",
+            "d": "4JGcLgyigm0keUMSp5VyLbO3KMV3vv1gqA3s_0rXwW4",
             "kty": "OKP",
-            "x": "9lUjcy2XnrXXkkTAhRM4Pyc7ktkEYoFqe_gaCfrVK_Y"
+            "x": "AshGSGuoscEXmnuHjo7vW88oCuDjxA5B8FEDdG8P5Mw"
           },
           "upgrade_days_of_week": [
             true,
@@ -51,7 +51,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195159a77b1739593a6d8b3d28cd1d3",
+        "id": "batt_01951a6371f9714ca0db9c956e06a06f",
         "type": "cert_manager",
         "config": {
           "type": "cert_manager",
@@ -63,21 +63,21 @@
           "webhook_image": "quay.io/jetstack/cert-manager-webhook:v1.15.4",
           "acmesolver_image_name_override": null,
           "acmesolver_image_tag_override": null,
-          "cainjector_image_name_override": null,
-          "cainjector_image_tag_override": null,
           "controller_image_name_override": null,
           "controller_image_tag_override": null,
-          "ctl_image_name_override": null,
-          "ctl_image_tag_override": null,
           "webhook_image_name_override": null,
-          "webhook_image_tag_override": null
+          "webhook_image_tag_override": null,
+          "cainjector_image_name_override": null,
+          "cainjector_image_tag_override": null,
+          "ctl_image_name_override": null,
+          "ctl_image_tag_override": null
         },
         "group": "net_sec",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0195159a77b172cba4e385c8b997ec11",
+        "id": "batt_01951a6371f978a0acb46849d0147c31",
         "type": "battery_ca",
         "config": {
           "type": "battery_ca"
@@ -87,7 +87,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195159a77b17a03b7bae4bb2a219202",
+        "id": "batt_01951a6371f97fbba99fc26aee615e0f",
         "type": "karpenter",
         "config": {
           "type": "karpenter",
@@ -96,16 +96,18 @@
           "queue_name": null,
           "node_role_name": null,
           "ami_alias": "al2@v20250212",
+          "bottlerocket_ami_alias": "bottlerocket@v1.32.0",
           "image_tag_override": null,
           "image_name_override": null,
-          "ami_alias_override": null
+          "ami_alias_override": null,
+          "bottlerocket_ami_alias_override": null
         },
         "group": "magic",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0195159a77b17a8091403579f0c2752e",
+        "id": "batt_01951a6371f9790f8ca2d7fba99b6700",
         "type": "aws_load_balancer_controller",
         "config": {
           "type": "aws_load_balancer_controller",
@@ -121,7 +123,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195159a77b17df48ef3a61a580b291e",
+        "id": "batt_01951a6371f970dfaa62fa35e27f907d",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
@@ -137,7 +139,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195159a77b171939af2ad39484a58b8",
+        "id": "batt_01951a6371f97f09978314e57f371257",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -152,7 +154,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195159a77b17d838ade4d22317fc57f",
+        "id": "batt_01951a6371f97ce295243304de63e132",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -165,7 +167,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195159a77b17926a16487bb782ecbc0",
+        "id": "batt_01951a6371f972cd90a8a45fadfdf6bd",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -210,7 +212,7 @@
           {
             "version": 1,
             "username": "battery-control-user",
-            "password": "DUO4FC2VARZEUVVSTXYOUT46"
+            "password": "KLSJH52Z6FACJXB4WWNEPY3I"
           }
         ],
         "cpu_requested": 500,
@@ -236,7 +238,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "UUCEF67USMLIKN3FKFYFSMPWY7PLDJDVBXJ5EII7XRXPIKJYYPEA===="
+          "battery/hash": "JAC77MMZMSEHBXOODKJ6ZY2IFHE4J63GIOGC677USBJEJXDVH7ZQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -246,7 +248,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195159a77b17b82b8555d3c05a7bfc0",
+          "battery/owner": "batt_01951a6371f973d59108fae4758aa120",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -269,7 +271,7 @@
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "A2HY77AEY6WBYNI3TW62YQHFG4NEGII3ZYYHAKJWWISDUGEIMK3A===="
+          "battery/hash": "EAWWNPASYH3KA2VD5PCU2NSPVS5V7M2ANHMDZTVQOWT4ZMGZH6AA===="
         },
         "labels": {
           "app": "battery-core",
@@ -279,7 +281,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195159a77b17b82b8555d3c05a7bfc0",
+          "battery/owner": "batt_01951a6371f973d59108fae4758aa120",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -303,7 +305,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_0195159a77b17b82b8555d3c05a7bfc0",
+              "battery/owner": "batt_01951a6371f973d59108fae4758aa120",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -316,7 +318,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "7E5AY7MNDDB4WQ5CZ3TN4S7POGSUJYSAKFUZEG5WM6XKRBFRI5XGKGQBCKMADW67"
+                    "value": "IDEEWPLZFRFN5QIVUS2ZOVC5NW4GACBARLXUKR6ZLS2EXQY37Z5LBE5P446DRDML"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -364,7 +366,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "DQ2EJRYRW7DEJB2VZHRBLU4VLTY2DRLD3M6AKX2U25Z4ODXHN3QA===="
+          "battery/hash": "GY47IADQCUN2DSUT3F5U4NQSX23XBWO4HY35WSP2D6H5X4O5K3LA===="
         },
         "labels": {
           "app": "battery-core",
@@ -374,7 +376,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195159a77b17b82b8555d3c05a7bfc0",
+          "battery/owner": "batt_01951a6371f973d59108fae4758aa120",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -386,7 +388,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "UNLN774DJQEVTJ7BOCWPNPTPGE5RVSOG3RSYNS7J7LNUQXBA6XMQ===="
+          "battery/hash": "NX2FRGIWSKL5V7BB4ZMHN5VVF6KXV3XBZ7FEEGGXNQDG3QIU4ASQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -396,7 +398,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195159a77b17b82b8555d3c05a7bfc0",
+          "battery/owner": "batt_01951a6371f973d59108fae4758aa120",
           "version": "latest"
         },
         "name": "bootstrap",
@@ -409,7 +411,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "BKQQPSV3Y26SQYV4DO4HFOSBBEWCBCA3CURIXHQM5GX4SUR2XKFQ====",
+          "battery/hash": "UCGU36BKHMP7EQPWF2NESE5RDSRHSCX4VX5JVHPEVSFGUJL66QNA====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -420,7 +422,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195159a77b17b82b8555d3c05a7bfc0",
+          "battery/owner": "batt_01951a6371f973d59108fae4758aa120",
           "version": "latest"
         },
         "name": "gp2"
@@ -435,7 +437,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "K4347WYFQ3BMPIKCXWZJ3LX7IDD4C4MCRLZICCMQZUYJFMDD3KGQ====",
+          "battery/hash": "EA6CJXCP2VCI4YJ56AEAOC6CLJXJEHKP2GR3UEXV5SDJEE4WKQGA====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -446,7 +448,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195159a77b17b82b8555d3c05a7bfc0",
+          "battery/owner": "batt_01951a6371f973d59108fae4758aa120",
           "version": "latest"
         },
         "name": "gp2-90032408"
@@ -466,7 +468,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "MTQEI7TD62XFZU7CA2M6XICINMCHYZQRQQRVGXJOSTUK4HUCZEIQ====",
+          "battery/hash": "CSJA5QLPDDUGDUD6OIWFKWOBQ72LMS4XQRB6HCSBM3TPP3BVHAPA====",
           "storageclass.kubernetes.io/is-default-class": "true"
         },
         "labels": {
@@ -477,7 +479,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195159a77b17b82b8555d3c05a7bfc0",
+          "battery/owner": "batt_01951a6371f973d59108fae4758aa120",
           "version": "latest"
         },
         "name": "gp3-105457460"

--- a/bootstrap/local.install.json
+++ b/bootstrap/local.install.json
@@ -1,13 +1,13 @@
 {
-  "id": "batt_0195159a77a275dfb24f503ea1cc2286",
+  "id": "batt_01951a6371ec769886f2a074e6a5af0c",
   "usage": "development",
-  "team_id": "batt_0195159a772b7010add2b1c0a2ff1e8e",
+  "team_id": "batt_01951a63718c7afdb0feca073c30d586",
   "default_size": "tiny",
   "control_jwk": {
     "crv": "Ed25519",
-    "d": "BbMKraSikUwpX-DZAgfNjcftR8NyLnX8jr9YiACMWU0",
+    "d": "IgZlCJzfaxieWzpqUeqMuJvE8mP0bvhpDuml1z_E9Is",
     "kty": "OKP",
-    "x": "YWAt17CTfuf_1PPqvH-R8CsbmlE3BDFOkdFe4DelWrg"
+    "x": "To3OhTjw5t70TvtnjTLvAKbICA2yQ__hOqKTyW3Jt_Y"
   },
   "inserted_at": null,
   "updated_at": null,

--- a/bootstrap/local.spec.json
+++ b/bootstrap/local.spec.json
@@ -9,7 +9,7 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_0195159a77b0726095611161e2420fa4",
+        "id": "batt_01951a6371f87572b39a4ba9048c8463",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -24,7 +24,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195159a77b07b9e845763c4a235861c",
+        "id": "batt_01951a6371f87ebd86a8f27904cf4aea",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -37,7 +37,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195159a77b079fa8101fd27092ebb62",
+        "id": "batt_01951a6371f87363a6eb6e0a0438b8f4",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -49,12 +49,12 @@
           "ai_namespace": "battery-ai",
           "default_size": "tiny",
           "cluster_name": "local",
-          "install_id": "batt_0195159a77a275dfb24f503ea1cc2286",
+          "install_id": "batt_01951a6371ec769886f2a074e6a5af0c",
           "control_jwk": {
             "crv": "Ed25519",
-            "d": "BbMKraSikUwpX-DZAgfNjcftR8NyLnX8jr9YiACMWU0",
+            "d": "IgZlCJzfaxieWzpqUeqMuJvE8mP0bvhpDuml1z_E9Is",
             "kty": "OKP",
-            "x": "YWAt17CTfuf_1PPqvH-R8CsbmlE3BDFOkdFe4DelWrg"
+            "x": "To3OhTjw5t70TvtnjTLvAKbICA2yQ__hOqKTyW3Jt_Y"
           },
           "upgrade_days_of_week": [
             true,
@@ -79,7 +79,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195159a77b07ea18d74dbde771eb2ed",
+        "id": "batt_01951a6371f878e281aba04366beed4f",
         "type": "metallb",
         "config": {
           "type": "metallb",
@@ -99,7 +99,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195159a77b0718ba572ef3407274881",
+        "id": "batt_01951a6371f8759fbe73b52e92186ef5",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
@@ -115,7 +115,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195159a77b0707698f7ff6700299984",
+        "id": "batt_01951a6371f879eca477740ba0755431",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -160,7 +160,7 @@
           {
             "version": 1,
             "username": "battery-control-user",
-            "password": "TSTCKQUR7KMRVZN2BOV5OXYH"
+            "password": "LC7NRIVKBFK6DI2N6ELP3HYY"
           }
         ],
         "cpu_requested": 500,
@@ -186,7 +186,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "7CBAXFY5P7KOQTCFYGHQBKFS5S6V7SXI62F3B6GKRPW34B42LAGQ===="
+          "battery/hash": "S2CJ7J5ODVEARFX3PZKAQEOAVDJYPUG44B3RN3PFOPWY7OQIULGQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -196,7 +196,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195159a77b079fa8101fd27092ebb62",
+          "battery/owner": "batt_01951a6371f87363a6eb6e0a0438b8f4",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -219,7 +219,7 @@
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "5BVKOXLYVG4OXMDU7YHLCBGDLTLUT5WPVL4IPI2OTXMJIWPACMJQ===="
+          "battery/hash": "E4SQXYDJ7RGJZ5W65XLU36HNJUSYTOABYVMGNVAS7QKTNCC4UW6Q===="
         },
         "labels": {
           "app": "battery-core",
@@ -229,7 +229,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195159a77b079fa8101fd27092ebb62",
+          "battery/owner": "batt_01951a6371f87363a6eb6e0a0438b8f4",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -253,7 +253,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_0195159a77b079fa8101fd27092ebb62",
+              "battery/owner": "batt_01951a6371f87363a6eb6e0a0438b8f4",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -266,7 +266,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "AS42QM43KJJF7JYBWKTRBB6AAPSIUTGXAHAZQVFD35BZD5FISTFBDRIFZRUCEELE"
+                    "value": "GUUPYJO2UFNAFEHBIPYAKMO5CHO4PHDYWGAP44UMIH64YIWD6JJETDBBUIOVSVTO"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -314,7 +314,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "RPAVHBXWNKJVLLS7MVKXJ3ELNHK6IVJ243CBQDCMKMUK3OO3ILZQ===="
+          "battery/hash": "D3274OIAMDZUC56P4YT6BG7MS4VSKLNLKFGDJCIQG4L2WHO74U2A===="
         },
         "labels": {
           "app": "battery-core",
@@ -324,7 +324,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195159a77b079fa8101fd27092ebb62",
+          "battery/owner": "batt_01951a6371f87363a6eb6e0a0438b8f4",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -336,7 +336,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "CO2EK7PFOLB4S6EOQ6SPWI4YBG7JXLW5Y2QEIEPTF47HXKYVTTPQ===="
+          "battery/hash": "EN4WMJFBK723W5GJB7KZF63LADCAS56O7A5WBEDG3LBM4CULBRJA===="
         },
         "labels": {
           "app": "battery-core",
@@ -346,7 +346,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195159a77b079fa8101fd27092ebb62",
+          "battery/owner": "batt_01951a6371f87363a6eb6e0a0438b8f4",
           "version": "latest"
         },
         "name": "bootstrap",

--- a/bootstrap/team.json
+++ b/bootstrap/team.json
@@ -1,5 +1,5 @@
 {
-  "id": "batt_0195159a772b7010add2b1c0a2ff1e8e",
+  "id": "batt_01951a63718c7afdb0feca073c30d586",
   "name": "Batteries Included Team",
   "inserted_at": null,
   "updated_at": null,

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/karpenter_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/karpenter_config.ex
@@ -12,5 +12,6 @@ defmodule CommonCore.Batteries.KarpenterConfig do
     field :node_role_name, :string
 
     defaultable_field :ami_alias, :string, default: "al2@v20250212"
+    defaultable_field :bottlerocket_ami_alias, :string, default: "bottlerocket@v1.32.0"
   end
 end


### PR DESCRIPTION
The AL2 AMIs don't have default support for GPUs but the bottlerocket AMIs do. So create a nodeclass for it and use that class for the nvidia node pool. 