### PR TITLE
chore(int-test): make the int test clusters smaller

### DIFF
--- a/bootstrap/dev.install.json
+++ b/bootstrap/dev.install.json
@@ -1,14 +1,14 @@
 {
-  "id": "batt_0195d3ae6ce57cbdbcae5c8033024f12",
+  "id": "batt_0196406ab7ee7059a815346ea98562d1",
   "usage": "internal_dev",
-  "team_id": "batt_0195d3ae6ce270cf8308b06625a34f35",
+  "team_id": "batt_0196406ab7eb7682b68e735cc3707b82",
   "default_size": "tiny",
   "control_jwk": {
     "crv": "P-256",
-    "d": "ccReu3Ua9BQot8abjMnRiARGbPB4CCmtJhGW2ivUmhs",
+    "d": "ECH9DmcwKxPUipWfBuYZGoOdQydkvOgjXH71PnTCBh0",
     "kty": "EC",
-    "x": "MLRLZ9blbOBP3KdtfVI4yUnlEOS1s_TOuA8lrOyn3KA",
-    "y": "Zat0BXORgjyVvutkVpqOA9aGyQaqyjBzmE_LWAOFhoo"
+    "x": "HqhptYrWhpg7DRThZGAlb3ure-cYYYyOFiikZ5mqjEM",
+    "y": "5I8yrnlNjdt2dpj-TI4CHN5FtgMWmI84KJunLuGsQgM"
   },
   "inserted_at": null,
   "updated_at": null,

--- a/bootstrap/dev.spec.json
+++ b/bootstrap/dev.spec.json
@@ -9,7 +9,7 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_0195d3ae6cfd7cabac2e52776e9a1e52",
+        "id": "batt_0196406ab80c7ddb9c1c9f2f7dab32b8",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -24,7 +24,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195d3ae6cfd7cc3b53375e6fe5acaa4",
+        "id": "batt_0196406ab80c76a888dc410259403189",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -37,7 +37,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195d3ae6cfd7a589fbdff7bc95b7d4c",
+        "id": "batt_0196406ab80c7fa4b422b51df67ff2d2",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -49,13 +49,13 @@
           "ai_namespace": "battery-ai",
           "default_size": "tiny",
           "cluster_name": "dev",
-          "install_id": "batt_0195d3ae6ce57cbdbcae5c8033024f12",
+          "install_id": "batt_0196406ab7ee7059a815346ea98562d1",
           "control_jwk": {
             "crv": "P-256",
-            "d": "ccReu3Ua9BQot8abjMnRiARGbPB4CCmtJhGW2ivUmhs",
+            "d": "ECH9DmcwKxPUipWfBuYZGoOdQydkvOgjXH71PnTCBh0",
             "kty": "EC",
-            "x": "MLRLZ9blbOBP3KdtfVI4yUnlEOS1s_TOuA8lrOyn3KA",
-            "y": "Zat0BXORgjyVvutkVpqOA9aGyQaqyjBzmE_LWAOFhoo"
+            "x": "HqhptYrWhpg7DRThZGAlb3ure-cYYYyOFiikZ5mqjEM",
+            "y": "5I8yrnlNjdt2dpj-TI4CHN5FtgMWmI84KJunLuGsQgM"
           },
           "upgrade_days_of_week": [
             true,
@@ -80,7 +80,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195d3ae6cfd7861b61f199c8ec0516c",
+        "id": "batt_0196406ab80c79e2818816cb2ef67e7e",
         "type": "metallb",
         "config": {
           "type": "metallb",
@@ -100,7 +100,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195d3ae6cfe7517b783a82de4b0077b",
+        "id": "batt_0196406ab80c73a0ac8d3358b09d74ff",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
@@ -116,7 +116,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195d3ae6cfe79829f1e382d066db396",
+        "id": "batt_0196406ab80c7d3bbe188989afcd4e55",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -172,7 +172,7 @@
           {
             "version": 2,
             "username": "battery-control-user",
-            "password": "G746YT7VOEOMTHD5QVXIWSZ4"
+            "password": "AOR6NH3QJ2PJU4DUKXC7TIKK"
           },
           {
             "version": 1,
@@ -205,7 +205,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "T4WEVFDSRPGF6IJEAEUR7ADMY62YWXSZEUDGLYAS27ZQBQGPLPYQ===="
+          "battery/hash": "WDHBMRV4OH5MTLZTHBRX7LYJTCSELBTZSHBH7BCPXJTT74YFIYCA===="
         },
         "labels": {
           "app": "battery-core",
@@ -215,7 +215,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195d3ae6cfd7a589fbdff7bc95b7d4c",
+          "battery/owner": "batt_0196406ab80c7fa4b422b51df67ff2d2",
           "istio-injection": "enabled",
           "version": "latest"
         },

--- a/bootstrap/int-prod.install.json
+++ b/bootstrap/int-prod.install.json
@@ -1,14 +1,14 @@
 {
-  "id": "batt_0195d3ae6cf77f0f969106cf15245d25",
+  "id": "batt_0196406ab805737dacd0b678e61de8fa",
   "usage": "internal_prod",
-  "team_id": "batt_0195d3ae6ce270cf8308b06625a34f35",
+  "team_id": "batt_0196406ab7eb7682b68e735cc3707b82",
   "default_size": "medium",
   "control_jwk": {
     "crv": "P-256",
-    "d": "aeD1fCe-cGjDlGCvKvsS1WVobdUqfoTiR4dmNaxkuvw",
+    "d": "67p5FzhBqEZnrWIlGFqrEsrYGzWgkDrETpZ855HEk7Y",
     "kty": "EC",
-    "x": "Nl5EAKWtSJ8zKCvXe1vWFfU3G1dguIDla7MNJSTO7To",
-    "y": "XnX_npSxNgSOevNJ9HiOnkqShOcmg-AFwDkyfrdK40U"
+    "x": "EU0bsmKcusz8NzAr07d1XVq9JF5G18-wkEZiGIlWc0c",
+    "y": "iPJnZeqjAjMx0m2tzkJzXnN3tULJrdbem5zEyzOveIA"
   },
   "inserted_at": null,
   "updated_at": null,

--- a/bootstrap/int-prod.spec.json
+++ b/bootstrap/int-prod.spec.json
@@ -9,7 +9,7 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_0195d3ae6d0277c39ef280bfea5db833",
+        "id": "batt_0196406ab81077bab8c1cad8fd4443b9",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -21,13 +21,13 @@
           "ai_namespace": "battery-ai",
           "default_size": "medium",
           "cluster_name": "int-prod",
-          "install_id": "batt_0195d3ae6cf77f0f969106cf15245d25",
+          "install_id": "batt_0196406ab805737dacd0b678e61de8fa",
           "control_jwk": {
             "crv": "P-256",
-            "d": "aeD1fCe-cGjDlGCvKvsS1WVobdUqfoTiR4dmNaxkuvw",
+            "d": "67p5FzhBqEZnrWIlGFqrEsrYGzWgkDrETpZ855HEk7Y",
             "kty": "EC",
-            "x": "Nl5EAKWtSJ8zKCvXe1vWFfU3G1dguIDla7MNJSTO7To",
-            "y": "XnX_npSxNgSOevNJ9HiOnkqShOcmg-AFwDkyfrdK40U"
+            "x": "EU0bsmKcusz8NzAr07d1XVq9JF5G18-wkEZiGIlWc0c",
+            "y": "iPJnZeqjAjMx0m2tzkJzXnN3tULJrdbem5zEyzOveIA"
           },
           "upgrade_days_of_week": [
             true,
@@ -52,7 +52,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195d3ae6d027644bbe9aa5026941225",
+        "id": "batt_0196406ab8107154a6f0556243ddba78",
         "type": "cert_manager",
         "config": {
           "type": "cert_manager",
@@ -78,7 +78,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195d3ae6d02746ba65de82c4b6df474",
+        "id": "batt_0196406ab8107119a1c0df8c4aaf48f5",
         "type": "battery_ca",
         "config": {
           "type": "battery_ca"
@@ -88,7 +88,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195d3ae6d0275ecb2874eed7d7c1e73",
+        "id": "batt_0196406ab8107ccca098b8a962c60365",
         "type": "karpenter",
         "config": {
           "type": "karpenter",
@@ -108,7 +108,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195d3ae6d0271ecb514d5b309be3d5a",
+        "id": "batt_0196406ab8107c7dbd8ae320ab282efe",
         "type": "aws_load_balancer_controller",
         "config": {
           "type": "aws_load_balancer_controller",
@@ -124,7 +124,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195d3ae6d0277b380720db749be30c1",
+        "id": "batt_0196406ab81078f58a2fd7c184b9dee8",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
@@ -140,7 +140,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195d3ae6d02792da92bf0d884ad9f80",
+        "id": "batt_0196406ab81074a2898b785309677dec",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -155,7 +155,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195d3ae6d02751db4b812078ebf453b",
+        "id": "batt_0196406ab8107093a0fb4e1c26e23372",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -168,7 +168,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195d3ae6d0277b1b37d802c693201bc",
+        "id": "batt_0196406ab8107fc59ded5f3bcf313d6a",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -180,7 +180,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195d3ae6d02789a8429b340dedc278d",
+        "id": "batt_0196406ab81077679799e9525cc8f026",
         "type": "ferretdb",
         "config": {
           "type": "ferretdb",
@@ -193,7 +193,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195d3ae6d027674986dadb1e8414707",
+        "id": "batt_0196406ab8107f93804cfa6883869d87",
         "type": "traditional_services",
         "config": {
           "type": "traditional_services",
@@ -204,7 +204,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195d3ae6d0273b0b0d0f214ca7dee68",
+        "id": "batt_0196406ab810799292912da18bc49d49",
         "type": "vm_agent",
         "config": {
           "type": "vm_agent",
@@ -216,11 +216,11 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195d3ae6d02798b87c96d6cb38310a5",
+        "id": "batt_0196406ab810752da719ebc70850c7ce",
         "type": "victoria_metrics",
         "config": {
           "type": "victoria_metrics",
-          "cookie_secret": "RWNJdJDC_XWO2Q-uiZdc-6cdQ_z1AS5D5Wgigw62nqQ=",
+          "cookie_secret": "906YKkuzrzD1GFZkKn2dM7DPhes2JVCK380GCsjUSZc=",
           "replication_factor": 1,
           "operator_image": "victoriametrics/operator:v0.44.0",
           "vmselect_volume_size": 536870912,
@@ -241,7 +241,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195d3ae6d027ece8dae8d3a0a4527b0",
+        "id": "batt_0196406ab810782784dba32ef6c90b9e",
         "type": "grafana",
         "config": {
           "type": "grafana",
@@ -274,7 +274,7 @@
         "env_values": [
           {
             "name": "BATTERY_TEAM_IDS",
-            "value": "batt_0195d3ae6ce270cf8308b06625a34f35",
+            "value": "batt_0196406ab7eb7682b68e735cc3707b82",
             "source_name": null,
             "source_type": "value",
             "source_key": null,
@@ -282,7 +282,7 @@
           },
           {
             "name": "SECRET_KEY_BASE",
-            "value": "QK6P3JWWUZRMFC76BXVD6CAAUWFS56OH6F7ZSSBF7FUGZXRG5GZJLQQ5Q7DO7MAT",
+            "value": "DPDVISW676RAV4OOEXXLARBSZCVULKXB36NRIHVU4JNZ7HNYJJCATUCONYKHWHBR",
             "source_name": null,
             "source_type": "value",
             "source_key": null,
@@ -580,7 +580,7 @@
           {
             "version": 1,
             "username": "battery-control-user",
-            "password": "IZXLKS4UNZWPABATVRM4LSKW"
+            "password": "3533XHZJGNXVXZWYGJXROFS2"
           }
         ],
         "cpu_requested": 4000,
@@ -626,7 +626,7 @@
           {
             "version": 1,
             "username": "home-base",
-            "password": "OLH7FZ4NQ6OXNVP7UKR46HB5"
+            "password": "UZ2U2U7EQWRU7UR3GFN2SVY5"
           }
         ],
         "cpu_requested": 4000,
@@ -672,7 +672,7 @@
           {
             "version": 1,
             "username": "cla",
-            "password": "UZV55PXDPHWPGHGQZALZZIPR"
+            "password": "P6XB7NAC6NYAKWK5HAPRVZIM"
           }
         ],
         "cpu_requested": 4000,
@@ -702,7 +702,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "RXUQJV5K7G6ZDEESIANMY3SIXLWDJNF4UB6HVFDPA7E4XDHXT7AA===="
+          "battery/hash": "IUWOYLVBEWCJSQ7DAOWVKNBXYY42YJ52Q5LTZUBOCIPPYQFRELGQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -712,7 +712,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195d3ae6d0277c39ef280bfea5db833",
+          "battery/owner": "batt_0196406ab81077bab8c1cad8fd4443b9",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -733,17 +733,17 @@
     "/config_map/home_base_seed_data": {
       "apiVersion": "v1",
       "data": {
-        "batt_0195d3ae6ce270cf8308b06625a34f35.team.json": "{\"id\":\"batt_0195d3ae6ce270cf8308b06625a34f35\",\"name\":\"Batteries Included Team\",\"inserted_at\":null,\"updated_at\":null,\"op_email\":\"elliott@batteriesincl.com\",\"deleted_at\":null}",
-        "dev.install.json": "{\"id\":\"batt_0195d3ae6ce57cbdbcae5c8033024f12\",\"usage\":\"internal_dev\",\"team_id\":\"batt_0195d3ae6ce270cf8308b06625a34f35\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"ccReu3Ua9BQot8abjMnRiARGbPB4CCmtJhGW2ivUmhs\",\"kty\":\"EC\",\"x\":\"MLRLZ9blbOBP3KdtfVI4yUnlEOS1s_TOuA8lrOyn3KA\",\"y\":\"Zat0BXORgjyVvutkVpqOA9aGyQaqyjBzmE_LWAOFhoo\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"dev\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
-        "int-prod.install.json": "{\"id\":\"batt_0195d3ae6cf77f0f969106cf15245d25\",\"usage\":\"internal_prod\",\"team_id\":\"batt_0195d3ae6ce270cf8308b06625a34f35\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"aeD1fCe-cGjDlGCvKvsS1WVobdUqfoTiR4dmNaxkuvw\",\"kty\":\"EC\",\"x\":\"Nl5EAKWtSJ8zKCvXe1vWFfU3G1dguIDla7MNJSTO7To\",\"y\":\"XnX_npSxNgSOevNJ9HiOnkqShOcmg-AFwDkyfrdK40U\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"aws\",\"slug\":\"int-prod\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
-        "int-test.install.json": "{\"id\":\"batt_0195d3ae6cf6733fbd4e633d6c427b49\",\"usage\":\"internal_int_test\",\"team_id\":\"batt_0195d3ae6ce270cf8308b06625a34f35\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"8WhzGqHNcYfW7-IQaSeHilDWtDTO7U7JYMLm4hN-thE\",\"kty\":\"EC\",\"x\":\"yOUJlDrxKmi-H4fFvrXoN7dczxI8o9MJTiBiO3xLlDo\",\"y\":\"8EOXF4kdSEHwqg6uPoCv74crmXgLKBKut12_SfvGkYU\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"int-test\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
-        "jason.install.json": "{\"id\":\"batt_0195d3ae6cf77690b49aa938bfdbbbd3\",\"usage\":\"development\",\"team_id\":\"batt_0195d3ae6ce270cf8308b06625a34f35\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"oMMKzeMq-AIb8V0TdFyou3fzVg0w4LOYyfwda4tsviY\",\"kty\":\"EC\",\"x\":\"FmIOr0z5tJHS8L159rCZPoQlzlwhPPuK5PSjMoMPo08\",\"y\":\"_1VpltITak6qdEXhzK-9gPiXv0_GZijIqxhwqGWhG7E\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"aws\",\"slug\":\"jason\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
-        "local.install.json": "{\"id\":\"batt_0195d3ae6cf775fe884b966088235f67\",\"usage\":\"development\",\"team_id\":\"batt_0195d3ae6ce270cf8308b06625a34f35\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"jod8jYzG3V4nvkHdOQsg4dLsKJ4sh5rYcc5a8Th0EZk\",\"kty\":\"EC\",\"x\":\"sFB3yIhMQo3eikRFVjRAahniOioPVZcZ27efWg1xTP8\",\"y\":\"3USC1T5VUD8ljtAqHo-StapxACTAw1dEcoXMtxxsT7I\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"local\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}"
+        "batt_0196406ab7eb7682b68e735cc3707b82.team.json": "{\"id\":\"batt_0196406ab7eb7682b68e735cc3707b82\",\"name\":\"Batteries Included Team\",\"inserted_at\":null,\"updated_at\":null,\"op_email\":\"elliott@batteriesincl.com\",\"deleted_at\":null}",
+        "dev.install.json": "{\"id\":\"batt_0196406ab7ee7059a815346ea98562d1\",\"usage\":\"internal_dev\",\"team_id\":\"batt_0196406ab7eb7682b68e735cc3707b82\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"ECH9DmcwKxPUipWfBuYZGoOdQydkvOgjXH71PnTCBh0\",\"kty\":\"EC\",\"x\":\"HqhptYrWhpg7DRThZGAlb3ure-cYYYyOFiikZ5mqjEM\",\"y\":\"5I8yrnlNjdt2dpj-TI4CHN5FtgMWmI84KJunLuGsQgM\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"dev\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
+        "int-prod.install.json": "{\"id\":\"batt_0196406ab805737dacd0b678e61de8fa\",\"usage\":\"internal_prod\",\"team_id\":\"batt_0196406ab7eb7682b68e735cc3707b82\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"67p5FzhBqEZnrWIlGFqrEsrYGzWgkDrETpZ855HEk7Y\",\"kty\":\"EC\",\"x\":\"EU0bsmKcusz8NzAr07d1XVq9JF5G18-wkEZiGIlWc0c\",\"y\":\"iPJnZeqjAjMx0m2tzkJzXnN3tULJrdbem5zEyzOveIA\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"aws\",\"slug\":\"int-prod\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
+        "int-test.install.json": "{\"id\":\"batt_0196406ab80573d7852f50a5835e7bb5\",\"usage\":\"internal_int_test\",\"team_id\":\"batt_0196406ab7eb7682b68e735cc3707b82\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"_WAcrL1679TiSQPNFa2in6vKTqAMds9-pn3V5YwG-JM\",\"kty\":\"EC\",\"x\":\"lljVCyINAGuVf_8fAiNKr__TylTZArlcPA2UJ8svq9Y\",\"y\":\"5Efg4a3xT_JkoOVVz1r6f6jYLC5sFwfPSAxBFPFXRBI\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"int-test\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
+        "jason.install.json": "{\"id\":\"batt_0196406ab8057cb39880c167eb3fc0d1\",\"usage\":\"development\",\"team_id\":\"batt_0196406ab7eb7682b68e735cc3707b82\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"8XJOJR7iUY3Pbd-b18wkmEaidk3hBKhl60xuOGfdtpA\",\"kty\":\"EC\",\"x\":\"1pvjUnU7IUCP6v1enrxp95W13Aw82HY8tS5nmrvrM8k\",\"y\":\"20OiWzhoujh9VVsi7L14Ic2es1tKGPh7PSyRPmjb4S8\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"aws\",\"slug\":\"jason\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
+        "local.install.json": "{\"id\":\"batt_0196406ab805751c92058812dad23f5b\",\"usage\":\"development\",\"team_id\":\"batt_0196406ab7eb7682b68e735cc3707b82\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"xSRcAcEJJ5LXVPFYyNLvja6kVfT4aqe8l3Hkb16h0P4\",\"kty\":\"EC\",\"x\":\"yVUDGgv7CjtJ6i16lq-HOwAQtzQ6OktXVR4rfR-D7HM\",\"y\":\"eqAw3XD4KT3v5WkjrsZc0HpSYaKLwqdMnvrQfP5FCD8\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"local\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}"
       },
       "kind": "ConfigMap",
       "metadata": {
         "annotations": {
-          "battery/hash": "RANNUTW72KQV7LPIZNJERXD7WMWL36SLOOFJLOSKOMWCDUY7ENAA===="
+          "battery/hash": "BUNFGX3BZ2RJXR4CAMKK3L5LYCKBU2DVQMYATDSRYL2HYKONGRPA===="
         },
         "labels": {
           "app": "traditional-services",
@@ -754,7 +754,7 @@
           "battery/delete-after": "PT45M",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195d3ae6d027674986dadb1e8414707",
+          "battery/owner": "batt_0196406ab8107f93804cfa6883869d87",
           "version": "latest"
         },
         "name": "home-base-seed-data",
@@ -766,7 +766,7 @@
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "HOF3BJSSZ6R2W3KPD4TQUTCRRYSGLFAVHN5CUBUW7KX4YZEGH5OQ===="
+          "battery/hash": "U2PPOWQYLW6EOMR7E3R5KK323KL5WRJOPLHVS2SB55F4EJQSXJDQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -776,7 +776,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195d3ae6d0277c39ef280bfea5db833",
+          "battery/owner": "batt_0196406ab81077bab8c1cad8fd4443b9",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -800,7 +800,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_0195d3ae6d0277c39ef280bfea5db833",
+              "battery/owner": "batt_0196406ab81077bab8c1cad8fd4443b9",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -813,7 +813,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "HBFOK4VJWDOIZUX62FHGT6KF6P43Q56LVPB6XUBFLWMKDGGUVQ2GS3N4KW4IOTAZ"
+                    "value": "KDKNEJBKHBK7WLZJYETOFY6HXHO4DS6MP6PVITU4SKXO5R52TUCWIUMDEUCU7NPL"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -861,7 +861,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "O6RN3Q76KGOJVH33NF2X75GUYD6AK2D4NBLRJU76BHWFEXQBDJAA===="
+          "battery/hash": "AAEUDGW22NCVEGTGANBP2OAEIPNAIOQ3UXAOENRRQZOSRHZTKEOQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -871,7 +871,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195d3ae6d0277c39ef280bfea5db833",
+          "battery/owner": "batt_0196406ab81077bab8c1cad8fd4443b9",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -883,7 +883,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "DWVEGD22JBCIQS7ADIP47JHSGA66PYEP3GIYFLZRFUUWQKVC5WWQ===="
+          "battery/hash": "3QWMIJJ23FANU4H4F73K6URVYYOISVBUVE3A2JAGZVFDUMQIKQLA===="
         },
         "labels": {
           "app": "traditional-services",
@@ -893,7 +893,7 @@
           "battery/app": "traditional-services",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195d3ae6d027674986dadb1e8414707",
+          "battery/owner": "batt_0196406ab8107f93804cfa6883869d87",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -905,7 +905,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "CVPDD5LBUPG63DJEBHEKJ3ZYQZDV7X4K3ZGKZSQ7XRSFNRS2DIQA===="
+          "battery/hash": "QBROT742VCHI5ESQF3SNK52ETXQUFXYDLE7MLULLQ5MOWMGCPO5Q===="
         },
         "labels": {
           "app": "battery-core",
@@ -915,7 +915,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195d3ae6d0277c39ef280bfea5db833",
+          "battery/owner": "batt_0196406ab81077bab8c1cad8fd4443b9",
           "version": "latest"
         },
         "name": "bootstrap",
@@ -928,7 +928,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "AW76B6P3L6K2IKZZWS2A2TZEHGDYGDQJUZM25RTHKDQDEAACM3PQ====",
+          "battery/hash": "64VGFPNYJSJFEGD2CQTNMRU5V4FUJB2W5GNBM5GJOXFJMFZSYU5A====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -939,7 +939,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195d3ae6d0277c39ef280bfea5db833",
+          "battery/owner": "batt_0196406ab81077bab8c1cad8fd4443b9",
           "version": "latest"
         },
         "name": "gp2"
@@ -954,7 +954,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "I4QV7DPQKCVUWQQNUMZDMFVORPLQAW3UQCFKEHNTZYY67V2PO67A====",
+          "battery/hash": "R3SOIHRI5KZDYXZQKS7TNEN547CPUX5CEW4P74Y2SHZODGXL4O3A====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -965,7 +965,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195d3ae6d0277c39ef280bfea5db833",
+          "battery/owner": "batt_0196406ab81077bab8c1cad8fd4443b9",
           "version": "latest"
         },
         "name": "gp2-90032408"
@@ -985,7 +985,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "TEPYXOJHC6Z3GNZCYYYOSQ7FRKMVTHBXOMBI4GXKXVS2ZZ5W3DIA====",
+          "battery/hash": "GMGUJEM5CTU5DN763J3ROVC6SIJOKM2IG5L6F6VDZBFFVUYSHN2Q====",
           "storageclass.kubernetes.io/is-default-class": "true"
         },
         "labels": {
@@ -996,7 +996,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195d3ae6d0277c39ef280bfea5db833",
+          "battery/owner": "batt_0196406ab81077bab8c1cad8fd4443b9",
           "version": "latest"
         },
         "name": "gp3-105457460"

--- a/bootstrap/int-test.install.json
+++ b/bootstrap/int-test.install.json
@@ -1,14 +1,14 @@
 {
-  "id": "batt_0195d3ae6cf6733fbd4e633d6c427b49",
+  "id": "batt_0196406ab80573d7852f50a5835e7bb5",
   "usage": "internal_int_test",
-  "team_id": "batt_0195d3ae6ce270cf8308b06625a34f35",
-  "default_size": "medium",
+  "team_id": "batt_0196406ab7eb7682b68e735cc3707b82",
+  "default_size": "tiny",
   "control_jwk": {
     "crv": "P-256",
-    "d": "8WhzGqHNcYfW7-IQaSeHilDWtDTO7U7JYMLm4hN-thE",
+    "d": "_WAcrL1679TiSQPNFa2in6vKTqAMds9-pn3V5YwG-JM",
     "kty": "EC",
-    "x": "yOUJlDrxKmi-H4fFvrXoN7dczxI8o9MJTiBiO3xLlDo",
-    "y": "8EOXF4kdSEHwqg6uPoCv74crmXgLKBKut12_SfvGkYU"
+    "x": "lljVCyINAGuVf_8fAiNKr__TylTZArlcPA2UJ8svq9Y",
+    "y": "5Efg4a3xT_JkoOVVz1r6f6jYLC5sFwfPSAxBFPFXRBI"
   },
   "inserted_at": null,
   "updated_at": null,

--- a/bootstrap/int-test.spec.json
+++ b/bootstrap/int-test.spec.json
@@ -9,7 +9,7 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_0195d3ae6d0074ed93dbd92672c2c117",
+        "id": "batt_0196406ab80f7c589fe42eb0bf7c02ba",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -19,15 +19,15 @@
           "base_namespace": "battery-base",
           "data_namespace": "battery-data",
           "ai_namespace": "battery-ai",
-          "default_size": "medium",
+          "default_size": "tiny",
           "cluster_name": "int-test",
-          "install_id": "batt_0195d3ae6cf6733fbd4e633d6c427b49",
+          "install_id": "batt_0196406ab80573d7852f50a5835e7bb5",
           "control_jwk": {
             "crv": "P-256",
-            "d": "8WhzGqHNcYfW7-IQaSeHilDWtDTO7U7JYMLm4hN-thE",
+            "d": "_WAcrL1679TiSQPNFa2in6vKTqAMds9-pn3V5YwG-JM",
             "kty": "EC",
-            "x": "yOUJlDrxKmi-H4fFvrXoN7dczxI8o9MJTiBiO3xLlDo",
-            "y": "8EOXF4kdSEHwqg6uPoCv74crmXgLKBKut12_SfvGkYU"
+            "x": "lljVCyINAGuVf_8fAiNKr__TylTZArlcPA2UJ8svq9Y",
+            "y": "5Efg4a3xT_JkoOVVz1r6f6jYLC5sFwfPSAxBFPFXRBI"
           },
           "upgrade_days_of_week": [
             true,
@@ -52,7 +52,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195d3ae6d0079babba73a00708f2a97",
+        "id": "batt_0196406ab80f75dcbb0eab6a30910013",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
@@ -68,7 +68,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195d3ae6d0076dcb53cbfe5531e0e5d",
+        "id": "batt_0196406ab80f7b5e89c908d966a26821",
         "type": "ferretdb",
         "config": {
           "type": "ferretdb",
@@ -81,7 +81,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195d3ae6d007d47939fd9e20590dfe3",
+        "id": "batt_0196406ab80f72748fdb8b6597d0dc90",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -96,7 +96,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195d3ae6d007487bdccbc5d5aed12aa",
+        "id": "batt_0196406ab80f7adeb7518edb601a4081",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -109,7 +109,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195d3ae6d007fe9be62712d262e5c21",
+        "id": "batt_0196406ab80f7ee2b113d16df044544a",
         "type": "metallb",
         "config": {
           "type": "metallb",
@@ -129,7 +129,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195d3ae6d0078849b5308576aba6770",
+        "id": "batt_0196406ab80f799d8cb93f39b91dd6c7",
         "type": "traditional_services",
         "config": {
           "type": "traditional_services",
@@ -140,297 +140,7 @@
         "updated_at": null
       }
     ],
-    "traditional_services": [
-      {
-        "id": null,
-        "name": "home-base",
-        "ports": [
-          {
-            "name": "home-base",
-            "protocol": "http2",
-            "number": 4000
-          }
-        ],
-        "inserted_at": null,
-        "updated_at": null,
-        "virtual_size": "small",
-        "env_values": [
-          {
-            "name": "BATTERY_TEAM_IDS",
-            "value": "batt_0195d3ae6ce270cf8308b06625a34f35",
-            "source_name": null,
-            "source_type": "value",
-            "source_key": null,
-            "source_optional": false
-          },
-          {
-            "name": "SECRET_KEY_BASE",
-            "value": "PPMMIYSWWAIZGAHG35XSD4R253HGJ2BLKRQ33NHKEHYW2HKJJMYJWB5TKSFKUVY3",
-            "source_name": null,
-            "source_type": "value",
-            "source_key": null,
-            "source_optional": false
-          },
-          {
-            "name": "HOME_JWK",
-            "value": null,
-            "source_name": "home-base-jwk",
-            "source_type": "secret",
-            "source_key": "jwk",
-            "source_optional": false
-          },
-          {
-            "name": "POSTGRES_DB",
-            "value": "home-base",
-            "source_name": null,
-            "source_type": "value",
-            "source_key": null,
-            "source_optional": false
-          },
-          {
-            "name": "POSTGRES_USER",
-            "value": null,
-            "source_name": "cloudnative-pg.pg-home-base.home-base",
-            "source_type": "secret",
-            "source_key": "username",
-            "source_optional": false
-          },
-          {
-            "name": "POSTGRES_PASSWORD",
-            "value": null,
-            "source_name": "cloudnative-pg.pg-home-base.home-base",
-            "source_type": "secret",
-            "source_key": "password",
-            "source_optional": false
-          },
-          {
-            "name": "POSTGRES_HOST",
-            "value": null,
-            "source_name": "cloudnative-pg.pg-home-base.home-base",
-            "source_type": "secret",
-            "source_key": "hostname",
-            "source_optional": false
-          }
-        ],
-        "num_instances": 1,
-        "cpu_requested": 500,
-        "cpu_limits": 2000,
-        "memory_requested": 1073741824,
-        "memory_limits": 4294967296,
-        "project_id": null,
-        "additional_hosts": [
-          "home.batteriesincl.com"
-        ],
-        "init_containers": [
-          {
-            "args": [
-              "home_base_init"
-            ],
-            "command": [
-              "/app/bin/start"
-            ],
-            "name": "init",
-            "path": "/app/bin/start",
-            "image": "ghcr.io/batteries-included/home-base:latest",
-            "env_values": [],
-            "mounts": [
-              {
-                "read_only": true,
-                "volume_name": "home-base-seed-data",
-                "mount_path": "/etc/init-config/"
-              }
-            ]
-          }
-        ],
-        "containers": [
-          {
-            "args": null,
-            "command": null,
-            "name": "home-base",
-            "path": null,
-            "image": "ghcr.io/batteries-included/home-base:latest",
-            "env_values": [],
-            "mounts": []
-          }
-        ],
-        "volumes": [
-          {
-            "name": "home-base-seed-data",
-            "type": "config_map",
-            "config": {
-              "name": "home-base-seed-data",
-              "type": "config_map",
-              "optional": true,
-              "default_mode": null
-            }
-          },
-          {
-            "name": "home-base-jwk",
-            "type": "secret",
-            "config": {
-              "name": "home-base-jwk",
-              "type": "secret",
-              "optional": false,
-              "default_mode": null
-            }
-          }
-        ],
-        "kube_internal": false,
-        "kube_deployment_type": "deployment"
-      },
-      {
-        "id": null,
-        "name": "cla",
-        "ports": [
-          {
-            "name": "cla",
-            "protocol": "http2",
-            "number": 5000
-          }
-        ],
-        "inserted_at": null,
-        "updated_at": null,
-        "virtual_size": "small",
-        "env_values": [
-          {
-            "name": "PROTOCOL",
-            "value": "https",
-            "source_name": null,
-            "source_type": "value",
-            "source_key": null,
-            "source_optional": false
-          },
-          {
-            "name": "HOST",
-            "value": "cla.batteriesincl.com",
-            "source_name": null,
-            "source_type": "value",
-            "source_key": null,
-            "source_optional": false
-          },
-          {
-            "name": "NODE_ENV",
-            "value": "prod",
-            "source_name": null,
-            "source_type": "value",
-            "source_key": null,
-            "source_optional": false
-          },
-          {
-            "name": "MONGODB",
-            "value": null,
-            "source_name": "ferret.cla.cla",
-            "source_type": "secret",
-            "source_key": "uri",
-            "source_optional": false
-          },
-          {
-            "name": "GITHUB_TOKEN",
-            "value": null,
-            "source_name": "cla",
-            "source_type": "secret",
-            "source_key": "GITHUB_TOKEN",
-            "source_optional": false
-          },
-          {
-            "name": "GITHUB_SECRET",
-            "value": null,
-            "source_name": "cla",
-            "source_type": "secret",
-            "source_key": "GITHUB_SECRET",
-            "source_optional": false
-          },
-          {
-            "name": "GITHUB_CLIENT",
-            "value": null,
-            "source_name": "cla",
-            "source_type": "secret",
-            "source_key": "GITHUB_CLIENT",
-            "source_optional": false
-          },
-          {
-            "name": "GITHUB_APP_SECRET",
-            "value": null,
-            "source_name": "cla",
-            "source_type": "secret",
-            "source_key": "GITHUB_APP_SECRET",
-            "source_optional": false
-          },
-          {
-            "name": "GITHUB_APP_PRIVATE_KEY",
-            "value": null,
-            "source_name": "cla",
-            "source_type": "secret",
-            "source_key": "GITHUB_APP_PRIVATE_KEY",
-            "source_optional": false
-          },
-          {
-            "name": "GITHUB_APP_NAME",
-            "value": null,
-            "source_name": "cla",
-            "source_type": "secret",
-            "source_key": "GITHUB_APP_NAME",
-            "source_optional": false
-          },
-          {
-            "name": "GITHUB_APP_ID",
-            "value": null,
-            "source_name": "cla",
-            "source_type": "secret",
-            "source_key": "GITHUB_APP_ID",
-            "source_optional": false
-          },
-          {
-            "name": "GITHUB_APP_CLIENT",
-            "value": null,
-            "source_name": "cla",
-            "source_type": "secret",
-            "source_key": "GITHUB_APP_CLIENT",
-            "source_optional": false
-          },
-          {
-            "name": "GITHUB_APP_SECRET",
-            "value": null,
-            "source_name": "cla",
-            "source_type": "secret",
-            "source_key": "GITHUB_APP_SECRET",
-            "source_optional": false
-          },
-          {
-            "name": "GITHUB_ADMIN_USERS",
-            "value": null,
-            "source_name": "cla",
-            "source_type": "secret",
-            "source_key": "GITHUB_ADMIN_USERS",
-            "source_optional": false
-          }
-        ],
-        "num_instances": 1,
-        "cpu_requested": 500,
-        "cpu_limits": 2000,
-        "memory_requested": 1073741824,
-        "memory_limits": 4294967296,
-        "project_id": null,
-        "additional_hosts": [
-          "cla.batteriesincl.com"
-        ],
-        "init_containers": [],
-        "containers": [
-          {
-            "args": null,
-            "command": null,
-            "name": "cla",
-            "path": null,
-            "image": "ghcr.io/batteries-included/cla-assistant:v2.13.1",
-            "env_values": [],
-            "mounts": []
-          }
-        ],
-        "volumes": [],
-        "kube_internal": false,
-        "kube_deployment_type": "deployment"
-      }
-    ],
+    "traditional_services": [],
     "model_instances": [],
     "postgres_clusters": [
       {
@@ -468,13 +178,13 @@
         "storage_class": null,
         "inserted_at": null,
         "updated_at": null,
-        "virtual_size": "medium",
+        "virtual_size": "tiny",
         "num_instances": 1,
         "password_versions": [
           {
             "version": 2,
             "username": "battery-control-user",
-            "password": "PMM7SJM4JS256QGUY5IS7PNX"
+            "password": "DMKK66LR353CSMNGF4OOK477"
           },
           {
             "version": 1,
@@ -482,107 +192,15 @@
             "password": "not-real"
           }
         ],
-        "cpu_requested": 4000,
-        "cpu_limits": 4000,
-        "memory_requested": 8589934592,
-        "memory_limits": 8589934592,
+        "cpu_requested": 500,
+        "cpu_limits": 500,
+        "memory_requested": 536870912,
+        "memory_limits": 536870912,
         "project_id": null,
         "backup_config": null,
-        "storage_size": 68719476736,
+        "storage_size": 536870912,
         "restore_from_backup": null,
-        "virtual_storage_size_range_value": 470590976688
-      },
-      {
-        "id": null,
-        "name": "home-base",
-        "type": "standard",
-        "database": {
-          "name": "home-base",
-          "owner": "home-base"
-        },
-        "users": [
-          {
-            "position": null,
-            "username": "home-base",
-            "roles": [
-              "superuser",
-              "createdb",
-              "login"
-            ],
-            "credential_namespaces": [
-              "battery-traditional"
-            ]
-          }
-        ],
-        "storage_class": null,
-        "inserted_at": null,
-        "updated_at": null,
-        "virtual_size": "medium",
-        "num_instances": 1,
-        "password_versions": [
-          {
-            "version": 1,
-            "username": "home-base",
-            "password": "7ZQCVYOGLSKFKEB73K5EZTY4"
-          }
-        ],
-        "cpu_requested": 4000,
-        "cpu_limits": 4000,
-        "memory_requested": 8589934592,
-        "memory_limits": 8589934592,
-        "project_id": null,
-        "backup_config": {
-          "type": "object_store"
-        },
-        "storage_size": 68719476736,
-        "restore_from_backup": null,
-        "virtual_storage_size_range_value": 470590976688
-      },
-      {
-        "id": null,
-        "name": "cla",
-        "type": "standard",
-        "database": {
-          "name": "cla",
-          "owner": "cla"
-        },
-        "users": [
-          {
-            "position": null,
-            "username": "cla",
-            "roles": [
-              "superuser",
-              "createdb",
-              "login"
-            ],
-            "credential_namespaces": [
-              "battery-traditional"
-            ]
-          }
-        ],
-        "storage_class": null,
-        "inserted_at": null,
-        "updated_at": null,
-        "virtual_size": "medium",
-        "num_instances": 1,
-        "password_versions": [
-          {
-            "version": 1,
-            "username": "cla",
-            "password": "VRWM74BDF2P7YF3D3OSGTRV4"
-          }
-        ],
-        "cpu_requested": 4000,
-        "cpu_limits": 4000,
-        "memory_requested": 8589934592,
-        "memory_limits": 8589934592,
-        "project_id": null,
-        "backup_config": {
-          "type": "object_store"
-        },
-        "storage_size": 68719476736,
-        "restore_from_backup": null,
-        "virtual_storage_size_range_value": 470590976688
+        "virtual_storage_size_range_value": 5035931120
       }
     ],
     "redis_instances": [],
@@ -599,7 +217,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "6YZJRCLAM6Y63MSO4O2RLEEY45JQ7NIQ5OHVBZIGLIU3OR5U2T5A===="
+          "battery/hash": "IHXGB7PUY6DXH6XVZIB7XWOIVJUJ6EZSSW4VWI377F3HUKJHPVYA===="
         },
         "labels": {
           "app": "battery-core",
@@ -609,7 +227,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195d3ae6d0074ed93dbd92672c2c117",
+          "battery/owner": "batt_0196406ab80f7c589fe42eb0bf7c02ba",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -630,17 +248,17 @@
     "/config_map/home_base_seed_data": {
       "apiVersion": "v1",
       "data": {
-        "batt_0195d3ae6ce270cf8308b06625a34f35.team.json": "{\"id\":\"batt_0195d3ae6ce270cf8308b06625a34f35\",\"name\":\"Batteries Included Team\",\"inserted_at\":null,\"updated_at\":null,\"op_email\":\"elliott@batteriesincl.com\",\"deleted_at\":null}",
-        "dev.install.json": "{\"id\":\"batt_0195d3ae6ce57cbdbcae5c8033024f12\",\"usage\":\"internal_dev\",\"team_id\":\"batt_0195d3ae6ce270cf8308b06625a34f35\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"ccReu3Ua9BQot8abjMnRiARGbPB4CCmtJhGW2ivUmhs\",\"kty\":\"EC\",\"x\":\"MLRLZ9blbOBP3KdtfVI4yUnlEOS1s_TOuA8lrOyn3KA\",\"y\":\"Zat0BXORgjyVvutkVpqOA9aGyQaqyjBzmE_LWAOFhoo\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"dev\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
-        "int-prod.install.json": "{\"id\":\"batt_0195d3ae6cf77f0f969106cf15245d25\",\"usage\":\"internal_prod\",\"team_id\":\"batt_0195d3ae6ce270cf8308b06625a34f35\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"aeD1fCe-cGjDlGCvKvsS1WVobdUqfoTiR4dmNaxkuvw\",\"kty\":\"EC\",\"x\":\"Nl5EAKWtSJ8zKCvXe1vWFfU3G1dguIDla7MNJSTO7To\",\"y\":\"XnX_npSxNgSOevNJ9HiOnkqShOcmg-AFwDkyfrdK40U\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"aws\",\"slug\":\"int-prod\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
-        "int-test.install.json": "{\"id\":\"batt_0195d3ae6cf6733fbd4e633d6c427b49\",\"usage\":\"internal_int_test\",\"team_id\":\"batt_0195d3ae6ce270cf8308b06625a34f35\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"8WhzGqHNcYfW7-IQaSeHilDWtDTO7U7JYMLm4hN-thE\",\"kty\":\"EC\",\"x\":\"yOUJlDrxKmi-H4fFvrXoN7dczxI8o9MJTiBiO3xLlDo\",\"y\":\"8EOXF4kdSEHwqg6uPoCv74crmXgLKBKut12_SfvGkYU\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"int-test\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
-        "jason.install.json": "{\"id\":\"batt_0195d3ae6cf77690b49aa938bfdbbbd3\",\"usage\":\"development\",\"team_id\":\"batt_0195d3ae6ce270cf8308b06625a34f35\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"oMMKzeMq-AIb8V0TdFyou3fzVg0w4LOYyfwda4tsviY\",\"kty\":\"EC\",\"x\":\"FmIOr0z5tJHS8L159rCZPoQlzlwhPPuK5PSjMoMPo08\",\"y\":\"_1VpltITak6qdEXhzK-9gPiXv0_GZijIqxhwqGWhG7E\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"aws\",\"slug\":\"jason\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
-        "local.install.json": "{\"id\":\"batt_0195d3ae6cf775fe884b966088235f67\",\"usage\":\"development\",\"team_id\":\"batt_0195d3ae6ce270cf8308b06625a34f35\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"jod8jYzG3V4nvkHdOQsg4dLsKJ4sh5rYcc5a8Th0EZk\",\"kty\":\"EC\",\"x\":\"sFB3yIhMQo3eikRFVjRAahniOioPVZcZ27efWg1xTP8\",\"y\":\"3USC1T5VUD8ljtAqHo-StapxACTAw1dEcoXMtxxsT7I\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"local\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}"
+        "batt_0196406ab7eb7682b68e735cc3707b82.team.json": "{\"id\":\"batt_0196406ab7eb7682b68e735cc3707b82\",\"name\":\"Batteries Included Team\",\"inserted_at\":null,\"updated_at\":null,\"op_email\":\"elliott@batteriesincl.com\",\"deleted_at\":null}",
+        "dev.install.json": "{\"id\":\"batt_0196406ab7ee7059a815346ea98562d1\",\"usage\":\"internal_dev\",\"team_id\":\"batt_0196406ab7eb7682b68e735cc3707b82\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"ECH9DmcwKxPUipWfBuYZGoOdQydkvOgjXH71PnTCBh0\",\"kty\":\"EC\",\"x\":\"HqhptYrWhpg7DRThZGAlb3ure-cYYYyOFiikZ5mqjEM\",\"y\":\"5I8yrnlNjdt2dpj-TI4CHN5FtgMWmI84KJunLuGsQgM\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"dev\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
+        "int-prod.install.json": "{\"id\":\"batt_0196406ab805737dacd0b678e61de8fa\",\"usage\":\"internal_prod\",\"team_id\":\"batt_0196406ab7eb7682b68e735cc3707b82\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"67p5FzhBqEZnrWIlGFqrEsrYGzWgkDrETpZ855HEk7Y\",\"kty\":\"EC\",\"x\":\"EU0bsmKcusz8NzAr07d1XVq9JF5G18-wkEZiGIlWc0c\",\"y\":\"iPJnZeqjAjMx0m2tzkJzXnN3tULJrdbem5zEyzOveIA\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"aws\",\"slug\":\"int-prod\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
+        "int-test.install.json": "{\"id\":\"batt_0196406ab80573d7852f50a5835e7bb5\",\"usage\":\"internal_int_test\",\"team_id\":\"batt_0196406ab7eb7682b68e735cc3707b82\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"_WAcrL1679TiSQPNFa2in6vKTqAMds9-pn3V5YwG-JM\",\"kty\":\"EC\",\"x\":\"lljVCyINAGuVf_8fAiNKr__TylTZArlcPA2UJ8svq9Y\",\"y\":\"5Efg4a3xT_JkoOVVz1r6f6jYLC5sFwfPSAxBFPFXRBI\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"int-test\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
+        "jason.install.json": "{\"id\":\"batt_0196406ab8057cb39880c167eb3fc0d1\",\"usage\":\"development\",\"team_id\":\"batt_0196406ab7eb7682b68e735cc3707b82\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"8XJOJR7iUY3Pbd-b18wkmEaidk3hBKhl60xuOGfdtpA\",\"kty\":\"EC\",\"x\":\"1pvjUnU7IUCP6v1enrxp95W13Aw82HY8tS5nmrvrM8k\",\"y\":\"20OiWzhoujh9VVsi7L14Ic2es1tKGPh7PSyRPmjb4S8\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"aws\",\"slug\":\"jason\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
+        "local.install.json": "{\"id\":\"batt_0196406ab805751c92058812dad23f5b\",\"usage\":\"development\",\"team_id\":\"batt_0196406ab7eb7682b68e735cc3707b82\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"xSRcAcEJJ5LXVPFYyNLvja6kVfT4aqe8l3Hkb16h0P4\",\"kty\":\"EC\",\"x\":\"yVUDGgv7CjtJ6i16lq-HOwAQtzQ6OktXVR4rfR-D7HM\",\"y\":\"eqAw3XD4KT3v5WkjrsZc0HpSYaKLwqdMnvrQfP5FCD8\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"local\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}"
       },
       "kind": "ConfigMap",
       "metadata": {
         "annotations": {
-          "battery/hash": "P4FPJQSIBNGKHJJ2TO6VJQUIB7P3METTZFQGPHSERIC5SLSMBOZA===="
+          "battery/hash": "I3HCUN5WJA6ECA5RRNAD7J4SLA4D4OVHWV2AO4234CYD2F7RMZIA===="
         },
         "labels": {
           "app": "traditional-services",
@@ -651,7 +269,7 @@
           "battery/delete-after": "PT45M",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195d3ae6d0078849b5308576aba6770",
+          "battery/owner": "batt_0196406ab80f799d8cb93f39b91dd6c7",
           "version": "latest"
         },
         "name": "home-base-seed-data",
@@ -663,7 +281,7 @@
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "WYZRQCXNZARTT7IAKPONWNM7DJ5QDRKCTEJDTOYU5UA3CHIL7LYA===="
+          "battery/hash": "S3HSNIT377YP62UU7WJ3ZZJD3PX6OQUL2NQ3RTBHONASJL2SMAEQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -673,7 +291,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195d3ae6d0074ed93dbd92672c2c117",
+          "battery/owner": "batt_0196406ab80f7c589fe42eb0bf7c02ba",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -697,7 +315,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_0195d3ae6d0074ed93dbd92672c2c117",
+              "battery/owner": "batt_0196406ab80f7c589fe42eb0bf7c02ba",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -710,7 +328,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "73SQCE3WTXOK2MX6NMDJLBWATTZB7DPPLHWVVIGZDCRLOFZG5VQWKYIEWCPB4I6V"
+                    "value": "J4B2I5SF5V6RXPRCEFXNXQRTKTIYCZZVHAYRLJ4RMAN4G5Z4FXENRCVJPFFXDII2"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -758,7 +376,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "BQQDGZG7X2KMLG7JDQXWPYWPAJYCW2ACFEQCDIIVR7ECFTCJAHNA===="
+          "battery/hash": "S6R225XEEUXNQIIV6ADUMMKKENLLVYIDLDYX2MXU6DSAMQXEA6QQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -768,7 +386,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195d3ae6d0074ed93dbd92672c2c117",
+          "battery/owner": "batt_0196406ab80f7c589fe42eb0bf7c02ba",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -780,7 +398,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "XILMBLLGQYFNVV3DKTHPPTWOFGTK6EUCD3Q5PQWDSHJSRPKI6UYQ===="
+          "battery/hash": "3UDAOJELJZQT7WBOJAW52QAKOJ35UBGKEW6TXU4ES5MNYJUFRPZQ===="
         },
         "labels": {
           "app": "traditional-services",
@@ -790,7 +408,7 @@
           "battery/app": "traditional-services",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195d3ae6d0078849b5308576aba6770",
+          "battery/owner": "batt_0196406ab80f799d8cb93f39b91dd6c7",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -802,7 +420,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "X6MOIVLTWHAGJVZ3UABPIT655GNNZVS5A6HL655U3AKSSCC6RFKQ===="
+          "battery/hash": "4QI7R4MVR3C67O33APEFI2KL27QQY7D4J6AHHGTQXDEXLJ7IWDFQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -812,7 +430,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195d3ae6d0074ed93dbd92672c2c117",
+          "battery/owner": "batt_0196406ab80f7c589fe42eb0bf7c02ba",
           "version": "latest"
         },
         "name": "bootstrap",

--- a/bootstrap/jason.install.json
+++ b/bootstrap/jason.install.json
@@ -1,14 +1,14 @@
 {
-  "id": "batt_0195d3ae6cf77690b49aa938bfdbbbd3",
+  "id": "batt_0196406ab8057cb39880c167eb3fc0d1",
   "usage": "development",
-  "team_id": "batt_0195d3ae6ce270cf8308b06625a34f35",
+  "team_id": "batt_0196406ab7eb7682b68e735cc3707b82",
   "default_size": "small",
   "control_jwk": {
     "crv": "P-256",
-    "d": "oMMKzeMq-AIb8V0TdFyou3fzVg0w4LOYyfwda4tsviY",
+    "d": "8XJOJR7iUY3Pbd-b18wkmEaidk3hBKhl60xuOGfdtpA",
     "kty": "EC",
-    "x": "FmIOr0z5tJHS8L159rCZPoQlzlwhPPuK5PSjMoMPo08",
-    "y": "_1VpltITak6qdEXhzK-9gPiXv0_GZijIqxhwqGWhG7E"
+    "x": "1pvjUnU7IUCP6v1enrxp95W13Aw82HY8tS5nmrvrM8k",
+    "y": "20OiWzhoujh9VVsi7L14Ic2es1tKGPh7PSyRPmjb4S8"
   },
   "inserted_at": null,
   "updated_at": null,

--- a/bootstrap/jason.spec.json
+++ b/bootstrap/jason.spec.json
@@ -9,7 +9,7 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_0195d3ae6d047a4db86d9b40380c1b2f",
+        "id": "batt_0196406ab81276309a81b09ffb938742",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -21,13 +21,13 @@
           "ai_namespace": "battery-ai",
           "default_size": "small",
           "cluster_name": "jason",
-          "install_id": "batt_0195d3ae6cf77690b49aa938bfdbbbd3",
+          "install_id": "batt_0196406ab8057cb39880c167eb3fc0d1",
           "control_jwk": {
             "crv": "P-256",
-            "d": "oMMKzeMq-AIb8V0TdFyou3fzVg0w4LOYyfwda4tsviY",
+            "d": "8XJOJR7iUY3Pbd-b18wkmEaidk3hBKhl60xuOGfdtpA",
             "kty": "EC",
-            "x": "FmIOr0z5tJHS8L159rCZPoQlzlwhPPuK5PSjMoMPo08",
-            "y": "_1VpltITak6qdEXhzK-9gPiXv0_GZijIqxhwqGWhG7E"
+            "x": "1pvjUnU7IUCP6v1enrxp95W13Aw82HY8tS5nmrvrM8k",
+            "y": "20OiWzhoujh9VVsi7L14Ic2es1tKGPh7PSyRPmjb4S8"
           },
           "upgrade_days_of_week": [
             true,
@@ -52,7 +52,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195d3ae6d047f889d0f5815950ec887",
+        "id": "batt_0196406ab812741498764aa94e35ce6e",
         "type": "cert_manager",
         "config": {
           "type": "cert_manager",
@@ -78,7 +78,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195d3ae6d04723789950a63d5cc393b",
+        "id": "batt_0196406ab8127da2a381dcf04bb63720",
         "type": "battery_ca",
         "config": {
           "type": "battery_ca"
@@ -88,7 +88,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195d3ae6d047ee9a2ec457d3aa46daf",
+        "id": "batt_0196406ab81271a1a742814eeeeea5b6",
         "type": "karpenter",
         "config": {
           "type": "karpenter",
@@ -108,7 +108,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195d3ae6d0479018200648b04604d2b",
+        "id": "batt_0196406ab81278748412b32bcf31db19",
         "type": "aws_load_balancer_controller",
         "config": {
           "type": "aws_load_balancer_controller",
@@ -124,7 +124,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195d3ae6d0474e9865cb2b310560b39",
+        "id": "batt_0196406ab81277a2acf1715f39d54409",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
@@ -140,7 +140,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195d3ae6d0475a99b40398e86f3008b",
+        "id": "batt_0196406ab81273f79e6e21af19613b18",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -155,7 +155,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195d3ae6d047304bd7f83965f8fe229",
+        "id": "batt_0196406ab812773f840886a33595a242",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -168,7 +168,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195d3ae6d047f2eba80da6d17d062c0",
+        "id": "batt_0196406ab8127bceb40ff4c48039e7ed",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -213,7 +213,7 @@
           {
             "version": 1,
             "username": "battery-control-user",
-            "password": "SDB6PXV57CNXN7ZWNNT7PFKW"
+            "password": "NCRJOSUUXEGACGCHB3CLDAQB"
           }
         ],
         "cpu_requested": 500,
@@ -241,7 +241,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "MB6ZDM4D3RM5NNPFZQCDMXFQSJWPPLSR7HYKFVQ3TWKEBQ4C26SA===="
+          "battery/hash": "35L7Q2MPDSTJOY35VNIS7ARZQ7WOLBRKXJXECEU52R6X6S3VVCQQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -251,7 +251,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195d3ae6d047a4db86d9b40380c1b2f",
+          "battery/owner": "batt_0196406ab81276309a81b09ffb938742",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -274,7 +274,7 @@
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "GX6XDCD2XL3X6EJMORZZPYISYWJ45RV6AS7EVLSLGLBSEY6ULLCA===="
+          "battery/hash": "EKLINM4AQ2H5FETZK56Y5OG3JUIZZEYWTDMDW2TAJ44JNFTU65PQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -284,7 +284,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195d3ae6d047a4db86d9b40380c1b2f",
+          "battery/owner": "batt_0196406ab81276309a81b09ffb938742",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -308,7 +308,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_0195d3ae6d047a4db86d9b40380c1b2f",
+              "battery/owner": "batt_0196406ab81276309a81b09ffb938742",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -321,7 +321,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "L4BBKCJM2D2U7QWV6HSCJDRXCTK26XVREOOU7BC6DD36ZJW6CITVK5B3SWHQDWRW"
+                    "value": "YJ7TAIPK5LWK24XE4HKLQ2XRY5P2OIARQMGWVJQ4P4NJBOVJTV4CFXWWSRX3H4CU"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -369,7 +369,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "RTA5FJODDL5PZWDNXVGR2MTLEEJ2GZLX5MTLFE6OFQTWNTIT334A===="
+          "battery/hash": "B3E7NYJXBN63VMPDEO2RVS3ULSGALTXGOGDLNWAZGXBPFJD5WLKQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -379,7 +379,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195d3ae6d047a4db86d9b40380c1b2f",
+          "battery/owner": "batt_0196406ab81276309a81b09ffb938742",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -391,7 +391,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "WWXR2UX7QXSLC4GUR3Z7ECRRWBB6SWPO4EKOXZVQMOMU4OMQUUYA===="
+          "battery/hash": "FFWB2D5FPJ3KKZQRNKJPXNL5XCRHG64V3YNSATJXNU4EOMSQHIVQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -401,7 +401,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195d3ae6d047a4db86d9b40380c1b2f",
+          "battery/owner": "batt_0196406ab81276309a81b09ffb938742",
           "version": "latest"
         },
         "name": "bootstrap",
@@ -414,7 +414,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "QK77Z5VV52GFTQWNF5SXTQZUVPED23KKR32IVXNTYRN7TUPJZ64Q====",
+          "battery/hash": "7BA6W77NVC7NJ73ETZIVOZIBX5EQKLDGEBK2YC73WN6XSXTWPCZA====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -425,7 +425,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195d3ae6d047a4db86d9b40380c1b2f",
+          "battery/owner": "batt_0196406ab81276309a81b09ffb938742",
           "version": "latest"
         },
         "name": "gp2"
@@ -440,7 +440,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "BVRGTB7N4KJJMB67N3TI3WTYYJ72JFH6WJCT2PLEFNW7SUNFKOLQ====",
+          "battery/hash": "2XUK3ZPGE5VDOW4TF2WEJJU6Q36AOA6CSUJT5AIL6LYII4TEPS7A====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -451,7 +451,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195d3ae6d047a4db86d9b40380c1b2f",
+          "battery/owner": "batt_0196406ab81276309a81b09ffb938742",
           "version": "latest"
         },
         "name": "gp2-90032408"
@@ -471,7 +471,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "N4XP273424Z3NESYKS6WYGWZQ6PCO45H56YDRH5BOGEPSTOJ3CCA====",
+          "battery/hash": "L7T6JBJXMSLSGRFHYWS7LSEI5PSNAIPUDDKDTYWBJPKX6AS3REFQ====",
           "storageclass.kubernetes.io/is-default-class": "true"
         },
         "labels": {
@@ -482,7 +482,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195d3ae6d047a4db86d9b40380c1b2f",
+          "battery/owner": "batt_0196406ab81276309a81b09ffb938742",
           "version": "latest"
         },
         "name": "gp3-105457460"

--- a/bootstrap/local.install.json
+++ b/bootstrap/local.install.json
@@ -1,14 +1,14 @@
 {
-  "id": "batt_0195d3ae6cf775fe884b966088235f67",
+  "id": "batt_0196406ab805751c92058812dad23f5b",
   "usage": "development",
-  "team_id": "batt_0195d3ae6ce270cf8308b06625a34f35",
+  "team_id": "batt_0196406ab7eb7682b68e735cc3707b82",
   "default_size": "tiny",
   "control_jwk": {
     "crv": "P-256",
-    "d": "jod8jYzG3V4nvkHdOQsg4dLsKJ4sh5rYcc5a8Th0EZk",
+    "d": "xSRcAcEJJ5LXVPFYyNLvja6kVfT4aqe8l3Hkb16h0P4",
     "kty": "EC",
-    "x": "sFB3yIhMQo3eikRFVjRAahniOioPVZcZ27efWg1xTP8",
-    "y": "3USC1T5VUD8ljtAqHo-StapxACTAw1dEcoXMtxxsT7I"
+    "x": "yVUDGgv7CjtJ6i16lq-HOwAQtzQ6OktXVR4rfR-D7HM",
+    "y": "eqAw3XD4KT3v5WkjrsZc0HpSYaKLwqdMnvrQfP5FCD8"
   },
   "inserted_at": null,
   "updated_at": null,

--- a/bootstrap/local.spec.json
+++ b/bootstrap/local.spec.json
@@ -9,7 +9,7 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_0195d3ae6d0479ee9018a522e96aa860",
+        "id": "batt_0196406ab8127b1ab62a00669f291a29",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -24,7 +24,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195d3ae6d047e16b51e166fdb52a5eb",
+        "id": "batt_0196406ab8127fa788b94fc4ed894289",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -37,7 +37,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195d3ae6d0471efa6b605d12eedd44d",
+        "id": "batt_0196406ab8127b8e8498e688cb2d6dc6",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -49,13 +49,13 @@
           "ai_namespace": "battery-ai",
           "default_size": "tiny",
           "cluster_name": "local",
-          "install_id": "batt_0195d3ae6cf775fe884b966088235f67",
+          "install_id": "batt_0196406ab805751c92058812dad23f5b",
           "control_jwk": {
             "crv": "P-256",
-            "d": "jod8jYzG3V4nvkHdOQsg4dLsKJ4sh5rYcc5a8Th0EZk",
+            "d": "xSRcAcEJJ5LXVPFYyNLvja6kVfT4aqe8l3Hkb16h0P4",
             "kty": "EC",
-            "x": "sFB3yIhMQo3eikRFVjRAahniOioPVZcZ27efWg1xTP8",
-            "y": "3USC1T5VUD8ljtAqHo-StapxACTAw1dEcoXMtxxsT7I"
+            "x": "yVUDGgv7CjtJ6i16lq-HOwAQtzQ6OktXVR4rfR-D7HM",
+            "y": "eqAw3XD4KT3v5WkjrsZc0HpSYaKLwqdMnvrQfP5FCD8"
           },
           "upgrade_days_of_week": [
             true,
@@ -80,7 +80,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195d3ae6d0474718afe0038fd777ba6",
+        "id": "batt_0196406ab8127545bad333a593bd86bf",
         "type": "metallb",
         "config": {
           "type": "metallb",
@@ -100,7 +100,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195d3ae6d047cb6a349f4501ecefc77",
+        "id": "batt_0196406ab81271c49b3fc628a392992c",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
@@ -116,7 +116,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_0195d3ae6d04730daa7086a6ea5bba73",
+        "id": "batt_0196406ab8127fcfa9cd543b5e349be2",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -161,7 +161,7 @@
           {
             "version": 1,
             "username": "battery-control-user",
-            "password": "XBOMAARY2R5AYLB77WBD5CLS"
+            "password": "6CB7K6ZB36BKGQWNFHBSNJ2H"
           }
         ],
         "cpu_requested": 500,
@@ -189,7 +189,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "D72BOA2BFC74WF7G5TBYY7FQ42QUGDO2PHQH2NH26VV5JWLHEUKA===="
+          "battery/hash": "XG6RMSFJ7LFTEPHARXCQMLAM4TKAQYU5ISBJTEYPHTU7UMLFUXFQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -199,7 +199,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195d3ae6d0471efa6b605d12eedd44d",
+          "battery/owner": "batt_0196406ab8127b8e8498e688cb2d6dc6",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -222,7 +222,7 @@
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "MRASNRJNWBHMZKU2ILKYFUWOBUHW5VP6433ED5ZXQOEP6WUSZSBA===="
+          "battery/hash": "4JWZHTKKLC2QQAKS5MHMJGJ43WUWDZBAWSOHJGKDLV7PMERHQ5LA===="
         },
         "labels": {
           "app": "battery-core",
@@ -232,7 +232,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195d3ae6d0471efa6b605d12eedd44d",
+          "battery/owner": "batt_0196406ab8127b8e8498e688cb2d6dc6",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -256,7 +256,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_0195d3ae6d0471efa6b605d12eedd44d",
+              "battery/owner": "batt_0196406ab8127b8e8498e688cb2d6dc6",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -269,7 +269,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "PAYHSURMOXYOPCAIH2EZSCCRJ7RXIUB7SQQZ3V5DLD2AF3OGQBGCLNTF6H7DDXSB"
+                    "value": "72FS42KPXJES3QZWIJB6427RHGTOCQ7Q5MDOQFEDJWHT3PO632LDL5PKXMDEQVA6"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -317,7 +317,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "TJK7QBGUKHVH63NM7BJP2RBO7VMJSZPRV7K3TCYUBWQVYQUBLNZA===="
+          "battery/hash": "3VPTE3BSD7H2CRJIRCW2NSYOCJTEFAQ6AGGKR3BSBB6454C2O3AQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -327,7 +327,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195d3ae6d0471efa6b605d12eedd44d",
+          "battery/owner": "batt_0196406ab8127b8e8498e688cb2d6dc6",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -339,7 +339,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "56WZK5EYN6BDVE25XJOB4MQ2U3646W5CYOSRKH5BBUUMZS3TCH4Q===="
+          "battery/hash": "LNXFIMWANNVBUQORBBSZU3QKOOQTXUVOVTR4BSJ5MIM7Y27BL6KQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -349,7 +349,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_0195d3ae6d0471efa6b605d12eedd44d",
+          "battery/owner": "batt_0196406ab8127b8e8498e688cb2d6dc6",
           "version": "latest"
         },
         "name": "bootstrap",

--- a/bootstrap/team.json
+++ b/bootstrap/team.json
@@ -1,5 +1,5 @@
 {
-  "id": "batt_0195d3ae6ce270cf8308b06625a34f35",
+  "id": "batt_0196406ab7eb7682b68e735cc3707b82",
   "name": "Batteries Included Team",
   "inserted_at": null,
   "updated_at": null,

--- a/platform_umbrella/apps/common_core/lib/common_core/installs/postgres.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/installs/postgres.ex
@@ -53,7 +53,7 @@ defmodule CommonCore.Installs.Postgres do
        }) do
     case usage do
       # create home-base and CLA assistant clusters
-      usage when usage in [:internal_int_test, :internal_prod] ->
+      usage when usage in [:internal_prod] ->
         home_base = TraditionalServices.home_base_name()
         cla = TraditionalServices.cla_name()
 

--- a/platform_umbrella/apps/common_core/lib/common_core/installs/traditional_services.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/installs/traditional_services.ex
@@ -11,7 +11,7 @@ defmodule CommonCore.Installs.TraditionalServices do
   def home_base_name, do: @home_base_name
   def cla_name, do: @cla_name
 
-  def services(%{usage: usage} = installation, home_base_init_data) when usage in [:internal_int_test, :internal_prod] do
+  def services(%{usage: usage} = installation, home_base_init_data) when usage in [:internal_prod] do
     Enum.map([&home_base/2, &cla/2], fn func -> func.(installation, home_base_init_data) end)
   end
 


### PR DESCRIPTION
The pg clusters for home_base and cla were preventing the cluster(s) from coming up in Actions runner. Remove 'em for now.