### PR TITLE
fix(ollama): only show gpu count if a gpu node type is selected

### DIFF
--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/ollama/form_subcomponents.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/ollama/form_subcomponents.ex
@@ -55,10 +55,6 @@ defmodule ControlServerWeb.OllamaFormSubcomponents do
         ]}
       />
       <.field>
-        <:label>GPU Count</:label>
-        <.input field={@form[:gpu_count]} type="number" placeholder="0" />
-      </.field>
-      <.field>
         <.input
           field={@form[:node_type]}
           type="select"
@@ -67,7 +63,14 @@ defmodule ControlServerWeb.OllamaFormSubcomponents do
           options={GPU.node_types_for_select()}
         />
       </.field>
+      <.field :if={gpu_node_type?(@form[:node_type].value)}>
+        <:label>GPU Count</:label>
+        <.input field={@form[:gpu_count]} type="number" placeholder="0" />
+      </.field>
     </.fieldset>
     """
   end
+
+  defp gpu_node_type?(node_type) when is_binary(node_type), do: node_type |> String.to_existing_atom() |> gpu_node_type?()
+  defp gpu_node_type?(node_type), do: node_type in GPU.node_types_with_gpus()
 end


### PR DESCRIPTION
We may want to do a quick look at the validations but this hides the count field unless a GPU is requested. :raised_hands: 