### PR TITLE
fix(bix): place bi in subdirectory

### DIFF
--- a/bin/common-functions.sh
+++ b/bin/common-functions.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 TRACE=${TRACE-""}
-BI_BUILD_DIR="${BI_BUILD_DIR:-$HOME/.local/share/bi}"
+BI_BUILD_DIR="${BI_BUILD_DIR:-$HOME/.local/share/bi/dev/}"
 KEEP_BUILDS="${KEEP_BUILDS:-10}"
 
 setup_colors() {


### PR DESCRIPTION
Installs from home-base put the binaries in the same directory. `bix` cleans those up indiscriminately.

Put em in a subdir so `bix` only cleans up `bix` created binaries.