### PR TITLE
bix: skip archiving when building bi

### DIFF
--- a/bin/bix
+++ b/bin/bix
@@ -632,7 +632,7 @@ do_ex_dialyzer() {
 }
 
 do_go_build_bi() {
-    goreleaser release --clean --snapshot ${TRACE:+--verbose} -p 1
+    goreleaser release --clean --snapshot ${TRACE:+--verbose} -p 1 --skip=archive
 }
 
 do_go_build_bi_ci() {


### PR DESCRIPTION
The archiving step takes time and doesn't do much for us during CI. Skip it.