### PR TITLE
ci: only build bi binary for int tests

### DIFF
--- a/.github/actions/setup-ci/action.yml
+++ b/.github/actions/setup-ci/action.yml
@@ -22,7 +22,6 @@ runs:
           platform_umbrella/deps
           platform_umbrella/_build
           platform_umbrella/.dialyzer
-          ~/.local/share/bi
         key:
           ${{ runner.os }}-ex-${{ hashFiles('**/mix.lock', '.tool-versions') }}
         restore-keys: |

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -16,7 +16,6 @@ env:
     platform_umbrella/deps
     platform_umbrella/_build
     platform_umbrella/.dialyzer
-    ~/.local/share/bi
   GO_PATHS: |
     ${{ vars.GOCACHE }}
     ${{ vars.GOMODCACHE }}

--- a/platform_umbrella/apps/verify/lib/verify/kind_install_worker.ex
+++ b/platform_umbrella/apps/verify/lib/verify/kind_install_worker.ex
@@ -3,7 +3,9 @@ defmodule Verify.KindInstallWorker do
   use GenServer
   use TypedStruct
 
+  alias CommonCore.ApiVersionKind
   alias CommonCore.Ecto.BatteryUUID
+  alias CommonCore.StateSummary.Namespaces
   alias Verify.PathHelper
 
   require Logger
@@ -20,7 +22,6 @@ defmodule Verify.KindInstallWorker do
     {state_opts, gen_opts} =
       opts
       |> Keyword.put_new(:name, __MODULE__)
-      |> Keyword.put_new_lazy(:bi_binary, &PathHelper.find_bi/0)
       |> Keyword.put_new_lazy(:root_path, &PathHelper.tmp_dir!/0)
       |> Keyword.split(@state_opts)
 
@@ -30,19 +31,38 @@ defmodule Verify.KindInstallWorker do
   def init(args) do
     state = struct!(State, args)
 
-    Logger.info("Starting KindInstallWorker with BI binary at #{state.bi_binary}")
+    Logger.info("Starting KindInstallWorker")
 
     {:ok, state}
   end
 
+  # determine bi_binary if necessary
+  def handle_call({:start, identifier}, _from, %{bi_binary: nil} = state) do
+    do_start(identifier, %{state | bi_binary: PathHelper.find_bi()})
+  end
+
   def handle_call({:start, identifier}, _from, state) do
-    path = build_install_spec(identifier, state)
+    do_start(identifier, state)
+  end
+
+  # determine bi_binary if necessary
+  def handle_call(:stop_all, _from, %{bi_binary: nil} = state) do
+    do_stop_all(%{state | bi_binary: PathHelper.find_bi()})
+  end
+
+  def handle_call(:stop_all, _from, state) do
+    do_stop_all(state)
+  end
+
+  defp do_start(identifier, state) do
+    {spec, path} = build_install_spec(identifier, state)
+    Logger.debug("Starting with #{path}")
 
     case System.cmd(state.bi_binary, ["start", path]) do
-      {output, 0} ->
+      {_output, 0} ->
         Logger.debug("Kind install started from #{path}")
 
-        {:reply, {:ok, extract_url(output)}, %{state | started: [path | state.started]}}
+        {:reply, {:ok, get_url(spec)}, %{state | started: [path | state.started]}}
 
       response ->
         Logger.warning("Unable to start Kind install from #{path}")
@@ -50,7 +70,7 @@ defmodule Verify.KindInstallWorker do
     end
   end
 
-  def handle_call(:stop_all, _from, %{started: started} = state) do
+  defp do_stop_all(%{started: started} = state) do
     Enum.each(started, fn path ->
       :ok = do_stop(state, path)
     end)
@@ -77,18 +97,21 @@ defmodule Verify.KindInstallWorker do
     id = BatteryUUID.autogenerate()
     path = Path.join(root_dir, "#{id}_#{install.slug}.spec.json")
     string = Jason.encode_to_iodata!(spec, pretty: true, escape: :javascript_safe)
-    File.write!(path, string)
-    path
+    :ok = File.write!(path, string)
+    {spec, path}
   end
 
-  def extract_url(output) do
-    output
-    |> String.split(~r|[\r\n]+|)
-    |> List.first()
-    |> String.trim()
-    |> String.split(~r|\s+|)
-    |> List.last()
-    |> String.trim()
+  def get_url(%{target_summary: summary} = _spec) do
+    # don't use the connection pool
+    {:ok, conn} = K8s.Conn.from_file("~/.kube/config", insecure_skip_tls_verify: true)
+
+    {api_version, kind} = ApiVersionKind.from_resource_type!(:config_map)
+    core_namespace = Namespaces.core_namespace(summary)
+    op = K8s.Client.get(api_version, kind, name: "access-info", namespace: core_namespace)
+
+    {:ok, %{"data" => %{"hostname" => hostname, "ssl" => ssl}}} = K8s.Client.run(conn, op)
+
+    "#{if ssl == "true", do: "https", else: "http"}://#{hostname}"
   end
 
   def start(path) do


### PR DESCRIPTION
I think I've got integration tests working here in Actions so I'm breaking the change into smaller pieces.

This fixes (everything?) that #1869 did w/o adding the local bi binary to the cache.

Tangentially, it also changes the URL fetching from parsing it out of the output to getting it from the access-info configmap.