### PR TITLE
fix(bi): allow using `rage` during integration tests

### DIFF
--- a/bi/cmd/start.go
+++ b/bi/cmd/start.go
@@ -49,6 +49,11 @@ complete displaying a url for running control server.`,
 			return err
 		}
 
+		err = env.Init(ctx)
+		if err != nil {
+			return err
+		}
+
 		if err := log.CollectDebugLogs(env.DebugLogPath(cmd.CommandPath())); err != nil {
 			return err
 		}

--- a/bi/cmd/stop.go
+++ b/bi/cmd/stop.go
@@ -25,6 +25,11 @@ var stopCmd = &cobra.Command{
 			return err
 		}
 
+		err = env.Init(ctx)
+		if err != nil {
+			return err
+		}
+
 		if err := log.CollectDebugLogs(env.DebugLogPath(cmd.CommandPath())); err != nil {
 			return err
 		}

--- a/bi/pkg/kube/remove_all.go
+++ b/bi/pkg/kube/remove_all.go
@@ -339,11 +339,9 @@ func (kubeClient *batteryKubeClient) getClusterScopedGVRs() ([]schema.GroupVersi
 				switch len(groupVersion) {
 				case 1:
 					version = groupVersion[0]
-					slog.Error("got version", slog.Any("gv", groupVersion))
 				case 2:
 					group = groupVersion[0]
 					version = groupVersion[1]
-					slog.Error("got group version", slog.Any("gv", groupVersion))
 
 				default:
 					return nil, fmt.Errorf("unexpected group/version format: %s", apiResourceList.GroupVersion)

--- a/bi/pkg/rage/rage.go
+++ b/bi/pkg/rage/rage.go
@@ -4,8 +4,7 @@ import (
 	"bi/pkg/access"
 	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
+	"io"
 )
 
 type RageReport struct {
@@ -32,20 +31,17 @@ type PodRageInfo struct {
 	ContainerInfo map[string]ContainerRageInfo
 }
 
-func (report *RageReport) Write(path string) error {
+func (report *RageReport) Write(w io.Writer) error {
 	// json serialize the report and write it to the path
 	contents, err := json.MarshalIndent(report, "", "  ")
 	if err != nil {
 		return fmt.Errorf("unable to marshal rage report: %w", err)
 	}
 
-	// Make the rage directory if it doesn't exist
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		return fmt.Errorf("unable to create rage directory: %w", err)
+	_, err = w.Write(contents)
+	if err != nil {
+		return fmt.Errorf("unable to write rage contents: %w", err)
 	}
 
-	if err := os.WriteFile(path, contents, 0644); err != nil {
-		return fmt.Errorf("unable to write rage report: %w", err)
-	}
 	return nil
 }


### PR DESCRIPTION
- Only init when necessary to avoid removing kube config
- Allow rage to output to arbitrary location or stdout