### PR TITLE
feat: add CommonCore.Util.VirtualSize

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/notebooks/jupyter_lab_notebook.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/notebooks/jupyter_lab_notebook.ex
@@ -145,4 +145,6 @@ defmodule CommonCore.Notebooks.JupyterLabNotebook do
   def preset_options_for_select do
     Enum.map(@presets, &{String.capitalize(&1.name), &1.name})
   end
+
+  def presets, do: @presets
 end

--- a/platform_umbrella/apps/common_core/lib/common_core/ollama/model_instance.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/ollama/model_instance.ex
@@ -147,4 +147,6 @@ defmodule CommonCore.Ollama.ModelInstance do
     |> Enum.sort(&(&1.memory_requested < &2.memory_requested))
     |> Enum.find(fn %{memory_requested: memory_requested} -> memory_requested >= size end)
   end
+
+  def presets, do: @presets
 end

--- a/platform_umbrella/apps/common_core/lib/common_core/util/virtual_size.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/util/virtual_size.ex
@@ -1,0 +1,35 @@
+defmodule CommonCore.Util.VirtualSize do
+  @moduledoc false
+
+  def get_virtual_size(struct) do
+    struct
+    |> get_presets()
+    |> find_matching_preset_name(struct)
+  end
+
+  defp get_presets(%{__struct__: struct}) do
+    # if the __struct__ module has a presets function, call it
+    if function_exported?(struct, :presets, 0) do
+      struct.presets()
+    else
+      []
+    end
+  end
+
+  defp get_presets(_), do: []
+
+  defp find_matching_preset_name(presets, struct) do
+    presets
+    |> Enum.find(
+      # Default to empty map if no presets match
+      %{},
+      fn preset ->
+        # All the values in the preset must match the struct
+        Enum.all?(preset, fn {k, v} ->
+          k == :name || Map.get(struct, k, nil) == v
+        end)
+      end
+    )
+    |> Map.get(:name, "custom")
+  end
+end

--- a/platform_umbrella/apps/common_core/test/common_core/util/virtual_size_test.exs
+++ b/platform_umbrella/apps/common_core/test/common_core/util/virtual_size_test.exs
@@ -1,0 +1,28 @@
+defmodule CommonCore.Util.VirtualSizeTest do
+  use ExUnit.Case, async: true
+
+  alias CommonCore.Postgres.Cluster
+  alias CommonCore.Util.VirtualSize
+
+  describe "Works with CommonCore.Postgres.Cluster" do
+    test "returns tiny when there's a tiny preset" do
+      cluster = Cluster.new!(virtual_size: "tiny", name: "test")
+
+      assert VirtualSize.get_virtual_size(cluster) == "tiny"
+    end
+
+    test "custom sizes work" do
+      cluster =
+        Cluster.new!(
+          name: "test",
+          storage_size: 1_000_000_003,
+          cpu_requested: 600,
+          cpu_limits: 700,
+          memory_requested: 1_000_000_005,
+          memory_limits: 1_000_000_006
+        )
+
+      assert VirtualSize.get_virtual_size(cluster) == "custom"
+    end
+  end
+end

--- a/platform_umbrella/apps/common_core/test/common_core/util/virtual_size_test.exs
+++ b/platform_umbrella/apps/common_core/test/common_core/util/virtual_size_test.exs
@@ -2,6 +2,7 @@ defmodule CommonCore.Util.VirtualSizeTest do
   use ExUnit.Case, async: true
 
   alias CommonCore.Postgres.Cluster
+  alias CommonCore.Util.Memory
   alias CommonCore.Util.VirtualSize
 
   describe "Works with CommonCore.Postgres.Cluster" do
@@ -15,14 +16,22 @@ defmodule CommonCore.Util.VirtualSizeTest do
       cluster =
         Cluster.new!(
           name: "test",
-          storage_size: 1_000_000_003,
+          virtual_size: "custom",
+          storage_size: Memory.to_bytes(255, :GB),
           cpu_requested: 600,
           cpu_limits: 700,
-          memory_requested: 1_000_000_005,
-          memory_limits: 1_000_000_006
+          memory_requested: Memory.to_bytes(1, :GB),
+          memory_limits: Memory.to_bytes(4, :GB)
         )
 
       assert VirtualSize.get_virtual_size(cluster) == "custom"
+    end
+  end
+
+  describe "Works with CommonCore.Notebooks.JupyterLabNotebook" do
+    test "returns tiny when there's a preset" do
+      notebook = CommonCore.Notebooks.JupyterLabNotebook.new!(virtual_size: "tiny", name: "test")
+      assert VirtualSize.get_virtual_size(notebook) == "tiny"
     end
   end
 end


### PR DESCRIPTION
Summary:
Add a module to get the matching virtual size for structs rather than
changesets

Test Plan:
- Tests included
