### PR TITLE
fix: allow bootstrapping a production cluster

### DIFF
--- a/platform_umbrella/apps/kube_bootstrap/lib/kube_bootstrap.ex
+++ b/platform_umbrella/apps/kube_bootstrap/lib/kube_bootstrap.ex
@@ -21,6 +21,8 @@ defmodule KubeBootstrap do
     istio_gateway
     karpenter
     metallb
+    vm_agent
+    victoria_metrics
   )a
 
   @spec bootstrap_from_summary(StateSummary.t()) :: :ok | {:error, :retries_exhausted | list()}


### PR DESCRIPTION
The production clusters have metrics/monitoring enabled. During bootstrap, we don't install the VM CRDs so the pod and service monitors never get created and bootstrapping fails.