### PR TITLE
fix: wrap image names in pre tag to allow copying

### DIFF
--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/containers/containers_panel.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/containers/containers_panel.ex
@@ -18,7 +18,7 @@ defmodule ControlServerWeb.Containers.ContainersPanel do
       </:menu>
       <.table id={"containers-table-#{@id}"} rows={Enum.with_index(@containers ++ @init_containers)}>
         <:col :let={{c, _idx}} label="Name">{c.name}</:col>
-        <:col :let={{c, _idx}} label="Image">{c.image}</:col>
+        <:col :let={{c, _idx}} label="Image"><pre>{c.image}</pre></:col>
 
         <:action :let={{c, idx}}>
           <.button

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/k8/pod/show.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/k8/pod/show.ex
@@ -199,7 +199,7 @@ defmodule ControlServerWeb.Live.PodShow do
     <.panel title="Containers" class="col-span-2">
       <.table id="container-status-table" rows={@container_statuses}>
         <:col :let={cs} label="Name">{Map.get(cs, "name", "")}</:col>
-        <:col :let={cs} label="Image">{Map.get(cs, "image", "")}</:col>
+        <:col :let={cs} label="Image"><pre>{Map.get(cs, "image", "")}</pre></:col>
         <:col :let={cs} label="Started"><.status_icon status={Map.get(cs, "started", false)} /></:col>
         <:col :let={cs} label="Ready"><.status_icon status={Map.get(cs, "ready", false)} /></:col>
         <:col :let={cs} label="Restart Count">


### PR DESCRIPTION
Summary:
In the browser any text that's in a pre tag can be selected by triple
clickinkg. It automatically makes sure that no added spaces are in the
selection. So this wraps the all the image names in that

Test Plan:
- Visual

![image](https://github.com/user-attachments/assets/5afaca51-a49e-4782-8132-d631bd206b1e)

- Tested copying
