### PR TITLE
feat(postgres): display backups in UI

### DIFF
--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/postgres/postgres_backups_table.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/postgres/postgres_backups_table.ex
@@ -1,0 +1,25 @@
+defmodule ControlServerWeb.Postgres.PostgresBackupsTable do
+  @moduledoc false
+  use ControlServerWeb, :html
+
+  attr :class, :string, default: ""
+  attr :backups, :list, required: true
+
+  def backups_panel(assigns) do
+    ~H"""
+    <.panel title="Backups" class={@class}>
+      <.table :if={@backups && @backups != []} id="postgres-backups-table" rows={@backups}>
+        <:col :let={backup} label="ID">{get_in(backup, ~w(status backupId))}</:col>
+        <:col :let={backup} label="Status">{get_in(backup, ~w(status phase))}</:col>
+        <:col :let={backup} label="Start Time">
+          <.relative_display time={get_in(backup, ~w(status startedAt))} />
+        </:col>
+        <:col :let={backup} label="Stopped Time">
+          <.relative_display time={get_in(backup, ~w(status stoppedAt))} />
+        </:col>
+      </.table>
+      <.light_text :if={@backups == []}>No backups</.light_text>
+    </.panel>
+    """
+  end
+end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/router.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/router.ex
@@ -150,6 +150,7 @@ defmodule ControlServerWeb.Router do
     live "/:id/users", Live.PostgresShow, :users
     live "/:id/services", Live.PostgresShow, :services
     live "/:id/edit_versions", Live.PostgresShow, :edit_versions
+    live "/:id/backups", Live.PostgresShow, :backups
   end
 
   scope "/ferretdb", ControlServerWeb do

--- a/platform_umbrella/apps/kube_services/lib/kube_services/system_state/summary_backup.ex
+++ b/platform_umbrella/apps/kube_services/lib/kube_services/system_state/summary_backup.ex
@@ -50,4 +50,7 @@ defmodule KubeServices.SystemState.SummaryBackup do
   def backups_for_cluster(target \\ @me, cluster) do
     GenServer.call(target, {:backups, cluster})
   end
+
+  @spec sort(list(map()), :asc | :desc) :: list(map())
+  def sort(backups, sorter \\ :asc), do: Enum.sort_by(backups, &get_in(&1, ~w(status startedAt)), sorter)
 end


### PR DESCRIPTION
Adds a table with the backups for a cluster to the cluster show page. This will be used for recovery in a future change.