### PR TITLE
ci(int-test): wait until containers published

### DIFF
--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -7,7 +7,7 @@ on:
     workflows:
       - BIX Docker
     types:
-      - requested
+      - completed
 
 jobs:
   elixir-int-test:
@@ -26,7 +26,5 @@ jobs:
           go_cache: 'false'
 
       - name: Run integration tests
-        env:
-          TEST_LOG_LEVEL: debug
         run: |
-          bin/bix -v ex-int-test
+          bin/bix ex-int-test


### PR DESCRIPTION
It took long enough that the containers eventually got published and pulled but we should just wait to start int-test until they are published.

https://github.com/batteries-included/batteries-included/actions/runs/14520777264/job/40740939744