### PR TITLE
fix(bix): don't double slash the local bi build dir

### DIFF
--- a/bin/common-functions.sh
+++ b/bin/common-functions.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 TRACE=${TRACE-""}
-BI_BUILD_DIR="${BI_BUILD_DIR:-$HOME/.local/share/bi/dev/}"
+BI_BUILD_DIR="${BI_BUILD_DIR:-$HOME/.local/share/bi/dev}"
 KEEP_BUILDS="${KEEP_BUILDS:-10}"
 
 setup_colors() {


### PR DESCRIPTION
Prevents e.g.:

```
[2025-04-28T18:49:03+0000]: bi binary not found at /home/runner/.local/share/bi/dev//569b1d6fe46c2c7235297c15a76618d612c8b720/bi building...
```