### PR TITLE
build: improve GH action security

### DIFF
--- a/.github/workflows/bix.yml
+++ b/.github/workflows/bix.yml
@@ -11,12 +11,17 @@ on:
 env:
   ASDF_BRANCH: v0.15.0
 
+# No Permissions by default
+permissions: {}
+
 jobs:
   check-fmt:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup ASDF
         uses: asdf-vm/actions/setup@v3
         with:

--- a/.github/workflows/bix_docker.yml
+++ b/.github/workflows/bix_docker.yml
@@ -25,6 +25,8 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup ASDF
         uses: asdf-vm/actions/setup@v3
         with:
@@ -81,7 +83,12 @@ jobs:
 
       - if: ${{ startsWith(github.ref, 'refs/tags/') }}
         run: |
-          echo "ADDITIONAL_TAGS=${{ github.ref_name }}" >> "$GITHUB_ENV"
+          echo "ADDITIONAL_TAGS=${GH_REF_NAME}" >> "$GITHUB_ENV"
+        env:
+          # Copy the refname into a env var
+          # Github will sanitize the input to make sure that it
+          # isn't malicious
+          GH_REF_NAME: ${{ github.ref_name }}
 
       - name: Login to GHCR
         if: ${{ fromJSON(env.PUSH) }}

--- a/.github/workflows/bix_elixir.yml
+++ b/.github/workflows/bix_elixir.yml
@@ -11,6 +11,9 @@ on:
 env:
   ASDF_BRANCH: v0.15.0
 
+# No Permissions by default
+permissions: {}
+
 jobs:
   elixir-test:
     runs-on: ubuntu-latest
@@ -31,6 +34,8 @@ jobs:
       POSTGRES_PASSWORD: 'batterypasswd'
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup ASDF
         uses: asdf-vm/actions/setup@v3
         with:
@@ -82,6 +87,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup ASDF
         uses: asdf-vm/actions/setup@v3
         with:
@@ -127,6 +134,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup ASDF
         uses: asdf-vm/actions/setup@v3
         with:

--- a/.github/workflows/bix_elixir.yml
+++ b/.github/workflows/bix_elixir.yml
@@ -32,6 +32,14 @@ jobs:
       POSTGRES_HOST: localhost
       POSTGRES_USER: battery-local-user
       POSTGRES_PASSWORD: 'batterypasswd'
+
+    # Elixir test reports the test results to GitHub
+    # So we need to be able to write to the checks
+    # while reading the results of other actions.
+    permissions:
+      contents: read
+      actions: read
+      checks: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/bix_go.yml
+++ b/.github/workflows/bix_go.yml
@@ -13,12 +13,17 @@ env:
   GOMODCACHE: /home/runner/.cache/go-mod
   ASDF_BRANCH: v0.15.0
 
+# No Permissions by default
+permissions: {}
+
 jobs:
   go-test:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup ASDF
         uses: asdf-vm/actions/setup@v3
         with:
@@ -66,6 +71,8 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup ASDF
         uses: asdf-vm/actions/setup@v3
         with:
@@ -113,6 +120,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Setup ASDF
         uses: asdf-vm/actions/setup@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
         # Leading to: https://goreleaser.com/ci/ |  https://goreleaser.com/ci/actions/#workflow
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup ASDF
         uses: asdf-vm/actions/setup@v3
@@ -52,18 +53,6 @@ jobs:
       - name: Reshim ASDF
         shell: bash
         run: asdf reshim
-
-      - name: Setup Go cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ${{ env.GOCACHE }}
-            ${{ env.GOMODCACHE }}
-          key:
-            ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum',
-            '.tool-versions') }}
-          restore-keys: |
-            ${{ runner.os }}-go-build-
 
       - name: Install upx
         run: sudo apt-get install upx zip -y


### PR DESCRIPTION
Summary:
- Stop allowing the ssh key from checkout to persist
- Use fewer permissions by default
- Sanitize ref_name before putting it into an env variable
- Turn off a lot of caching for

Test Plan:
- CI
