### PR TITLE
chore: bump stable bi version

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/defaults/versions.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/defaults/versions.ex
@@ -2,5 +2,5 @@ defmodule CommonCore.Defaults.Versions do
   @moduledoc false
 
   @spec bi_stable_version() :: String.t()
-  def bi_stable_version, do: "0.58.0"
+  def bi_stable_version, do: "0.60.0"
 end


### PR DESCRIPTION
Summary:
- Prepare for 0.61.0 release
- Bump to 0.60.0 bi

Test Plan:
- CI
