### PR TITLE
chore: refactor json logging configuration

### DIFF
--- a/platform_umbrella/config/prod.exs
+++ b/platform_umbrella/config/prod.exs
@@ -49,6 +49,3 @@ config :logger, :console,
   compile_time_purge_matching: [
     [library: :k8s]
   ]
-
-config :logger, :default_handler,
-  formatter: {LoggerJSON.Formatters.Basic, %{metadata: [:mfa, :request_id], redactors: [], encoder_opts: []}}

--- a/platform_umbrella/config/runtime.exs
+++ b/platform_umbrella/config/runtime.exs
@@ -3,3 +3,7 @@ import Config
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",
   level: :debug
+
+if config_env() == :prod do
+  config :logger, :default_handler, formatter: LoggerJSON.Formatters.Basic.new(metadata: [:mfa, :request_id])
+end


### PR DESCRIPTION
Move the formatter configuration to runtime config. Moving to `new/1` should ensure that we always have a valid formatter config. I think the issue we had was that `redactors` was `nil` instead of `[]` which I fixed (temporarily) by copying the output of new to the compile time config.