### PR TITLE
chore(internal): fix resource generation

### DIFF
--- a/platform_umbrella/apps/common_core/lib/mix/tasks/gen_resource.ex
+++ b/platform_umbrella/apps/common_core/lib/mix/tasks/gen_resource.ex
@@ -531,7 +531,7 @@ defmodule Mix.Tasks.Gen.Resource do
     pipe(
       pipeline,
       quote do
-        Map.put(unquote(key), unquote(value))
+        Map.put(unquote(key), unquote(Macro.escape(value)))
       end
     )
   end
@@ -794,7 +794,7 @@ defmodule Mix.Tasks.Gen.Resource do
     quote do
       resource(unquote(method_name), battery, state) do
         namespace = core_namespace(state)
-        rules = unquote(rules)
+        rules = unquote(Macro.escape(rules))
         unquote(main_pipeline)
       end
     end
@@ -803,7 +803,7 @@ defmodule Mix.Tasks.Gen.Resource do
   defp cluster_resource_method_from_pipeline_and_rules(rules, main_pipeline, method_name) do
     quote do
       resource(unquote(method_name)) do
-        rules = unquote(rules)
+        rules = unquote(Macro.escape(rules))
 
         unquote(main_pipeline)
       end


### PR DESCRIPTION
Was getting errors. Not sure when they started but this change I've had stashed fixes 'em.

```bash
mix gen.resource <(helm template nfd https://github.com/kubernetes-sigs/node-feature-discovery/releases/download/v0.17.2/node-feature-discovery-chart-0.17.2.tgz) testing
** (ArgumentError) tried to unquote invalid AST: [%{"apiGroups" => [""], "resources" => ["namespaces"], "verbs" => ["watch", "list"]}, %{"apiGroups" => [""], "resources" => ["nodes", "nodes/status"], "verbs" => ["get", "patch", "update", "list"]}, %{"apiGroups" => ["nfd.k8s-sigs.io"], "resources" => ["nodefeatures", "nodefeaturerules", "nodefeaturegroups"], "verbs" => ["get", "list", "watch"]}, %{"apiGroups" => ["nfd.k8s-sigs.io"], "resources" => ["nodefeaturegroups/status"], "verbs" => ["patch", "update"]}, %{"apiGroups" => ["coordination.k8s.io"], "resources" => ["leases"], "verbs" => ["create"]}, %{"apiGroups" => ["coordination.k8s.io"], "resourceNames" => ["nfd-master.nfd.kubernetes.io"], "resources" => ["leases"], "verbs" => ["get", "update"]}]
Did you forget to escape term using Macro.escape/1?
    (elixir 1.18.3) src/elixir_quote.erl:542: :elixir_quote.argument_error/1
    (common_core 0.57.0) lib/mix/tasks/gen_resource.ex:806: Mix.Tasks.Gen.Resource.cluster_resource_method_from_pipeline_and_rules/3
    (common_core 0.57.0) lib/mix/tasks/gen_resource.ex:230: Mix.Tasks.Gen.Resource.process_resource/3
    (elixir 1.18.3) lib/enum.ex:1714: Enum."-map/2-lists^map/1-1-"/2
    (elixir 1.18.3) lib/enum.ex:1714: Enum."-map/2-lists^map/1-1-"/2
    (common_core 0.57.0) lib/mix/tasks/gen_resource.ex:57: Mix.Tasks.Gen.Resource.run/1
    (mix 1.18.3) lib/mix/task.ex:495: anonymous fn/3 in Mix.Task.run_task/5
    (mix 1.18.3) lib/mix/cli.ex:107: Mix.CLI.run_task/2
```