### PR TITLE
fix(int-prod): bootstrap with team IDs pre-populated

### DIFF
--- a/bootstrap/dev.install.json
+++ b/bootstrap/dev.install.json
@@ -1,14 +1,14 @@
 {
-  "id": "batt_0195c9448b897d11b08d4df46c7eaf82",
+  "id": "batt_0195cdcd628276c6ab184fa13845c2bd",
   "usage": "internal_dev",
-  "team_id": "batt_0195c9448b8475d09205a9949eb3682c",
+  "team_id": "batt_0195cdcd627e7b3eb452d35222757e2a",
   "default_size": "tiny",
   "control_jwk": {
     "crv": "P-256",
-    "d": "bU4zl-Ue6ID-4o1R-O0sPBaTOtNqd7G2uybxCdsx4y4",
+    "d": "iqhCYVm-h_O40zW6Y6dqiyKxrKcbGMdwYbVN5UggDIw",
     "kty": "EC",
-    "x": "bkg5j5cXMdXZmYWnLZeILyJstHNMmj6TCs1qag9FoHY",
-    "y": "AH-frxm-9ceIe2tpux9gkDD8LgFTOtcovhTQQrqfo4I"
+    "x": "ISMzB5bDG4BE_mr--oQGZvR-VvT5-78znbYH2G_Pfis",
+    "y": "F2cf19E4YZGucPWOAgBbhuzUmdSd6ICQc6O9Hog_F8U"
   },
   "inserted_at": null,
   "updated_at": null,

--- a/bootstrap/dev.spec.json
+++ b/bootstrap/dev.spec.json
@@ -9,7 +9,7 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_0195c9448ba0746f970381bd3e21901e",
+        "id": "batt_0195cdcd62977faba2d83f559fec70fb",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -24,7 +24,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195c9448ba071c1b9ebc827c82a0af3",
+        "id": "batt_0195cdcd62977b878cebbaa11b959f26",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -37,7 +37,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195c9448ba079238515b98adc33736a",
+        "id": "batt_0195cdcd629771019d189aeafb3c1946",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -49,13 +49,13 @@
           "ai_namespace": "battery-ai",
           "default_size": "tiny",
           "cluster_name": "dev",
-          "install_id": "batt_0195c9448b897d11b08d4df46c7eaf82",
+          "install_id": "batt_0195cdcd628276c6ab184fa13845c2bd",
           "control_jwk": {
             "crv": "P-256",
-            "d": "bU4zl-Ue6ID-4o1R-O0sPBaTOtNqd7G2uybxCdsx4y4",
+            "d": "iqhCYVm-h_O40zW6Y6dqiyKxrKcbGMdwYbVN5UggDIw",
             "kty": "EC",
-            "x": "bkg5j5cXMdXZmYWnLZeILyJstHNMmj6TCs1qag9FoHY",
-            "y": "AH-frxm-9ceIe2tpux9gkDD8LgFTOtcovhTQQrqfo4I"
+            "x": "ISMzB5bDG4BE_mr--oQGZvR-VvT5-78znbYH2G_Pfis",
+            "y": "F2cf19E4YZGucPWOAgBbhuzUmdSd6ICQc6O9Hog_F8U"
           },
           "upgrade_days_of_week": [
             true,
@@ -80,7 +80,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195c9448ba0723ca4bbcdc42008dc42",
+        "id": "batt_0195cdcd62977fa4a6ebcb4a84ca393d",
         "type": "metallb",
         "config": {
           "type": "metallb",
@@ -100,7 +100,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195c9448ba0714fba6319c6e8802945",
+        "id": "batt_0195cdcd62977fcfa5dcfd35d6ea4d9a",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
@@ -108,15 +108,15 @@
           "service_role_arn": null,
           "bucket_name": null,
           "bucket_arn": null,
-          "image_name_override": null,
-          "image_tag_override": null
+          "image_tag_override": null,
+          "image_name_override": null
         },
         "group": "data",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0195c9448ba07610b22819e02e540992",
+        "id": "batt_0195cdcd6297778485d5ae4e35765575",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -172,7 +172,7 @@
           {
             "version": 2,
             "username": "battery-control-user",
-            "password": "DQEZQFXANTL7K7C5B347MK3F"
+            "password": "SSFKSM5DJ4M5UH56FR27G7QT"
           },
           {
             "version": 1,
@@ -205,7 +205,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "TNQDLA4Y7A5QWROWCJ766Y3IPBWW7WKWHZLZLYCLG25OJBKFLOEA===="
+          "battery/hash": "5MIRKYIOLNWQO57GOTQHDHJL5IRLVDW3L2IMIHW5UZJMTAS6IMDQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -215,7 +215,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195c9448ba079238515b98adc33736a",
+          "battery/owner": "batt_0195cdcd629771019d189aeafb3c1946",
           "istio-injection": "enabled",
           "version": "latest"
         },

--- a/bootstrap/int-prod.install.json
+++ b/bootstrap/int-prod.install.json
@@ -1,14 +1,14 @@
 {
-  "id": "batt_0195c9448b9c7b11ab03d3558b7433f8",
+  "id": "batt_0195cdcd62947e42b706e8d89f64c737",
   "usage": "internal_prod",
-  "team_id": "batt_0195c9448b8475d09205a9949eb3682c",
+  "team_id": "batt_0195cdcd627e7b3eb452d35222757e2a",
   "default_size": "medium",
   "control_jwk": {
     "crv": "P-256",
-    "d": "ByWzN8ZkUC6V3m_emeCHYZaVchx7LQqHCOZ85IpUDW4",
+    "d": "G3TG4qn2Yn6RKh1y5IRcdverbWncUJg8iGTv80qWB6s",
     "kty": "EC",
-    "x": "Wdff8M94Zwa1wYFnNAbESVSYmWAWxDtA4pr6b_2g2is",
-    "y": "3ozzeeIMl-WDbkjkjXLNaRdfULrF8CimZZo3os0MkMA"
+    "x": "E-Pyhv4YQMgFdH9e2VUY21PeKhXV6cVsh5px8ck1C3I",
+    "y": "i573oEMDr1WIxlj-FBjoOOkZ1im1pzy9wqJkMupJqBo"
   },
   "inserted_at": null,
   "updated_at": null,

--- a/bootstrap/int-prod.spec.json
+++ b/bootstrap/int-prod.spec.json
@@ -9,7 +9,7 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_0195c9448ba27f1a9b07110ac64680b2",
+        "id": "batt_0195cdcd6299702b99138cea61e381ec",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -21,13 +21,13 @@
           "ai_namespace": "battery-ai",
           "default_size": "medium",
           "cluster_name": "int-prod",
-          "install_id": "batt_0195c9448b9c7b11ab03d3558b7433f8",
+          "install_id": "batt_0195cdcd62947e42b706e8d89f64c737",
           "control_jwk": {
             "crv": "P-256",
-            "d": "ByWzN8ZkUC6V3m_emeCHYZaVchx7LQqHCOZ85IpUDW4",
+            "d": "G3TG4qn2Yn6RKh1y5IRcdverbWncUJg8iGTv80qWB6s",
             "kty": "EC",
-            "x": "Wdff8M94Zwa1wYFnNAbESVSYmWAWxDtA4pr6b_2g2is",
-            "y": "3ozzeeIMl-WDbkjkjXLNaRdfULrF8CimZZo3os0MkMA"
+            "x": "E-Pyhv4YQMgFdH9e2VUY21PeKhXV6cVsh5px8ck1C3I",
+            "y": "i573oEMDr1WIxlj-FBjoOOkZ1im1pzy9wqJkMupJqBo"
           },
           "upgrade_days_of_week": [
             true,
@@ -52,7 +52,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195c9448ba276718a7fbbefe1779569",
+        "id": "batt_0195cdcd629977dea2880c2df41af091",
         "type": "cert_manager",
         "config": {
           "type": "cert_manager",
@@ -78,7 +78,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195c9448ba27b44acef581668f929b8",
+        "id": "batt_0195cdcd6299758ba12eddef46f756b3",
         "type": "battery_ca",
         "config": {
           "type": "battery_ca"
@@ -88,7 +88,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195c9448ba2773592ea4a82d9e1218f",
+        "id": "batt_0195cdcd62997194ad7c52b1cbb21ffb",
         "type": "karpenter",
         "config": {
           "type": "karpenter",
@@ -98,8 +98,8 @@
           "node_role_name": null,
           "ami_alias": "al2@v20250212",
           "bottlerocket_ami_alias": "bottlerocket@v1.32.0",
-          "image_name_override": null,
           "image_tag_override": null,
+          "image_name_override": null,
           "ami_alias_override": null,
           "bottlerocket_ami_alias_override": null
         },
@@ -108,7 +108,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195c9448ba27ecf8b1928e631abc406",
+        "id": "batt_0195cdcd62997d84b8e0dcdf3207eea9",
         "type": "aws_load_balancer_controller",
         "config": {
           "type": "aws_load_balancer_controller",
@@ -116,15 +116,15 @@
           "service_role_arn": null,
           "subnets": null,
           "eip_allocations": null,
-          "image_name_override": null,
-          "image_tag_override": null
+          "image_tag_override": null,
+          "image_name_override": null
         },
         "group": "magic",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0195c9448ba2725998e1299791598c3d",
+        "id": "batt_0195cdcd62997bf6a61b3a0060dfb097",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
@@ -132,15 +132,15 @@
           "service_role_arn": null,
           "bucket_name": null,
           "bucket_arn": null,
-          "image_name_override": null,
-          "image_tag_override": null
+          "image_tag_override": null,
+          "image_name_override": null
         },
         "group": "data",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0195c9448ba27a839ef057de1407752a",
+        "id": "batt_0195cdcd62997520aea11075c78ca928",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -155,7 +155,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195c9448ba27ad9b94e0fea9fe28d81",
+        "id": "batt_0195cdcd62997ceabb8806c9c1e3adb2",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -168,7 +168,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195c9448ba270a2863e3014676b2913",
+        "id": "batt_0195cdcd62997e2db9820e4a6b0b138a",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -180,7 +180,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195c9448ba2798e9ddeb91a75f07f6f",
+        "id": "batt_0195cdcd62997350ae25fae31e390f6a",
         "type": "ferretdb",
         "config": {
           "type": "ferretdb",
@@ -193,7 +193,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195c9448ba27e3fa2d5645c2268ba98",
+        "id": "batt_0195cdcd62997df098bae9e692134a81",
         "type": "traditional_services",
         "config": {
           "type": "traditional_services",
@@ -204,7 +204,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195c9448ba27cfa9d1455d1e57d59c7",
+        "id": "batt_0195cdcd629a71b994250cf49deca829",
         "type": "vm_agent",
         "config": {
           "type": "vm_agent",
@@ -216,11 +216,11 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195c9448ba2798b86272545f2fa38d9",
+        "id": "batt_0195cdcd629a7f2c95a20bdd2e0f6ea8",
         "type": "victoria_metrics",
         "config": {
           "type": "victoria_metrics",
-          "cookie_secret": "6wTeyB-H6VgcQZlR-2rWky4Oy_mj-wzVTO_PM3bDd6U=",
+          "cookie_secret": "0bzsmR9gEpvVm1Yz39KP-UTuRG2u-F8SO4pAh5XK_s4=",
           "replication_factor": 1,
           "operator_image": "victoriametrics/operator:v0.44.0",
           "vmselect_volume_size": 536870912,
@@ -241,14 +241,14 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195c9448ba2787dab0acf720632aae2",
+        "id": "batt_0195cdcd629a7349b409dac20710c1c5",
         "type": "grafana",
         "config": {
           "type": "grafana",
           "image": "grafana/grafana:11.3.1",
           "sidecar_image": "quay.io/kiwigrid/k8s-sidecar:1.27.4",
-          "image_name_override": null,
           "image_tag_override": null,
+          "image_name_override": null,
           "sidecar_image_name_override": null,
           "sidecar_image_tag_override": null
         },
@@ -273,8 +273,16 @@
         "virtual_size": "medium",
         "env_values": [
           {
+            "name": "BATTERY_TEAM_IDS",
+            "value": "batt_0195cdcd627e7b3eb452d35222757e2a",
+            "source_name": null,
+            "source_type": "value",
+            "source_key": null,
+            "source_optional": false
+          },
+          {
             "name": "SECRET_KEY_BASE",
-            "value": "WJTYFZ7G42M6IRA5LSMOGJBR3HDZEQSW3IN4ZJ2LKBYNIRRVKNKPJY7FEC4ZP5NB",
+            "value": "NMJBWVH2VT6LP5RM5QSNMAWVNL6NDJAOOACIT3TPR42C5JC4IEONUD5NAAOGZO2P",
             "source_name": null,
             "source_type": "value",
             "source_key": null,
@@ -572,7 +580,7 @@
           {
             "version": 1,
             "username": "battery-control-user",
-            "password": "LVWHZVZ7R72N5BOZMXBW3IYN"
+            "password": "EYJKERTMKRYID6GZBTW5F4JA"
           }
         ],
         "cpu_requested": 4000,
@@ -617,7 +625,7 @@
           {
             "version": 1,
             "username": "home-base",
-            "password": "RCM37P25KOO6RCVGJY2X7DBC"
+            "password": "64PQ22E7YU2D5RAYGUEKANZI"
           }
         ],
         "cpu_requested": 4000,
@@ -662,7 +670,7 @@
           {
             "version": 1,
             "username": "cla",
-            "password": "GGPC6Q23DKYU2H6I3TXGYXQQ"
+            "password": "JAFRPD2OQ7M5IRNROFBZHNTD"
           }
         ],
         "cpu_requested": 4000,
@@ -692,7 +700,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "AMUVIQZS5RC4XBOLUPKXIOXOMNW6FOQYUR2OSPFXQLCHF3SWKDXA===="
+          "battery/hash": "2MT47YASCEQAKLQOPD6EWIOLRXWIGP77VDHFQ6B5NY42WNAV6DSA===="
         },
         "labels": {
           "app": "battery-core",
@@ -702,7 +710,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195c9448ba27f1a9b07110ac64680b2",
+          "battery/owner": "batt_0195cdcd6299702b99138cea61e381ec",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -723,17 +731,17 @@
     "/config_map/home_base_seed_data": {
       "apiVersion": "v1",
       "data": {
-        "batt_0195c9448b8475d09205a9949eb3682c.team.json": "{\"id\":\"batt_0195c9448b8475d09205a9949eb3682c\",\"name\":\"Batteries Included Team\",\"inserted_at\":null,\"updated_at\":null,\"op_email\":\"elliott@batteriesincl.com\",\"deleted_at\":null}",
-        "dev.install.json": "{\"id\":\"batt_0195c9448b897d11b08d4df46c7eaf82\",\"usage\":\"internal_dev\",\"team_id\":\"batt_0195c9448b8475d09205a9949eb3682c\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"bU4zl-Ue6ID-4o1R-O0sPBaTOtNqd7G2uybxCdsx4y4\",\"kty\":\"EC\",\"x\":\"bkg5j5cXMdXZmYWnLZeILyJstHNMmj6TCs1qag9FoHY\",\"y\":\"AH-frxm-9ceIe2tpux9gkDD8LgFTOtcovhTQQrqfo4I\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"dev\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
-        "int-prod.install.json": "{\"id\":\"batt_0195c9448b9c7b11ab03d3558b7433f8\",\"usage\":\"internal_prod\",\"team_id\":\"batt_0195c9448b8475d09205a9949eb3682c\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"ByWzN8ZkUC6V3m_emeCHYZaVchx7LQqHCOZ85IpUDW4\",\"kty\":\"EC\",\"x\":\"Wdff8M94Zwa1wYFnNAbESVSYmWAWxDtA4pr6b_2g2is\",\"y\":\"3ozzeeIMl-WDbkjkjXLNaRdfULrF8CimZZo3os0MkMA\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"aws\",\"slug\":\"int-prod\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
-        "int-test.install.json": "{\"id\":\"batt_0195c9448b9c727db246e2ac027aeb5e\",\"usage\":\"internal_int_test\",\"team_id\":\"batt_0195c9448b8475d09205a9949eb3682c\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"NMO_iUYVXt2sX0zs9T9Xn8FnDaujEEtXX-YuRimt3jg\",\"kty\":\"EC\",\"x\":\"2bQpQcnhym8e2Zk8u4-jsoxQnVcPQLf-ZzSN_l3k5Jg\",\"y\":\"IpgWfpZj7FjdKEgB1oKvGKqgw0v6IInNQQMLe7r7_54\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"int-test\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
-        "jason.install.json": "{\"id\":\"batt_0195c9448b9d715bb9d064f4524ebab3\",\"usage\":\"development\",\"team_id\":\"batt_0195c9448b8475d09205a9949eb3682c\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"42YhC13W4QvdTzgUYDe_aTUnz-F72aIpnRsn2aVg07M\",\"kty\":\"EC\",\"x\":\"7W_swqR2_sizzHp3hF5MrB51PDf_tfuinNknqGifu5Q\",\"y\":\"iOx73UvLcO8u8tKLJ60j4CYzBKLjY8BWxGDI_DM369I\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"aws\",\"slug\":\"jason\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
-        "local.install.json": "{\"id\":\"batt_0195c9448b9d7aaf84fe9e34b568ffc0\",\"usage\":\"development\",\"team_id\":\"batt_0195c9448b8475d09205a9949eb3682c\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"IAwqnw8MXcWRpsre2tPJQZY8n8FAPV6bejmlYjhlncI\",\"kty\":\"EC\",\"x\":\"m651EwuY7GXuJ9-dUp4vZ8Is6YCmtAFJ_yVJUhhDMqY\",\"y\":\"lb8Kp3L_QvNpuZUw0f1YZsPtdXxxu6p8e0cyys4L6eg\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"local\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}"
+        "batt_0195cdcd627e7b3eb452d35222757e2a.team.json": "{\"id\":\"batt_0195cdcd627e7b3eb452d35222757e2a\",\"name\":\"Batteries Included Team\",\"inserted_at\":null,\"updated_at\":null,\"op_email\":\"elliott@batteriesincl.com\",\"deleted_at\":null}",
+        "dev.install.json": "{\"id\":\"batt_0195cdcd628276c6ab184fa13845c2bd\",\"usage\":\"internal_dev\",\"team_id\":\"batt_0195cdcd627e7b3eb452d35222757e2a\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"iqhCYVm-h_O40zW6Y6dqiyKxrKcbGMdwYbVN5UggDIw\",\"kty\":\"EC\",\"x\":\"ISMzB5bDG4BE_mr--oQGZvR-VvT5-78znbYH2G_Pfis\",\"y\":\"F2cf19E4YZGucPWOAgBbhuzUmdSd6ICQc6O9Hog_F8U\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"dev\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
+        "int-prod.install.json": "{\"id\":\"batt_0195cdcd62947e42b706e8d89f64c737\",\"usage\":\"internal_prod\",\"team_id\":\"batt_0195cdcd627e7b3eb452d35222757e2a\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"G3TG4qn2Yn6RKh1y5IRcdverbWncUJg8iGTv80qWB6s\",\"kty\":\"EC\",\"x\":\"E-Pyhv4YQMgFdH9e2VUY21PeKhXV6cVsh5px8ck1C3I\",\"y\":\"i573oEMDr1WIxlj-FBjoOOkZ1im1pzy9wqJkMupJqBo\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"aws\",\"slug\":\"int-prod\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
+        "int-test.install.json": "{\"id\":\"batt_0195cdcd629477fd8a55e73c2844a7ec\",\"usage\":\"internal_int_test\",\"team_id\":\"batt_0195cdcd627e7b3eb452d35222757e2a\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"ox-pBWRXx4nhRRlyp_MfpqGMA2JZDHhWqu6beDvCxjk\",\"kty\":\"EC\",\"x\":\"LVu6w4QovAdWm_Ju7lfaJSGZdGRW3DzT5Kf5_59SSTc\",\"y\":\"sI5geU-BQd03JHW0_hbY0TaAer5EFU4Vx88y4ClsP6E\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"int-test\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
+        "jason.install.json": "{\"id\":\"batt_0195cdcd629479e48169d92f87059b4b\",\"usage\":\"development\",\"team_id\":\"batt_0195cdcd627e7b3eb452d35222757e2a\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"Uvm4IrNbEmpfm7qK8n9l0IOFYPkAnHtfphLVT_7q8Ss\",\"kty\":\"EC\",\"x\":\"WPpSSKhH8-oSt-iKZ8EFTbw_P5PPAi8-gJicqpTRLjk\",\"y\":\"fVidS5XlOouTAki8qchK2JblufPuZ81K6XbpkLyEod8\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"aws\",\"slug\":\"jason\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
+        "local.install.json": "{\"id\":\"batt_0195cdcd62947e96890366de26bd187d\",\"usage\":\"development\",\"team_id\":\"batt_0195cdcd627e7b3eb452d35222757e2a\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"KxWCxQVx7otMp1PSrc322rEi8R41cg7-yyX-bUxJZWs\",\"kty\":\"EC\",\"x\":\"3G0jHngRx4rfkS1S5VR9nNh1K0p5Y1pUi3uKz4na4iY\",\"y\":\"vYgbzEp2BL8Rg4Fewp93dJ6QTm9FiRQjV8TvoM77QyA\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"local\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}"
       },
       "kind": "ConfigMap",
       "metadata": {
         "annotations": {
-          "battery/hash": "F2WGHDMTTT24GSW273XM4326H4TI7ECWAZPOWFUQVGVDBRVLFEAA===="
+          "battery/hash": "VCLQSMS56U6IXDLL4N3Z2VBJX3UXB7HPXIVZK4VCJW3QJGCU2S5Q===="
         },
         "labels": {
           "app": "traditional-services",
@@ -743,7 +751,7 @@
           "battery/app": "traditional-services",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195c9448ba27e3fa2d5645c2268ba98",
+          "battery/owner": "batt_0195cdcd62997df098bae9e692134a81",
           "version": "latest"
         },
         "name": "home-base-seed-data",
@@ -755,7 +763,7 @@
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "TMOZAIH7R5TQPIN5FFRQBZ5QM7M4YHBAXZWBQ6VLQUZ5XZME443Q===="
+          "battery/hash": "NOH6ETY2JNVPQ757BUT4OA6ON6KF7QOIJURO5JZWQTBPHLNVRUXA===="
         },
         "labels": {
           "app": "battery-core",
@@ -765,7 +773,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195c9448ba27f1a9b07110ac64680b2",
+          "battery/owner": "batt_0195cdcd6299702b99138cea61e381ec",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -789,7 +797,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_0195c9448ba27f1a9b07110ac64680b2",
+              "battery/owner": "batt_0195cdcd6299702b99138cea61e381ec",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -802,7 +810,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "OHLOTKCRPAOC2DN66INYUYEJQI7GHQ2NGVR2E2FSZ623QF25KBEA7M4FEDBOD353"
+                    "value": "G42XRCOWOJ2HYHLBXG6VPFZZWBY4RDTDVIURLNMIUTDF54ZZ66TWHEOO7HCFS7UV"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -850,7 +858,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "YL3RSYVA4AWFTI3GMDKL3II5V6IONQ5A6XCUUNUKJS7WPOGQ36NA===="
+          "battery/hash": "TVOLLDQY4556NIOS2VHH3N6ZGPCSFQWQQPV2FDIKUUV6QIIIPUNQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -860,7 +868,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195c9448ba27f1a9b07110ac64680b2",
+          "battery/owner": "batt_0195cdcd6299702b99138cea61e381ec",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -872,7 +880,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "BOLLH2EENO3PSFRTIAZXHXP2RSBPWQMBOHHTSDCILBMOTASNDY2Q===="
+          "battery/hash": "JZWXCTNZV5YRYD6LIMNRJ3V267BBE7PHQCRM7D7QQ5FTRSW2N7BA===="
         },
         "labels": {
           "app": "traditional-services",
@@ -882,7 +890,7 @@
           "battery/app": "traditional-services",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195c9448ba27e3fa2d5645c2268ba98",
+          "battery/owner": "batt_0195cdcd62997df098bae9e692134a81",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -894,7 +902,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "FF3QNZIOSFE2NNNOKI3NXKZGEAZYAHKJB5JDKU3BBRMH5EYFIYAQ===="
+          "battery/hash": "5TTBX7AYAGQNTSSMMVT6EHHMBJATZMVNHQYYBGLLRYLHEHWSWM7Q===="
         },
         "labels": {
           "app": "battery-core",
@@ -904,7 +912,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195c9448ba27f1a9b07110ac64680b2",
+          "battery/owner": "batt_0195cdcd6299702b99138cea61e381ec",
           "version": "latest"
         },
         "name": "bootstrap",
@@ -917,7 +925,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "TOHAW2IBDQ3BOE4U2UCE5BLHLJB5LCJQLUZLQQ2GAFYAFGAWN22Q====",
+          "battery/hash": "LLJS7KY5TYIJVW7S4ITPQ4FCELBIM3XCBOAV6BABLYRMP7K6OZVA====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -928,7 +936,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195c9448ba27f1a9b07110ac64680b2",
+          "battery/owner": "batt_0195cdcd6299702b99138cea61e381ec",
           "version": "latest"
         },
         "name": "gp2"
@@ -943,7 +951,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "GJDK5HKCKZU2BBZBYCTHHLSA367OELLN7KAGTUVCTDPCKICFRKZQ====",
+          "battery/hash": "CPOIWZQYTVTWV7OPYZWX4ATGEWWF7BOIHIHSGBIYLX5RMMOVGATQ====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -954,7 +962,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195c9448ba27f1a9b07110ac64680b2",
+          "battery/owner": "batt_0195cdcd6299702b99138cea61e381ec",
           "version": "latest"
         },
         "name": "gp2-90032408"
@@ -974,7 +982,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "Y4SW5UHQXI4Y4XEHWFCDPO63DORJR2NM7HDP4WCR64PDSA2QREXQ====",
+          "battery/hash": "TCW63XP7FQ5LHRMJAM3NY74GJXQ5PBCEY75BCR37WS4MWI4O5TTQ====",
           "storageclass.kubernetes.io/is-default-class": "true"
         },
         "labels": {
@@ -985,7 +993,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195c9448ba27f1a9b07110ac64680b2",
+          "battery/owner": "batt_0195cdcd6299702b99138cea61e381ec",
           "version": "latest"
         },
         "name": "gp3-105457460"

--- a/bootstrap/int-test.install.json
+++ b/bootstrap/int-test.install.json
@@ -1,14 +1,14 @@
 {
-  "id": "batt_0195c9448b9c727db246e2ac027aeb5e",
+  "id": "batt_0195cdcd629477fd8a55e73c2844a7ec",
   "usage": "internal_int_test",
-  "team_id": "batt_0195c9448b8475d09205a9949eb3682c",
+  "team_id": "batt_0195cdcd627e7b3eb452d35222757e2a",
   "default_size": "medium",
   "control_jwk": {
     "crv": "P-256",
-    "d": "NMO_iUYVXt2sX0zs9T9Xn8FnDaujEEtXX-YuRimt3jg",
+    "d": "ox-pBWRXx4nhRRlyp_MfpqGMA2JZDHhWqu6beDvCxjk",
     "kty": "EC",
-    "x": "2bQpQcnhym8e2Zk8u4-jsoxQnVcPQLf-ZzSN_l3k5Jg",
-    "y": "IpgWfpZj7FjdKEgB1oKvGKqgw0v6IInNQQMLe7r7_54"
+    "x": "LVu6w4QovAdWm_Ju7lfaJSGZdGRW3DzT5Kf5_59SSTc",
+    "y": "sI5geU-BQd03JHW0_hbY0TaAer5EFU4Vx88y4ClsP6E"
   },
   "inserted_at": null,
   "updated_at": null,

--- a/bootstrap/int-test.spec.json
+++ b/bootstrap/int-test.spec.json
@@ -9,7 +9,7 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_0195c9448ba07e26927d18f357e11b04",
+        "id": "batt_0195cdcd62987b34afac4c0bbf36f6a7",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -21,13 +21,13 @@
           "ai_namespace": "battery-ai",
           "default_size": "medium",
           "cluster_name": "int-test",
-          "install_id": "batt_0195c9448b9c727db246e2ac027aeb5e",
+          "install_id": "batt_0195cdcd629477fd8a55e73c2844a7ec",
           "control_jwk": {
             "crv": "P-256",
-            "d": "NMO_iUYVXt2sX0zs9T9Xn8FnDaujEEtXX-YuRimt3jg",
+            "d": "ox-pBWRXx4nhRRlyp_MfpqGMA2JZDHhWqu6beDvCxjk",
             "kty": "EC",
-            "x": "2bQpQcnhym8e2Zk8u4-jsoxQnVcPQLf-ZzSN_l3k5Jg",
-            "y": "IpgWfpZj7FjdKEgB1oKvGKqgw0v6IInNQQMLe7r7_54"
+            "x": "LVu6w4QovAdWm_Ju7lfaJSGZdGRW3DzT5Kf5_59SSTc",
+            "y": "sI5geU-BQd03JHW0_hbY0TaAer5EFU4Vx88y4ClsP6E"
           },
           "upgrade_days_of_week": [
             true,
@@ -52,7 +52,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195c9448ba072a78eb40012106911df",
+        "id": "batt_0195cdcd62987d5589a4be9b564b87ff",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
@@ -60,15 +60,15 @@
           "service_role_arn": null,
           "bucket_name": null,
           "bucket_arn": null,
-          "image_name_override": null,
-          "image_tag_override": null
+          "image_tag_override": null,
+          "image_name_override": null
         },
         "group": "data",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0195c9448ba07e7d9f05893048052eac",
+        "id": "batt_0195cdcd629874d28095d61b0c852787",
         "type": "ferretdb",
         "config": {
           "type": "ferretdb",
@@ -81,7 +81,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195c9448ba177e19d45db684dc24b01",
+        "id": "batt_0195cdcd62987303b4dea708640101b3",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -96,7 +96,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195c9448ba1746fb691eff2d53c56eb",
+        "id": "batt_0195cdcd62987ac485944d8bd62ccee0",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -109,7 +109,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195c9448ba17275b45659a3f2e6e165",
+        "id": "batt_0195cdcd629879e0ba8c0ad08077f6fb",
         "type": "metallb",
         "config": {
           "type": "metallb",
@@ -129,7 +129,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195c9448ba17f85881b51f1bea1a32f",
+        "id": "batt_0195cdcd62987906862e3621dbcfcf20",
         "type": "traditional_services",
         "config": {
           "type": "traditional_services",
@@ -156,8 +156,16 @@
         "virtual_size": "small",
         "env_values": [
           {
+            "name": "BATTERY_TEAM_IDS",
+            "value": "batt_0195cdcd627e7b3eb452d35222757e2a",
+            "source_name": null,
+            "source_type": "value",
+            "source_key": null,
+            "source_optional": false
+          },
+          {
             "name": "SECRET_KEY_BASE",
-            "value": "ZYWSC6DG7H3QRFHIBSRTJVQDA2GWOTD6XXLJC2QRN5EL7GUUT7LOLYCNA5SUFTBE",
+            "value": "L5T3JQ37O55JESB3T2VGAVGPJXZ6EDVV4TG2KXL7KFTAAXSRHD7EIH26TOYNO63O",
             "source_name": null,
             "source_type": "value",
             "source_key": null,
@@ -466,7 +474,7 @@
           {
             "version": 2,
             "username": "battery-control-user",
-            "password": "NA4VH2ZEBCX7Y4FXY4D7SDSD"
+            "password": "3IAVAD2I2NBDQKULQSA3OZUU"
           },
           {
             "version": 1,
@@ -514,7 +522,7 @@
           {
             "version": 1,
             "username": "home-base",
-            "password": "6NYT5O6YTBLT443YQKRRS7CF"
+            "password": "AKX73TQ5FRBOTWSBW2TNDXOI"
           }
         ],
         "cpu_requested": 4000,
@@ -559,7 +567,7 @@
           {
             "version": 1,
             "username": "cla",
-            "password": "OIYIHIHRNLR3UGISKXWDYN5O"
+            "password": "3WUP4GF4NGSS5P5XRZGWU227"
           }
         ],
         "cpu_requested": 4000,
@@ -589,7 +597,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "GS34Q3LAS5K2XVHJKTCE24SCTGONSOBTCAVKEDSKIZWUKM5PIFHA===="
+          "battery/hash": "PUBZ6CHLBXJFIY44G3AKOVO6ZKA3CJYETQFIENPVRBMT4NRKZZHQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -599,7 +607,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195c9448ba07e26927d18f357e11b04",
+          "battery/owner": "batt_0195cdcd62987b34afac4c0bbf36f6a7",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -620,17 +628,17 @@
     "/config_map/home_base_seed_data": {
       "apiVersion": "v1",
       "data": {
-        "batt_0195c9448b8475d09205a9949eb3682c.team.json": "{\"id\":\"batt_0195c9448b8475d09205a9949eb3682c\",\"name\":\"Batteries Included Team\",\"inserted_at\":null,\"updated_at\":null,\"op_email\":\"elliott@batteriesincl.com\",\"deleted_at\":null}",
-        "dev.install.json": "{\"id\":\"batt_0195c9448b897d11b08d4df46c7eaf82\",\"usage\":\"internal_dev\",\"team_id\":\"batt_0195c9448b8475d09205a9949eb3682c\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"bU4zl-Ue6ID-4o1R-O0sPBaTOtNqd7G2uybxCdsx4y4\",\"kty\":\"EC\",\"x\":\"bkg5j5cXMdXZmYWnLZeILyJstHNMmj6TCs1qag9FoHY\",\"y\":\"AH-frxm-9ceIe2tpux9gkDD8LgFTOtcovhTQQrqfo4I\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"dev\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
-        "int-prod.install.json": "{\"id\":\"batt_0195c9448b9c7b11ab03d3558b7433f8\",\"usage\":\"internal_prod\",\"team_id\":\"batt_0195c9448b8475d09205a9949eb3682c\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"ByWzN8ZkUC6V3m_emeCHYZaVchx7LQqHCOZ85IpUDW4\",\"kty\":\"EC\",\"x\":\"Wdff8M94Zwa1wYFnNAbESVSYmWAWxDtA4pr6b_2g2is\",\"y\":\"3ozzeeIMl-WDbkjkjXLNaRdfULrF8CimZZo3os0MkMA\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"aws\",\"slug\":\"int-prod\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
-        "int-test.install.json": "{\"id\":\"batt_0195c9448b9c727db246e2ac027aeb5e\",\"usage\":\"internal_int_test\",\"team_id\":\"batt_0195c9448b8475d09205a9949eb3682c\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"NMO_iUYVXt2sX0zs9T9Xn8FnDaujEEtXX-YuRimt3jg\",\"kty\":\"EC\",\"x\":\"2bQpQcnhym8e2Zk8u4-jsoxQnVcPQLf-ZzSN_l3k5Jg\",\"y\":\"IpgWfpZj7FjdKEgB1oKvGKqgw0v6IInNQQMLe7r7_54\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"int-test\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
-        "jason.install.json": "{\"id\":\"batt_0195c9448b9d715bb9d064f4524ebab3\",\"usage\":\"development\",\"team_id\":\"batt_0195c9448b8475d09205a9949eb3682c\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"42YhC13W4QvdTzgUYDe_aTUnz-F72aIpnRsn2aVg07M\",\"kty\":\"EC\",\"x\":\"7W_swqR2_sizzHp3hF5MrB51PDf_tfuinNknqGifu5Q\",\"y\":\"iOx73UvLcO8u8tKLJ60j4CYzBKLjY8BWxGDI_DM369I\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"aws\",\"slug\":\"jason\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
-        "local.install.json": "{\"id\":\"batt_0195c9448b9d7aaf84fe9e34b568ffc0\",\"usage\":\"development\",\"team_id\":\"batt_0195c9448b8475d09205a9949eb3682c\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"IAwqnw8MXcWRpsre2tPJQZY8n8FAPV6bejmlYjhlncI\",\"kty\":\"EC\",\"x\":\"m651EwuY7GXuJ9-dUp4vZ8Is6YCmtAFJ_yVJUhhDMqY\",\"y\":\"lb8Kp3L_QvNpuZUw0f1YZsPtdXxxu6p8e0cyys4L6eg\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"local\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}"
+        "batt_0195cdcd627e7b3eb452d35222757e2a.team.json": "{\"id\":\"batt_0195cdcd627e7b3eb452d35222757e2a\",\"name\":\"Batteries Included Team\",\"inserted_at\":null,\"updated_at\":null,\"op_email\":\"elliott@batteriesincl.com\",\"deleted_at\":null}",
+        "dev.install.json": "{\"id\":\"batt_0195cdcd628276c6ab184fa13845c2bd\",\"usage\":\"internal_dev\",\"team_id\":\"batt_0195cdcd627e7b3eb452d35222757e2a\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"iqhCYVm-h_O40zW6Y6dqiyKxrKcbGMdwYbVN5UggDIw\",\"kty\":\"EC\",\"x\":\"ISMzB5bDG4BE_mr--oQGZvR-VvT5-78znbYH2G_Pfis\",\"y\":\"F2cf19E4YZGucPWOAgBbhuzUmdSd6ICQc6O9Hog_F8U\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"dev\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
+        "int-prod.install.json": "{\"id\":\"batt_0195cdcd62947e42b706e8d89f64c737\",\"usage\":\"internal_prod\",\"team_id\":\"batt_0195cdcd627e7b3eb452d35222757e2a\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"G3TG4qn2Yn6RKh1y5IRcdverbWncUJg8iGTv80qWB6s\",\"kty\":\"EC\",\"x\":\"E-Pyhv4YQMgFdH9e2VUY21PeKhXV6cVsh5px8ck1C3I\",\"y\":\"i573oEMDr1WIxlj-FBjoOOkZ1im1pzy9wqJkMupJqBo\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"aws\",\"slug\":\"int-prod\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
+        "int-test.install.json": "{\"id\":\"batt_0195cdcd629477fd8a55e73c2844a7ec\",\"usage\":\"internal_int_test\",\"team_id\":\"batt_0195cdcd627e7b3eb452d35222757e2a\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"ox-pBWRXx4nhRRlyp_MfpqGMA2JZDHhWqu6beDvCxjk\",\"kty\":\"EC\",\"x\":\"LVu6w4QovAdWm_Ju7lfaJSGZdGRW3DzT5Kf5_59SSTc\",\"y\":\"sI5geU-BQd03JHW0_hbY0TaAer5EFU4Vx88y4ClsP6E\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"int-test\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
+        "jason.install.json": "{\"id\":\"batt_0195cdcd629479e48169d92f87059b4b\",\"usage\":\"development\",\"team_id\":\"batt_0195cdcd627e7b3eb452d35222757e2a\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"Uvm4IrNbEmpfm7qK8n9l0IOFYPkAnHtfphLVT_7q8Ss\",\"kty\":\"EC\",\"x\":\"WPpSSKhH8-oSt-iKZ8EFTbw_P5PPAi8-gJicqpTRLjk\",\"y\":\"fVidS5XlOouTAki8qchK2JblufPuZ81K6XbpkLyEod8\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"aws\",\"slug\":\"jason\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
+        "local.install.json": "{\"id\":\"batt_0195cdcd62947e96890366de26bd187d\",\"usage\":\"development\",\"team_id\":\"batt_0195cdcd627e7b3eb452d35222757e2a\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"KxWCxQVx7otMp1PSrc322rEi8R41cg7-yyX-bUxJZWs\",\"kty\":\"EC\",\"x\":\"3G0jHngRx4rfkS1S5VR9nNh1K0p5Y1pUi3uKz4na4iY\",\"y\":\"vYgbzEp2BL8Rg4Fewp93dJ6QTm9FiRQjV8TvoM77QyA\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"local\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}"
       },
       "kind": "ConfigMap",
       "metadata": {
         "annotations": {
-          "battery/hash": "VDAPXGUWMKT2AHIXBLVVUYAGA34IENFUMIH662C2SPT7I6ICEGEA===="
+          "battery/hash": "HQTPH33PW5QKAP5RFK2IIGKG54N4V2WWFYKNXEUDSCBG3BOURI3A===="
         },
         "labels": {
           "app": "traditional-services",
@@ -640,7 +648,7 @@
           "battery/app": "traditional-services",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195c9448ba17f85881b51f1bea1a32f",
+          "battery/owner": "batt_0195cdcd62987906862e3621dbcfcf20",
           "version": "latest"
         },
         "name": "home-base-seed-data",
@@ -652,7 +660,7 @@
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "KWGXRY7LLRS256QHAWWG6HSRDGDMGJP73GZXH4NTAQNDAXZOAJ6Q===="
+          "battery/hash": "6DHHCFUPGIVIYG5O6ZOXOW76UI77R3XU2AG5FZUXZFQPND23YSXA===="
         },
         "labels": {
           "app": "battery-core",
@@ -662,7 +670,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195c9448ba07e26927d18f357e11b04",
+          "battery/owner": "batt_0195cdcd62987b34afac4c0bbf36f6a7",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -686,7 +694,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_0195c9448ba07e26927d18f357e11b04",
+              "battery/owner": "batt_0195cdcd62987b34afac4c0bbf36f6a7",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -699,7 +707,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "6CI3NWIYF5F2KOOQWJ5VIXZEFWZILKFI4BPSJ6CQYTJBVDCX3TKAAKHXMCJPLK6H"
+                    "value": "A5JLKW7ZMNRLHV3WMSJ44P7MH65FSM63R7SNZIROVCR2H5JY7YBHRG2IINDF34C4"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -747,7 +755,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "UIMKWQWSFZ7GPDLVW5Y63K3SG7RNOBN2TO6WX3OVPPWQJQU2BLCQ===="
+          "battery/hash": "Q5T2LY27CHRHIDOPCLAPNGFAXA2JX7BMWWAQCGNIWXD5KPEWPG2Q===="
         },
         "labels": {
           "app": "battery-core",
@@ -757,7 +765,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195c9448ba07e26927d18f357e11b04",
+          "battery/owner": "batt_0195cdcd62987b34afac4c0bbf36f6a7",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -769,7 +777,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "JB5JQM5DKD4LMAJYQMXPPESQBRLOAFT5SUJBHGWZQHH2CTNF6EEQ===="
+          "battery/hash": "5L4UXXALTPG3ZPIH2S4SIET53EG3275CH7QTJKYMC6YJRJX22U5Q===="
         },
         "labels": {
           "app": "traditional-services",
@@ -779,7 +787,7 @@
           "battery/app": "traditional-services",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195c9448ba17f85881b51f1bea1a32f",
+          "battery/owner": "batt_0195cdcd62987906862e3621dbcfcf20",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -791,7 +799,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "4Y44PDF7FWGW5CCR6DZNSTBG55F7CH46FV7U46UR2W3QKMXP3EAA===="
+          "battery/hash": "WA6VSJQPP5VLQDME3UXKQNWOB2LJKHJK7V3K5D7BXKG5UFOJ2A4A===="
         },
         "labels": {
           "app": "battery-core",
@@ -801,7 +809,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195c9448ba07e26927d18f357e11b04",
+          "battery/owner": "batt_0195cdcd62987b34afac4c0bbf36f6a7",
           "version": "latest"
         },
         "name": "bootstrap",

--- a/bootstrap/jason.install.json
+++ b/bootstrap/jason.install.json
@@ -1,14 +1,14 @@
 {
-  "id": "batt_0195c9448b9d715bb9d064f4524ebab3",
+  "id": "batt_0195cdcd629479e48169d92f87059b4b",
   "usage": "development",
-  "team_id": "batt_0195c9448b8475d09205a9949eb3682c",
+  "team_id": "batt_0195cdcd627e7b3eb452d35222757e2a",
   "default_size": "small",
   "control_jwk": {
     "crv": "P-256",
-    "d": "42YhC13W4QvdTzgUYDe_aTUnz-F72aIpnRsn2aVg07M",
+    "d": "Uvm4IrNbEmpfm7qK8n9l0IOFYPkAnHtfphLVT_7q8Ss",
     "kty": "EC",
-    "x": "7W_swqR2_sizzHp3hF5MrB51PDf_tfuinNknqGifu5Q",
-    "y": "iOx73UvLcO8u8tKLJ60j4CYzBKLjY8BWxGDI_DM369I"
+    "x": "WPpSSKhH8-oSt-iKZ8EFTbw_P5PPAi8-gJicqpTRLjk",
+    "y": "fVidS5XlOouTAki8qchK2JblufPuZ81K6XbpkLyEod8"
   },
   "inserted_at": null,
   "updated_at": null,

--- a/bootstrap/jason.spec.json
+++ b/bootstrap/jason.spec.json
@@ -9,7 +9,7 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_0195c9448ba47baf8f7e55d4b842267f",
+        "id": "batt_0195cdcd629c719798a8715f43c5be24",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -21,13 +21,13 @@
           "ai_namespace": "battery-ai",
           "default_size": "small",
           "cluster_name": "jason",
-          "install_id": "batt_0195c9448b9d715bb9d064f4524ebab3",
+          "install_id": "batt_0195cdcd629479e48169d92f87059b4b",
           "control_jwk": {
             "crv": "P-256",
-            "d": "42YhC13W4QvdTzgUYDe_aTUnz-F72aIpnRsn2aVg07M",
+            "d": "Uvm4IrNbEmpfm7qK8n9l0IOFYPkAnHtfphLVT_7q8Ss",
             "kty": "EC",
-            "x": "7W_swqR2_sizzHp3hF5MrB51PDf_tfuinNknqGifu5Q",
-            "y": "iOx73UvLcO8u8tKLJ60j4CYzBKLjY8BWxGDI_DM369I"
+            "x": "WPpSSKhH8-oSt-iKZ8EFTbw_P5PPAi8-gJicqpTRLjk",
+            "y": "fVidS5XlOouTAki8qchK2JblufPuZ81K6XbpkLyEod8"
           },
           "upgrade_days_of_week": [
             true,
@@ -52,7 +52,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195c9448ba47e6bbbd53556a17e393a",
+        "id": "batt_0195cdcd629c768f9937ed15fd3e50ea",
         "type": "cert_manager",
         "config": {
           "type": "cert_manager",
@@ -78,7 +78,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195c9448ba47c30a5711ed89ef6a69f",
+        "id": "batt_0195cdcd629c7fcf8f86a6a85995fb61",
         "type": "battery_ca",
         "config": {
           "type": "battery_ca"
@@ -88,7 +88,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195c9448ba47dddb89f7083d14de089",
+        "id": "batt_0195cdcd629c706f939bbdfd1ca8a6e7",
         "type": "karpenter",
         "config": {
           "type": "karpenter",
@@ -98,8 +98,8 @@
           "node_role_name": null,
           "ami_alias": "al2@v20250212",
           "bottlerocket_ami_alias": "bottlerocket@v1.32.0",
-          "image_name_override": null,
           "image_tag_override": null,
+          "image_name_override": null,
           "ami_alias_override": null,
           "bottlerocket_ami_alias_override": null
         },
@@ -108,7 +108,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195c9448ba477ac81ba49aaff595e6a",
+        "id": "batt_0195cdcd629c7e708a944196f8102111",
         "type": "aws_load_balancer_controller",
         "config": {
           "type": "aws_load_balancer_controller",
@@ -116,15 +116,15 @@
           "service_role_arn": null,
           "subnets": null,
           "eip_allocations": null,
-          "image_name_override": null,
-          "image_tag_override": null
+          "image_tag_override": null,
+          "image_name_override": null
         },
         "group": "magic",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0195c9448ba47d638c7f6028b4a77002",
+        "id": "batt_0195cdcd629c7ea19b3b8669861a7d1d",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
@@ -132,15 +132,15 @@
           "service_role_arn": null,
           "bucket_name": null,
           "bucket_arn": null,
-          "image_name_override": null,
-          "image_tag_override": null
+          "image_tag_override": null,
+          "image_name_override": null
         },
         "group": "data",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0195c9448ba47b08ab8c7d0a2e31dcc7",
+        "id": "batt_0195cdcd629c729595e9105603119234",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -155,7 +155,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195c9448ba4773cb77888ba99f421fb",
+        "id": "batt_0195cdcd629c7e6e839bd3d92fe23a67",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -168,7 +168,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195c9448ba479d699cd3b5feb7be74c",
+        "id": "batt_0195cdcd629c79e4ba8502500a4a4b07",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -213,7 +213,7 @@
           {
             "version": 1,
             "username": "battery-control-user",
-            "password": "QKKJWSO4JIYNGMIKML735L6A"
+            "password": "2VSPXILIQLSAEZBLW2RURTRJ"
           }
         ],
         "cpu_requested": 500,
@@ -241,7 +241,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "2CRO4POOSAMHMYMM5MEO3SN3UXVR3MBRW6XWLGA3LHODBP2P2LYQ===="
+          "battery/hash": "AG2KDJDD2VMBMRIIL7PU27PV6CORTZNLLRDFCEJGOYVLDVC5LNOA===="
         },
         "labels": {
           "app": "battery-core",
@@ -251,7 +251,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195c9448ba47baf8f7e55d4b842267f",
+          "battery/owner": "batt_0195cdcd629c719798a8715f43c5be24",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -274,7 +274,7 @@
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "CBEI4GSVS3JDQPJSZRIFFM63KZDWHM34W45QCBZQL6IK53G5JLUQ===="
+          "battery/hash": "ENETBFWFFQZ77EOP36CDXEOAKBNOUJDMKQN5NQD5F66YV435QIDA===="
         },
         "labels": {
           "app": "battery-core",
@@ -284,7 +284,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195c9448ba47baf8f7e55d4b842267f",
+          "battery/owner": "batt_0195cdcd629c719798a8715f43c5be24",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -308,7 +308,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_0195c9448ba47baf8f7e55d4b842267f",
+              "battery/owner": "batt_0195cdcd629c719798a8715f43c5be24",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -321,7 +321,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "7LIBWEP6EE7MMUAVGLUV6DTDAXXLUCC2DLQU6NZ7D3MG2IBSII2AVSXFADZF6NWA"
+                    "value": "7JVCYVEEAHBEHGK63X5VNACXBQVGWBO5EXF6C2RW4GC5BXGBDSCBPWYJ6K7XH7QH"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -369,7 +369,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "F6QU34MAERMX3XUJFX6KQBG46XUOVFDNEQPKG7U6XVAY7STAN7FA===="
+          "battery/hash": "QTTXKD6UNZQQKBRQIOPQLYG4KCRLIBUGZI7F63VSJ24QLNNXSE4A===="
         },
         "labels": {
           "app": "battery-core",
@@ -379,7 +379,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195c9448ba47baf8f7e55d4b842267f",
+          "battery/owner": "batt_0195cdcd629c719798a8715f43c5be24",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -391,7 +391,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "URGMBSOCB7MXANV34XAEXY4NQYZJTP3D643P252GAEDNQYETKBQA===="
+          "battery/hash": "33BLAH54SDFIGRKBRIJZN564HANEBWN4I6WEBL66SQGGNXUH2HOQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -401,7 +401,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195c9448ba47baf8f7e55d4b842267f",
+          "battery/owner": "batt_0195cdcd629c719798a8715f43c5be24",
           "version": "latest"
         },
         "name": "bootstrap",
@@ -414,7 +414,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "7K5EB3BJ6QF7CL2IC7APTQOFEXS2VCBYICPXDMTQMEWWKZWQXR7A====",
+          "battery/hash": "6CUMKUVODIOR5QL3AI6HCHEQBBQRPN455VDIOETACIKZ33NS2L3A====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -425,7 +425,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195c9448ba47baf8f7e55d4b842267f",
+          "battery/owner": "batt_0195cdcd629c719798a8715f43c5be24",
           "version": "latest"
         },
         "name": "gp2"
@@ -440,7 +440,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "7EENSA2GW5SAMRIE4WKGGYU3JN76XMCZJLL2X6BPL7KYMXJ4WLEQ====",
+          "battery/hash": "3UJYTOVJF7TDWQUEL3JUWG4G3YRDNFIKRBXH7PWRPRVPVRLZTYDQ====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -451,7 +451,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195c9448ba47baf8f7e55d4b842267f",
+          "battery/owner": "batt_0195cdcd629c719798a8715f43c5be24",
           "version": "latest"
         },
         "name": "gp2-90032408"
@@ -471,7 +471,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "MQPBYXIIKFGRLVCPDIPAIN6QJR4E33W4YM57ZJIIATPSQ2OOMRKA====",
+          "battery/hash": "SQ3OZQRGCUMEXE4OBW5XVA2B67WNBID7MI54ZEYKF7NCTYI53KZQ====",
           "storageclass.kubernetes.io/is-default-class": "true"
         },
         "labels": {
@@ -482,7 +482,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195c9448ba47baf8f7e55d4b842267f",
+          "battery/owner": "batt_0195cdcd629c719798a8715f43c5be24",
           "version": "latest"
         },
         "name": "gp3-105457460"

--- a/bootstrap/local.install.json
+++ b/bootstrap/local.install.json
@@ -1,14 +1,14 @@
 {
-  "id": "batt_0195c9448b9d7aaf84fe9e34b568ffc0",
+  "id": "batt_0195cdcd62947e96890366de26bd187d",
   "usage": "development",
-  "team_id": "batt_0195c9448b8475d09205a9949eb3682c",
+  "team_id": "batt_0195cdcd627e7b3eb452d35222757e2a",
   "default_size": "tiny",
   "control_jwk": {
     "crv": "P-256",
-    "d": "IAwqnw8MXcWRpsre2tPJQZY8n8FAPV6bejmlYjhlncI",
+    "d": "KxWCxQVx7otMp1PSrc322rEi8R41cg7-yyX-bUxJZWs",
     "kty": "EC",
-    "x": "m651EwuY7GXuJ9-dUp4vZ8Is6YCmtAFJ_yVJUhhDMqY",
-    "y": "lb8Kp3L_QvNpuZUw0f1YZsPtdXxxu6p8e0cyys4L6eg"
+    "x": "3G0jHngRx4rfkS1S5VR9nNh1K0p5Y1pUi3uKz4na4iY",
+    "y": "vYgbzEp2BL8Rg4Fewp93dJ6QTm9FiRQjV8TvoM77QyA"
   },
   "inserted_at": null,
   "updated_at": null,

--- a/bootstrap/local.spec.json
+++ b/bootstrap/local.spec.json
@@ -9,7 +9,7 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_0195c9448ba375a4af0b03922be3ff17",
+        "id": "batt_0195cdcd629b7472bab1945bf356e32b",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -24,7 +24,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195c9448ba37c23998cb7bb6c199b08",
+        "id": "batt_0195cdcd629b7a3eafc1a2b79452aced",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -37,7 +37,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195c9448ba37033858cba1aad1a14ee",
+        "id": "batt_0195cdcd629b722691799d449f2f90f2",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -49,13 +49,13 @@
           "ai_namespace": "battery-ai",
           "default_size": "tiny",
           "cluster_name": "local",
-          "install_id": "batt_0195c9448b9d7aaf84fe9e34b568ffc0",
+          "install_id": "batt_0195cdcd62947e96890366de26bd187d",
           "control_jwk": {
             "crv": "P-256",
-            "d": "IAwqnw8MXcWRpsre2tPJQZY8n8FAPV6bejmlYjhlncI",
+            "d": "KxWCxQVx7otMp1PSrc322rEi8R41cg7-yyX-bUxJZWs",
             "kty": "EC",
-            "x": "m651EwuY7GXuJ9-dUp4vZ8Is6YCmtAFJ_yVJUhhDMqY",
-            "y": "lb8Kp3L_QvNpuZUw0f1YZsPtdXxxu6p8e0cyys4L6eg"
+            "x": "3G0jHngRx4rfkS1S5VR9nNh1K0p5Y1pUi3uKz4na4iY",
+            "y": "vYgbzEp2BL8Rg4Fewp93dJ6QTm9FiRQjV8TvoM77QyA"
           },
           "upgrade_days_of_week": [
             true,
@@ -80,7 +80,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195c9448ba37884ae29d7beb86e8021",
+        "id": "batt_0195cdcd629b796480e35893428fcaa1",
         "type": "metallb",
         "config": {
           "type": "metallb",
@@ -100,7 +100,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195c9448ba47142a2ee6c94b20231e1",
+        "id": "batt_0195cdcd629b765fa758ce3b04adac89",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
@@ -108,15 +108,15 @@
           "service_role_arn": null,
           "bucket_name": null,
           "bucket_arn": null,
-          "image_name_override": null,
-          "image_tag_override": null
+          "image_tag_override": null,
+          "image_name_override": null
         },
         "group": "data",
         "inserted_at": null,
         "updated_at": null
       },
       {
-        "id": "batt_0195c9448ba47e11a3421804dc053d25",
+        "id": "batt_0195cdcd629b7aa7b043a4ae605c9ea7",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -161,7 +161,7 @@
           {
             "version": 1,
             "username": "battery-control-user",
-            "password": "NYZAOMGJTPYWCQDH4IVN5QBM"
+            "password": "NQNKISNJHU4FXLOHLSQDRWUC"
           }
         ],
         "cpu_requested": 500,
@@ -189,7 +189,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "P6JS5LRADQ3CF3VN4X7TL7II6PQJ6DIQJUE634LOXFXP556TSJ3Q===="
+          "battery/hash": "P47YFE25AVSUVWOKWR2KVVJMUMZ45E52JNUZV4PSZNGOJLV56HMA===="
         },
         "labels": {
           "app": "battery-core",
@@ -199,7 +199,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195c9448ba37033858cba1aad1a14ee",
+          "battery/owner": "batt_0195cdcd629b722691799d449f2f90f2",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -222,7 +222,7 @@
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "SGGFTPEXZWSC35V5375UN6FNYX4CZUKV2KOZUUGKAFPPS372P4VA===="
+          "battery/hash": "HEKVX4AEYZ6A2SD6VKDLDYR4DDJJXIINTVII7WT65X3OU7XDOOWQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -232,7 +232,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195c9448ba37033858cba1aad1a14ee",
+          "battery/owner": "batt_0195cdcd629b722691799d449f2f90f2",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -256,7 +256,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_0195c9448ba37033858cba1aad1a14ee",
+              "battery/owner": "batt_0195cdcd629b722691799d449f2f90f2",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -269,7 +269,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "YVNMLA34VKN24VXRESLJMKWWNSEXJELMFKMGOSDPSMTRQLVF2FOB34RVT75Q2APD"
+                    "value": "FLHU24V4VO4MLPKP4FZH5QFFHKSVAX42UICVWRZPV3XL4GBL4ZKQGNIKINJIGI4E"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -317,7 +317,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "DOKZGFIF4OFCEK4VBCYQMMULEJGKOVN4OLXTN24T7LKRVYGILM5Q===="
+          "battery/hash": "4X3CFIQMOVLKPNY7HBMWP2NLBFGUMBMQ6URP6OMBEWCRFUN55S4A===="
         },
         "labels": {
           "app": "battery-core",
@@ -327,7 +327,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195c9448ba37033858cba1aad1a14ee",
+          "battery/owner": "batt_0195cdcd629b722691799d449f2f90f2",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -339,7 +339,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "CFIMOZR24NGM546TAITAFBOID2SMJGY2Q66DKU7V5CVCFLVYQU7A===="
+          "battery/hash": "PX4GWB6RHVDYSM3WJJYDKJQ3K7ZO3EYHHGPM5RKAA5BHV4JZ6DPA===="
         },
         "labels": {
           "app": "battery-core",
@@ -349,7 +349,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195c9448ba37033858cba1aad1a14ee",
+          "battery/owner": "batt_0195cdcd629b722691799d449f2f90f2",
           "version": "latest"
         },
         "name": "bootstrap",

--- a/bootstrap/team.json
+++ b/bootstrap/team.json
@@ -1,5 +1,5 @@
 {
-  "id": "batt_0195c9448b8475d09205a9949eb3682c",
+  "id": "batt_0195cdcd627e7b3eb452d35222757e2a",
   "name": "Batteries Included Team",
   "inserted_at": null,
   "updated_at": null,

--- a/platform_umbrella/apps/common_core/lib/common_core/state_summary/state_summary.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/state_summary/state_summary.ex
@@ -59,7 +59,7 @@ defmodule CommonCore.StateSummary do
       %{
         batteries: Enum.map(batteries, fn b -> %{Map.from_struct(b) | config: Map.from_struct(b.config)} end),
         postgres_clusters: Postgres.cluster_arg_list(batteries, installation),
-        traditional_services: TraditionalServices.services(installation),
+        traditional_services: TraditionalServices.services(installation, home_base_init_data),
         home_base_init_data: Map.from_struct(home_base_init_data),
         # For now we don't have projects to add to the target summary
         # once we work out inter-cluster project sharing we can add this


### PR DESCRIPTION
Looking at bootstrap stuff this morning and noticed we could pre-populate the `BATTERY_TEAM_IDS` instead of having to manually add it.