### PR TITLE
fix: keep battery_core battery starting first no matter what

### DIFF
--- a/platform_umbrella/apps/kube_services/lib/kube_services/batteries/installed_watcher.ex
+++ b/platform_umbrella/apps/kube_services/lib/kube_services/batteries/installed_watcher.ex
@@ -33,7 +33,15 @@ defmodule KubeServices.Batteries.InstalledWatcher do
     :ok = Database.subscribe(:system_battery)
 
     Logger.debug("Started watching for new batteries. Making sure already installed are running")
-    _ = start_batteries(ControlServer.Batteries.list_system_batteries())
+
+    # This is super important
+    #
+    # The battery_core battery is used by lots of batteries
+    # It's critical to start it first
+    #
+    batteries = Enum.sort(ControlServer.Batteries.list_system_batteries(), fn a, _b -> a.type == :battery_core end)
+
+    _ = start_batteries(batteries)
     {:ok, :initial_state}
   end
 


### PR DESCRIPTION
Summary:
- This should fix oauth enabled clusters

Test Plan:
- tried the repro locally and it passed
