### PR TITLE
feat(bix): add ability to run test setup independently

### DIFF
--- a/bin/bix
+++ b/bin/bix
@@ -88,6 +88,7 @@ Available commands:
 
 **Elixir Commands**
 - ex-test-deep      Run all tests with coverage and reset the database
+- ex-test-setup     Setup the test database
 - ex-test           Run all tests
 - ex-lint           Run all linters (dialexir, credo, format)
 - ex-credo          Run credo linter
@@ -561,11 +562,22 @@ do_ex_test_deep() {
 
     export MIX_ENV=test
     run_mix "do" deps.get, compile --warnings-as-errors >/dev/null
-    run_mix compile --warnings-as-errors >/dev/null
     run_mix ecto.reset >/dev/null
     run_mix test --trace --slowest 10 --cover --export-coverage default --warnings-as-errors --all-warnings
     run_mix test.coverage
     log "Elixir tests ${GREEN}Passed${NOFORMAT}"
+}
+
+do_ex_test_setup() {
+    local slug=${1:-"dev"}
+    log "${GREEN}Running${NOFORMAT} elixir test setup"
+    # Start the port forwarder
+    try_portforward "${slug}" &
+
+    export MIX_ENV=test
+    run_mix "do" deps.get, compile --warnings-as-errors >/dev/null
+    run_mix ecto.reset >/dev/null
+    log "${GREEN}Finished${NOFORMAT} setting up test DB"
 }
 
 do_ex_test() {
@@ -726,6 +738,9 @@ bi-location)
     ;;
 ex-test-deep)
     do_ex_test_deep "${args[@]}"
+    ;;
+ex-test-setup)
+    do_ex_test_setup "${args[@]}"
     ;;
 ex-test)
     do_ex_test "${args[@]}"

--- a/bin/bix
+++ b/bin/bix
@@ -555,7 +555,8 @@ tag_push() {
 }
 
 do_ex_test_deep() {
-    local slug=${1:-"dev"}
+    local setup_only=${1:-0}
+    local slug=${2:-"dev"}
     log "${GREEN}Running${NOFORMAT} elixir tests with coverage and resetting the database"
     # Start the port forwarder
     try_portforward "${slug}" &
@@ -563,21 +564,10 @@ do_ex_test_deep() {
     export MIX_ENV=test
     run_mix "do" deps.get, compile --warnings-as-errors >/dev/null
     run_mix ecto.reset >/dev/null
+    [[ $setup_only -eq 1 ]] && return
     run_mix test --trace --slowest 10 --cover --export-coverage default --warnings-as-errors --all-warnings
     run_mix test.coverage
     log "Elixir tests ${GREEN}Passed${NOFORMAT}"
-}
-
-do_ex_test_setup() {
-    local slug=${1:-"dev"}
-    log "${GREEN}Running${NOFORMAT} elixir test setup"
-    # Start the port forwarder
-    try_portforward "${slug}" &
-
-    export MIX_ENV=test
-    run_mix "do" deps.get, compile --warnings-as-errors >/dev/null
-    run_mix ecto.reset >/dev/null
-    log "${GREEN}Finished${NOFORMAT} setting up test DB"
 }
 
 do_ex_test() {
@@ -592,7 +582,6 @@ do_ex_test() {
     try_portforward "${slug}" &
 
     export MIX_ENV=test
-
     run_mix test ${TRACE:+--trace} --warnings-as-errors --all-warnings >$out
     log "Elixir tests ${GREEN}Passed${NOFORMAT}"
 }
@@ -737,10 +726,10 @@ bi-location)
     do_bi_location
     ;;
 ex-test-deep)
-    do_ex_test_deep "${args[@]}"
+    do_ex_test_deep 0 "${args[@]}"
     ;;
 ex-test-setup)
-    do_ex_test_setup "${args[@]}"
+    do_ex_test_deep 1 "${args[@]}"
     ;;
 ex-test)
     do_ex_test "${args[@]}"


### PR DESCRIPTION
We used to have this with nix but it got dropped in the conversion but I find myself running `ex-test-deep` fairly regularly just to set up the DB.