### PR TITLE
chore: bump bi stable version to 0.58.0

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/defaults/versions.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/defaults/versions.ex
@@ -2,5 +2,5 @@ defmodule CommonCore.Defaults.Versions do
   @moduledoc false
 
   @spec bi_stable_version() :: String.t()
-  def bi_stable_version, do: "0.57.0"
+  def bi_stable_version, do: "0.58.0"
 end


### PR DESCRIPTION
Summary:
I missed the version and it isn't signing well. So fix that.

Test Plan:
- /shrug
- CI
