### PR TITLE
ci: invalidate elixir cache on bi changes

### DIFF
--- a/.github/actions/setup-asdf/action.yml
+++ b/.github/actions/setup-asdf/action.yml
@@ -13,6 +13,10 @@ runs:
       with:
         asdf_branch: ${{ inputs.asdf_branch }}
 
+    - name: Determine hash keys
+      shell: bash
+      run: bin/bix ci-gen-hashes >> "$GITHUB_ENV"
+
     - name: Restore ASDF cache
       uses: actions/cache/restore@v4
       id: asdf-cache
@@ -22,7 +26,7 @@ runs:
           ~/.asdf/installs
           ~/.asdf/plugins
           ~/.asdf/shims
-        key: ${{ runner.os }}-asdf-${{ hashFiles('.tool-versions') }}
+        key: ${{ env.ASDF_HASH_KEY }}
         restore-keys: ${{ runner.os }}-asdf-
 
     - name: Install ASDF Tools

--- a/.github/actions/setup-ci/action.yml
+++ b/.github/actions/setup-ci/action.yml
@@ -13,6 +13,10 @@ runs:
     - name: Setup ASDF
       uses: ./.github/actions/setup-asdf
 
+    - name: Determine hash keys
+      shell: bash
+      run: bin/bix ci-gen-hashes >> "$GITHUB_ENV"
+
     - name: Restore elixir cache
       if: ${{ inputs.elixir_cache == 'true' }}
       uses: actions/cache/restore@v4
@@ -23,10 +27,9 @@ runs:
           platform_umbrella/_build
           platform_umbrella/.dialyzer
           ~/.local/share/bi
-        key:
-          ${{ runner.os }}-ex-${{ hashFiles('**/mix.lock', '.tool-versions') }}
+        key: ${{ env.ELIXIR_HASH_KEY }}
         restore-keys: |
-          ${{ runner.os }}-ex-
+          ${{ runner.os }}-elixir-
 
     - name: Restore Go cache
       if: ${{ inputs.go_cache == 'true' }}
@@ -35,6 +38,9 @@ runs:
         path: |
           /home/runner/.cache/go-cache
           /home/runner/.cache/go-mod-cache
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum', '.tool-versions') }}
+        key: ${{ env.GO_HASH_KEY }}
         restore-keys: |
           ${{ runner.os }}-go-
+
+    - shell: bash
+      run: rm -f bi_revision.txt

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -35,19 +35,7 @@ jobs:
           persist-credentials: false
 
       - name: Compute hash keys
-        env:
-          ASDF_HASH_KEY:
-            ${{ runner.os }}-asdf-${{ hashFiles('.tool-versions') }}
-          ELIXIR_HASH_KEY:
-            ${{ runner.os }}-ex-${{ hashFiles('**/mix.lock', '.tool-versions')
-            }}
-          GO_HASH_KEY:
-            ${{ runner.os }}-go-${{ hashFiles('**/go.sum', '.tool-versions') }}
-
-        run: |
-          { echo "ASDF_HASH_KEY=$ASDF_HASH_KEY";
-            echo "ELIXIR_HASH_KEY=$ELIXIR_HASH_KEY";
-            echo "GO_HASH_KEY=$GO_HASH_KEY"; } >> "$GITHUB_ENV"
+        run: bin/bix ci-gen-hashes >> "$GITHUB_ENV"
 
       - name: Check existing ASDF cache
         uses: actions/cache/restore@v4

--- a/bin/bix
+++ b/bin/bix
@@ -102,6 +102,10 @@ Available commands:
 **Static Site Commands**
 - static-dev       Start a development environment with npm
 - static-build     Build the static site
+
+**CI Commands**
+- ci-gen-hashes    Generate hashes
+
 EOF
     exit 1
 }
@@ -632,6 +636,50 @@ do_version_tag() {
     version_tag
 }
 
+do_generate_hashes() {
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    trap 'rm -rf "${tmpdir}"; trap - RETURN;' RETURN
+
+    # named pipe for writing output of bi_revision
+    local bi_rev_file="${tmpdir}/bi-revision"
+    mkfifo -m 600 "${bi_rev_file}"
+    bi_revision >"${bi_rev_file}" &
+
+    # generate sha256s for each file
+    # append it to the correct file(s) in the temp dir
+    while read -r hash file; do
+        case $file in
+        */go.mod)
+            echo "${hash}" | tee -a "${tmpdir}/go" >/dev/null
+            ;;
+        */mix.lock | */bi-revision)
+            echo "${hash}" | tee -a "${tmpdir}/elixir" >/dev/null
+            ;;
+        .tool-versions)
+            echo "${hash}" | tee -a \
+                "${tmpdir}/go" \
+                "${tmpdir}/elixir" \
+                "${tmpdir}/asdf" >/dev/null
+            ;;
+        *)
+            # make sure our pattern matches catch everything
+            log "Failed to match file: ${file}"
+            exit 1
+            ;;
+        esac
+    done < <(sha256sum -- .tool-versions **/go.mod **/mix.lock "${bi_rev_file}")
+
+    # generate the final hash based on the files in the temp dir
+    for type in go elixir asdf; do
+        local sum key
+        sum="$(sha256sum "${tmpdir}/${type}" | cut -d " " -f 1)"
+        key="$(printf "%s-%s-%s" "$(uname)" "${type}" "${sum}")"
+
+        printf '%s=%s\n' "${type^^}_HASH_KEY" "${key}"
+    done
+}
+
 do_ensure_bi() {
     local bin_path
     bin_path=$(bi_bin_location)
@@ -771,6 +819,9 @@ static-dev)
     ;;
 static-build)
     do_static_build
+    ;;
+ci-gen-hashes)
+    do_generate_hashes
     ;;
 root-dir)
     echo "${ROOT_DIR}"


### PR DESCRIPTION
We cache the locally built `bi` binary in the elixir cache. When there's any change in that directory, the binary will get rebuilt which takes > 1 min in CI.

So use the hash of the `bi` directory as an input to the elixir cache key.