### PR TITLE
fix(bi): update signature algorithm to match new home-base

### DIFF
--- a/bi/pkg/installs/env.go
+++ b/bi/pkg/installs/env.go
@@ -98,7 +98,7 @@ func readInstallEnv(slugOrURL string) (string, *InstallEnv, error) {
 
 		spec, err := specs.GetSpecFromURL(p.path)
 		if err != nil {
-			l.Debug("Didn't find install")
+			l.Debug("Didn't find install", slog.Any("err", err))
 			continue
 		}
 		l.Debug("Found install")

--- a/bi/pkg/specs/get_spec.go
+++ b/bi/pkg/specs/get_spec.go
@@ -103,7 +103,7 @@ func parseSpecResponse(specBytes []byte) ([]byte, error) {
 		return nil, fmt.Errorf("failed to marshal JWS back into string: %w", err)
 	}
 
-	jws, err := jose.ParseSigned(string(bs), []jose.SignatureAlgorithm{jose.EdDSA})
+	jws, err := jose.ParseSigned(string(bs), []jose.SignatureAlgorithm{jose.ES256})
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse signed payload: %w", err)
 	}


### PR DESCRIPTION
The algorithm changed but we didn't update it on the `bi` side which is preventing installations from installing.