### PR TITLE
chore: create better pagination test

### DIFF
--- a/platform_umbrella/apps/control_server/test/control_server/ferretdb_test.exs
+++ b/platform_umbrella/apps/control_server/test/control_server/ferretdb_test.exs
@@ -16,11 +16,7 @@ defmodule ControlServer.FerretDBTest do
     end
 
     test "list_ferret_services/1 returns paginated ferret services" do
-      ferret_service1 = ferret_service_fixture()
-      _ferret_service2 = ferret_service_fixture()
-
-      assert {:ok, {[ferret_service], _}} = FerretDB.list_ferret_services(%{limit: 1})
-      assert ferret_service.id == ferret_service1.id
+      pagination_test(&ferret_service_fixture/1, &FerretDB.list_ferret_services/1)
     end
 
     test "get_ferret_service!/1 returns the ferret_service with given id" do

--- a/platform_umbrella/apps/control_server/test/control_server/knative_test.exs
+++ b/platform_umbrella/apps/control_server/test/control_server/knative_test.exs
@@ -20,11 +20,7 @@ defmodule ControlServer.KnativeTest do
     end
 
     test "list_services/1 returns paginated services" do
-      service1 = service_fixture()
-      _service2 = service_fixture()
-
-      assert {:ok, {[service], _}} = Knative.list_services(%{limit: 1})
-      assert service.id == service1.id
+      pagination_test(&service_fixture/1, &Knative.list_services/1)
     end
 
     test "get_service!/1 returns the service with given id" do

--- a/platform_umbrella/apps/control_server/test/control_server/metal_lb_test.exs
+++ b/platform_umbrella/apps/control_server/test/control_server/metal_lb_test.exs
@@ -15,11 +15,7 @@ defmodule ControlServer.MetalLBTest do
     end
 
     test "list_ip_address_pools/1 returns paginated ip address pools" do
-      ip_address_pool1 = ip_address_pool_fixture()
-      _ip_address_pool2 = ip_address_pool_fixture()
-
-      assert {:ok, {[ip_address_pool], _}} = MetalLB.list_ip_address_pools(%{limit: 1})
-      assert ip_address_pool.id == ip_address_pool1.id
+      pagination_test(&ip_address_pool_fixture/1, &MetalLB.list_ip_address_pools/1)
     end
 
     test "get_ip_address_pool!/1 returns the ip_address_pool with given id" do

--- a/platform_umbrella/apps/control_server/test/control_server/notebooks_test.exs
+++ b/platform_umbrella/apps/control_server/test/control_server/notebooks_test.exs
@@ -24,11 +24,7 @@ defmodule ControlServer.NotebooksTest do
     end
 
     test "list_jupyter_lab_notebooks/1 returns paginated jupyter lab notebooks" do
-      jupyter_lab_notebook1 = jupyter_lab_notebook_fixture()
-      _jupyter_lab_notebook2 = jupyter_lab_notebook_fixture()
-
-      assert {:ok, {[jupyter_lab_notebook], _}} = Notebooks.list_jupyter_lab_notebooks(%{limit: 1})
-      assert jupyter_lab_notebook.id == jupyter_lab_notebook1.id
+      pagination_test(&jupyter_lab_notebook_fixture/1, &Notebooks.list_jupyter_lab_notebooks/1)
     end
 
     test "get_jupyter_lab_notebook!/1 returns the jupyter_lab_notebook with given id" do

--- a/platform_umbrella/apps/control_server/test/control_server/postgres_test.exs
+++ b/platform_umbrella/apps/control_server/test/control_server/postgres_test.exs
@@ -40,21 +40,8 @@ defmodule ControlServer.PostgresTest do
       assert Postgres.list_clusters() == [cluster]
     end
 
-    # create a number of clusters with a unique name pattern
-    # find clusters matching that pattern 1 at a time
-    # ensure we can fetch e.g. first and last "page"
     test "list_clusters/1 returns paginated clusters" do
-      name_prefix = "list-clusters-pagination-test"
-      params = %{order_by: [:id], filters: [%{field: :name, op: :ilike, value: "#{name_prefix}-"}]}
-      created = Enum.map(0..9, fn i -> cluster_fixture(%{name: "#{name_prefix}-#{i}"}) end)
-
-      assert {:ok, {[first], meta}} = Postgres.list_clusters(Map.put(params, :first, 1))
-      assert created |> List.first() |> Map.get(:id) == first.id
-      assert {false, true} = {meta.has_previous_page?, meta.has_next_page?}
-
-      assert {:ok, {[last], meta}} = Postgres.list_clusters(Map.put(params, :last, 1))
-      assert created |> List.last() |> Map.get(:id) == last.id
-      assert {true, false} = {meta.has_previous_page?, meta.has_next_page?}
+      pagination_test(&cluster_fixture/1, &Postgres.list_clusters/1, count: 15)
     end
 
     test "get_cluster!/1 returns the cluster with given id" do

--- a/platform_umbrella/apps/control_server/test/control_server/projects/projects_test.exs
+++ b/platform_umbrella/apps/control_server/test/control_server/projects/projects_test.exs
@@ -22,14 +22,13 @@ defmodule ControlServer.ProjectsTest do
 
   describe "list_projects/0" do
     test "should list all projects", ctx do
-      assert list_projects() == [ctx.project, ctx.project2, ctx.project3]
+      assert Enum.sort(list_projects()) == Enum.sort([ctx.project, ctx.project2, ctx.project3])
     end
   end
 
   describe "list_projects/1" do
-    test "should list paginated projects", ctx do
-      assert {:ok, {[project], _}} = list_projects(%{limit: 1})
-      assert project == ctx.project
+    test "should list paginated projects", _ctx do
+      pagination_test(&project_fixture/1, &list_projects/1)
     end
   end
 

--- a/platform_umbrella/apps/control_server/test/control_server/redis_test.exs
+++ b/platform_umbrella/apps/control_server/test/control_server/redis_test.exs
@@ -18,17 +18,7 @@ defmodule ControlServer.RedisTest do
     end
 
     test "list_redis_instances/1 returns paginated failover clusters" do
-      name_prefix = "list-redis-instances-pagination-test"
-      params = %{order_by: [:id], filters: [%{field: :name, op: :ilike, value: "#{name_prefix}-"}]}
-      created = Enum.map(0..9, fn i -> redis_instance_fixture(%{name: "#{name_prefix}-#{i}"}) end)
-
-      assert {:ok, {[first], meta}} = Redis.list_redis_instances(Map.put(params, :first, 1))
-      assert created |> List.first() |> Map.get(:id) == first.id
-      assert {false, true} = {meta.has_previous_page?, meta.has_next_page?}
-
-      assert {:ok, {[last], meta}} = Redis.list_redis_instances(Map.put(params, :last, 1))
-      assert created |> List.last() |> Map.get(:id) == last.id
-      assert {true, false} = {meta.has_previous_page?, meta.has_next_page?}
+      pagination_test(&redis_instance_fixture/1, &Redis.list_redis_instances/1)
     end
 
     test "get_redis_instance!/1 returns the redis_instance with given id" do

--- a/platform_umbrella/apps/control_server/test/control_server/traditional_services/traditional_services_test.exs
+++ b/platform_umbrella/apps/control_server/test/control_server/traditional_services/traditional_services_test.exs
@@ -22,11 +22,7 @@ defmodule ControlServer.TraditionalServicesTest do
     end
 
     test "list_traditional_services/1 returns paginated traditional services" do
-      service1 = service_fixture()
-      _service2 = service_fixture()
-
-      assert {:ok, {[service], _}} = TraditionalServices.list_traditional_services(%{limit: 1})
-      assert service.id == service1.id
+      pagination_test(&service_fixture/1, &TraditionalServices.list_traditional_services/1)
     end
 
     test "get_service!/1 returns the service with given id" do

--- a/platform_umbrella/apps/control_server/test/support/data_case.ex
+++ b/platform_umbrella/apps/control_server/test/support/data_case.ex
@@ -74,4 +74,82 @@ defmodule ControlServer.DataCase do
     operation = K8s.Client.create(single_resource)
     assert Map.get(operation.data, "metadata") == Map.get(single_resource, "metadata")
   end
+
+  @typep pagination_fixture_fn :: (%{name: String.t()} -> map())
+  @typep pagination_list_fn :: (map() | Flop.t() -> {:ok, {[any()], Flop.Meta.t()}} | {:error, Flop.Meta.t()})
+  @typep pagination_option :: {:count, pos_integer()}
+  @typep pagination_options :: [pagination_option()]
+
+  @doc """
+  Run DB list tests that excercise Flop pagination
+  The fixture fn should accept a map parameter that is able to change the name of the entity
+  The list fn should accept Flop params e.g. `ControlServer.Postgres.list_clusters/1`
+  """
+  @spec pagination_test(pagination_fixture_fn(), pagination_list_fn(), pagination_options()) :: any()
+  def pagination_test(fixture_fn, list_fn, opts \\ []) do
+    count = Keyword.get(opts, :count, 10)
+    prefix = build_prefix(depth: 3)
+
+    params = %{
+      order_by: [:id],
+      filters: [%{field: :name, op: :ilike, value: "#{prefix}-"}],
+      page_size: 1,
+      page: nil
+    }
+
+    entities = Enum.map(1..count, fn i -> fixture_fn.(%{name: "#{prefix}-#{i}"}) end)
+
+    # page through one page / entity at a time
+    assert [] = Enum.reduce(1..count, entities, build_pagination_assertions(list_fn, params, count))
+
+    # all entities are found on a single page if page_size >= count
+    assert {:ok, {found, meta}} = list_fn.(%{params | page: 1, page_size: count})
+    assert Enum.all?(entities, fn e -> Enum.any?(found, &(&1.id == e.id && &1.name == e.name)) end)
+    assert meta.has_next_page? == false
+  end
+
+  defp build_pagination_assertions(list_fn, params, count) do
+    fn i, entities ->
+      # get the ith page
+      assert {:ok, {[ith], meta}} = list_fn.(%{params | page: i})
+
+      case i do
+        1 ->
+          # first page doesn't have prev page
+          assert {false, true} = {meta.has_previous_page?, meta.has_next_page?}
+
+        ^count ->
+          # last page doesn't have next page
+          assert {true, false} = {meta.has_previous_page?, meta.has_next_page?}
+
+        _ ->
+          # every other page should have prev and next
+          assert {true, true} = {meta.has_previous_page?, meta.has_next_page?}
+      end
+
+      # ensure that the result is in the list of created entities
+      assert Enum.any?(entities, &(&1.id == ith.id))
+
+      # remove the found element. it shouldn't be returned from the DB again
+      Enum.reject(entities, &(&1.id == ith.id))
+    end
+  end
+
+  @typep build_prefix_option :: {:depth, pos_integer()}
+  @typep build_prefix_options :: [build_prefix_option()]
+
+  @doc """
+  Generate a prefix (or suffix) based on the caller's module name.
+  The depth option may be useful to increase depending on the call stack
+  """
+  @spec build_prefix(build_prefix_options()) :: String.t()
+  def build_prefix(opts \\ []) do
+    self()
+    |> Process.info(:current_stacktrace)
+    |> elem(1)
+    |> Enum.fetch!(Keyword.get(opts, :depth, 2))
+    |> elem(0)
+    |> Module.split()
+    |> Enum.map_join("-", &(&1 |> Macro.underscore() |> String.downcase() |> String.replace("_", "-")))
+  end
 end


### PR DESCRIPTION
We're still getting some flakes on pagination tests. This doesn't rely on ordering or timing so should be reliable. Additionally, it excercises pagination more fully.