### PR TITLE
fix: revert refactor json logging configuration

### DIFF
--- a/platform_umbrella/config/prod.exs
+++ b/platform_umbrella/config/prod.exs
@@ -49,3 +49,6 @@ config :logger, :console,
   compile_time_purge_matching: [
     [library: :k8s]
   ]
+
+config :logger, :default_handler,
+  formatter: {LoggerJSON.Formatters.Basic, %{metadata: [:mfa, :request_id], redactors: [], encoder_opts: []}}

--- a/platform_umbrella/config/runtime.exs
+++ b/platform_umbrella/config/runtime.exs
@@ -3,7 +3,3 @@ import Config
 config :logger, :console,
   format: "$time $metadata[$level] $message\n",
   level: :debug
-
-if config_env() == :prod do
-  config :logger, :default_handler, formatter: LoggerJSON.Formatters.Basic.new(metadata: [:mfa, :request_id])
-end


### PR DESCRIPTION
Reverts batteries-included/batteries-included#1851

This change doesn't work with our releases without additional work.