### PR TITLE
chore: bump stable bi version to 0.66.0

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/defaults/versions.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/defaults/versions.ex
@@ -2,5 +2,5 @@ defmodule CommonCore.Defaults.Versions do
   @moduledoc false
 
   @spec bi_stable_version() :: String.t()
-  def bi_stable_version, do: "0.65.0"
+  def bi_stable_version, do: "0.66.0"
 end


### PR DESCRIPTION
Summary:
- Preparing for a release

Test Plan:
- CI
