### PR TITLE
chore: set the bi stable version to the next release version

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/defaults/versions.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/defaults/versions.ex
@@ -2,5 +2,5 @@ defmodule CommonCore.Defaults.Versions do
   @moduledoc false
 
   @spec bi_stable_version() :: String.t()
-  def bi_stable_version, do: "0.56.0"
+  def bi_stable_version, do: "0.57.0"
 end


### PR DESCRIPTION
Summary:
This will mean that we have to wait for the bi binary to build before
being able to test.

However this is needed since the keys are going to be changing.

Test Plan:
- /shrug
