### PR TITLE
chore(bootstrap): re-gen specs to remove unused int-test batteries

### DIFF
--- a/bootstrap/dev.install.json
+++ b/bootstrap/dev.install.json
@@ -1,14 +1,14 @@
 {
-  "id": "batt_019659b9dff272b483b1a0b39f3e2e6c",
+  "id": "batt_019687ec7c117059bc7406b8d1ffaa67",
   "usage": "internal_dev",
-  "team_id": "batt_019659b9dff07592bd45cc718aa943d3",
+  "team_id": "batt_019687ec7c0e766fb039570bb2d0e6af",
   "default_size": "tiny",
   "control_jwk": {
     "crv": "P-256",
-    "d": "XLYkmzlDC5CexH-dKiUXWNwswpM3pUWxHRYCyshrDew",
+    "d": "HCvYLw4HaZWRbMdhiNMqGU_Bz8HOIZZuVnlkp0OR_Eg",
     "kty": "EC",
-    "x": "U5OBYfWB9ykJiFhnXK8pMgNNaOTq-ZYPxs1yx6Ap7g4",
-    "y": "Izs5ZQGTqhTXBs-MWrJq4kDx8k5DyyV0y4ZQHI-L2nM"
+    "x": "5fUxr4dZ5hgPwpd9HK_RazwBu4-k9XoXacULNme1EKw",
+    "y": "JotnuhiuPSVin19n6oxAAIZGnpYk0pmoC5SSFowl87E"
   },
   "inserted_at": null,
   "updated_at": null,

--- a/bootstrap/dev.spec.json
+++ b/bootstrap/dev.spec.json
@@ -9,7 +9,7 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_019659b9e000750baa93523d8a690ea1",
+        "id": "batt_019687ec7c277b668f0c04a31bf336a3",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -24,7 +24,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_019659b9e0007c92b97e2ae7ec43ef46",
+        "id": "batt_019687ec7c277484ab2b4fee725d82b1",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -37,7 +37,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_019659b9e0007b03832a8746336dc436",
+        "id": "batt_019687ec7c277de9b7db60be0c951a99",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -49,13 +49,13 @@
           "ai_namespace": "battery-ai",
           "default_size": "tiny",
           "cluster_name": "dev",
-          "install_id": "batt_019659b9dff272b483b1a0b39f3e2e6c",
+          "install_id": "batt_019687ec7c117059bc7406b8d1ffaa67",
           "control_jwk": {
             "crv": "P-256",
-            "d": "XLYkmzlDC5CexH-dKiUXWNwswpM3pUWxHRYCyshrDew",
+            "d": "HCvYLw4HaZWRbMdhiNMqGU_Bz8HOIZZuVnlkp0OR_Eg",
             "kty": "EC",
-            "x": "U5OBYfWB9ykJiFhnXK8pMgNNaOTq-ZYPxs1yx6Ap7g4",
-            "y": "Izs5ZQGTqhTXBs-MWrJq4kDx8k5DyyV0y4ZQHI-L2nM"
+            "x": "5fUxr4dZ5hgPwpd9HK_RazwBu4-k9XoXacULNme1EKw",
+            "y": "JotnuhiuPSVin19n6oxAAIZGnpYk0pmoC5SSFowl87E"
           },
           "upgrade_days_of_week": [
             true,
@@ -80,7 +80,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_019659b9e0007ee8be4d00778d9a9a2f",
+        "id": "batt_019687ec7c2775a4ae8ff08de0488396",
         "type": "metallb",
         "config": {
           "type": "metallb",
@@ -100,7 +100,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_019659b9e000714586d54dd37d2f578f",
+        "id": "batt_019687ec7c28724c942c0d681dec7b0b",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
@@ -116,7 +116,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_019659b9e00071d38530f1695a7a9c2e",
+        "id": "batt_019687ec7c287b71bcf422e6c82dfd2a",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -172,7 +172,7 @@
           {
             "version": 2,
             "username": "battery-control-user",
-            "password": "3N4SDFJKWLXUFHUIJ5WTPIID"
+            "password": "FTWTK3U7UL6XQKQW7IST5PGI"
           },
           {
             "version": 1,
@@ -205,7 +205,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "NKRV7LSKSR3WDFI6CWYHVSFNWWGQAEE2PTGRS6SALGJ6ESERX4VQ===="
+          "battery/hash": "RDAXJE6SUV6TSRD6HA3QSJZP5JJDXYXHYCCA7VVK6FODV2ANEFNQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -215,7 +215,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_019659b9e0007b03832a8746336dc436",
+          "battery/owner": "batt_019687ec7c277de9b7db60be0c951a99",
           "istio-injection": "enabled",
           "version": "latest"
         },

--- a/bootstrap/int-prod.install.json
+++ b/bootstrap/int-prod.install.json
@@ -1,14 +1,14 @@
 {
-  "id": "batt_019659b9dffc7b3487132be6982ea17c",
+  "id": "batt_019687ec7c2272d5993331c4f100e534",
   "usage": "internal_prod",
-  "team_id": "batt_019659b9dff07592bd45cc718aa943d3",
+  "team_id": "batt_019687ec7c0e766fb039570bb2d0e6af",
   "default_size": "medium",
   "control_jwk": {
     "crv": "P-256",
-    "d": "D-ndnMiGQgU-0bZriyEgXV1-A6n9iSabfT8BFq8tyoc",
+    "d": "DvWtSZMNATqFlidH1v6HFkTM9kS8Rg4BFBAe1RRps48",
     "kty": "EC",
-    "x": "TQHS0J50eyP9YllyR7HmryNMHtvIRmSr8VzrXPPVx40",
-    "y": "pjGZrKmKJrtrE9xyY-bn5KRZBOtt7C_X2d0JAuHautM"
+    "x": "mxnYgHdOg1EYmZ9ZlBOzng4toanqYUyibRvgp3lcrVY",
+    "y": "MsvYmXNPJlVj39uJ3xpKs-sJy1SzhboHz8AzVEsZ8k4"
   },
   "inserted_at": null,
   "updated_at": null,

--- a/bootstrap/int-prod.spec.json
+++ b/bootstrap/int-prod.spec.json
@@ -9,7 +9,7 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_019659b9e00271e4b35f83f6a7a216a7",
+        "id": "batt_019687ec7c2b773083f40f00cc49fcdf",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -21,13 +21,13 @@
           "ai_namespace": "battery-ai",
           "default_size": "medium",
           "cluster_name": "int-prod",
-          "install_id": "batt_019659b9dffc7b3487132be6982ea17c",
+          "install_id": "batt_019687ec7c2272d5993331c4f100e534",
           "control_jwk": {
             "crv": "P-256",
-            "d": "D-ndnMiGQgU-0bZriyEgXV1-A6n9iSabfT8BFq8tyoc",
+            "d": "DvWtSZMNATqFlidH1v6HFkTM9kS8Rg4BFBAe1RRps48",
             "kty": "EC",
-            "x": "TQHS0J50eyP9YllyR7HmryNMHtvIRmSr8VzrXPPVx40",
-            "y": "pjGZrKmKJrtrE9xyY-bn5KRZBOtt7C_X2d0JAuHautM"
+            "x": "mxnYgHdOg1EYmZ9ZlBOzng4toanqYUyibRvgp3lcrVY",
+            "y": "MsvYmXNPJlVj39uJ3xpKs-sJy1SzhboHz8AzVEsZ8k4"
           },
           "upgrade_days_of_week": [
             true,
@@ -52,7 +52,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_019659b9e00277bcb977f5c4416d3c2d",
+        "id": "batt_019687ec7c2b7bb690a9ddc7e75781b6",
         "type": "cert_manager",
         "config": {
           "type": "cert_manager",
@@ -78,7 +78,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_019659b9e0027d17b1655f4153cdb72c",
+        "id": "batt_019687ec7c2b71cf9218913fc06b3415",
         "type": "battery_ca",
         "config": {
           "type": "battery_ca"
@@ -88,7 +88,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_019659b9e00277f280fa1fd5739fdc67",
+        "id": "batt_019687ec7c2b73999b19eb50ff7fb811",
         "type": "karpenter",
         "config": {
           "type": "karpenter",
@@ -108,7 +108,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_019659b9e00270659f5c559d6ea2b9fb",
+        "id": "batt_019687ec7c2b7c7c838e11931b516089",
         "type": "aws_load_balancer_controller",
         "config": {
           "type": "aws_load_balancer_controller",
@@ -124,7 +124,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_019659b9e0027b55ba70b5fc6cd92665",
+        "id": "batt_019687ec7c2b7e29938335d37fb2ee61",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
@@ -140,7 +140,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_019659b9e0027b5a920398afc0d9a62a",
+        "id": "batt_019687ec7c2b7ffea4ea884457dc78a1",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -155,7 +155,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_019659b9e002790d886f7162c17ed182",
+        "id": "batt_019687ec7c2b723aae0671eaaec75e0f",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -168,7 +168,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_019659b9e0027efe8027a13a0b6fc573",
+        "id": "batt_019687ec7c2b7e81ba7d1d995f690c24",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -180,7 +180,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_019659b9e0027ec6942024b7d31f2d94",
+        "id": "batt_019687ec7c2b78cca98e23132df5cd1f",
         "type": "ferretdb",
         "config": {
           "type": "ferretdb",
@@ -193,7 +193,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_019659b9e0027516a163ea5430a49838",
+        "id": "batt_019687ec7c2b7aa3a408cf519611df08",
         "type": "traditional_services",
         "config": {
           "type": "traditional_services",
@@ -204,7 +204,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_019659b9e0027113bf02d8d0e9b82230",
+        "id": "batt_019687ec7c2b76c18d3ffa7c42ed2cd0",
         "type": "vm_agent",
         "config": {
           "type": "vm_agent",
@@ -216,11 +216,11 @@
         "updated_at": null
       },
       {
-        "id": "batt_019659b9e0027a7cb99a8ea472c58a6a",
+        "id": "batt_019687ec7c2b7c57a72cd5dd4e2a1291",
         "type": "victoria_metrics",
         "config": {
           "type": "victoria_metrics",
-          "cookie_secret": "XDG7abd_P6INTK7Emz693CQpEo0MJMRzAMU5Lo-zOTE=",
+          "cookie_secret": "cyyyvoX9mir8d2w6dMgrxV2ZZ8vOl3AQ18Qrp6j6eYo=",
           "replication_factor": 1,
           "operator_image": "victoriametrics/operator:v0.44.0",
           "vmselect_volume_size": 536870912,
@@ -241,7 +241,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_019659b9e002771799e8fc7416f856f1",
+        "id": "batt_019687ec7c2b75d68a4968c125d55a3d",
         "type": "grafana",
         "config": {
           "type": "grafana",
@@ -274,7 +274,7 @@
         "env_values": [
           {
             "name": "BATTERY_TEAM_IDS",
-            "value": "batt_019659b9dff07592bd45cc718aa943d3",
+            "value": "batt_019687ec7c0e766fb039570bb2d0e6af",
             "source_name": null,
             "source_type": "value",
             "source_key": null,
@@ -282,7 +282,7 @@
           },
           {
             "name": "SECRET_KEY_BASE",
-            "value": "GUBVFNQTQ5KW6OJ7KASAQ64IHCKO6OMLSZSTCXCG6MUOM7474RYGZZSMSZ22HPTA",
+            "value": "SENRO3KNTPYIO3H4KHGQTQ3FWCRJTYLNY3KCKZ5RLNA6Q5BFZ6JIKX2NLB6M4SON",
             "source_name": null,
             "source_type": "value",
             "source_key": null,
@@ -580,7 +580,7 @@
           {
             "version": 1,
             "username": "battery-control-user",
-            "password": "SPJZO5L4O4UEU6UZOV5ONGZ4"
+            "password": "B2CP3OIDNVFXT6MMGDJ3R2BB"
           }
         ],
         "cpu_requested": 4000,
@@ -626,7 +626,7 @@
           {
             "version": 1,
             "username": "home-base",
-            "password": "YY5KRHJ6WFPUWB6ZC4CYNZUG"
+            "password": "YWTCWXKYTQJ6TV2MJTLAOWSM"
           }
         ],
         "cpu_requested": 4000,
@@ -672,7 +672,7 @@
           {
             "version": 1,
             "username": "cla",
-            "password": "LC54LXAUV2OQ7JTYAZ5MU3C4"
+            "password": "3RPKBSQXCSD475ZBW7XX3RZD"
           }
         ],
         "cpu_requested": 4000,
@@ -702,7 +702,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "6IUCUYSM4SC5SP2RYMW5KPO32PB4CUQULSZWSMYODGNKFXVC6LXA===="
+          "battery/hash": "LMK6W6H3JOHDG4HQO33QLKHAL5RUSV5P23RIUZDYRC4XOBDZS32A===="
         },
         "labels": {
           "app": "battery-core",
@@ -712,7 +712,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_019659b9e00271e4b35f83f6a7a216a7",
+          "battery/owner": "batt_019687ec7c2b773083f40f00cc49fcdf",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -733,17 +733,17 @@
     "/config_map/home_base_seed_data": {
       "apiVersion": "v1",
       "data": {
-        "batt_019659b9dff07592bd45cc718aa943d3.team.json": "{\"id\":\"batt_019659b9dff07592bd45cc718aa943d3\",\"name\":\"Batteries Included Team\",\"inserted_at\":null,\"updated_at\":null,\"op_email\":\"elliott@batteriesincl.com\",\"deleted_at\":null}",
-        "dev.install.json": "{\"id\":\"batt_019659b9dff272b483b1a0b39f3e2e6c\",\"usage\":\"internal_dev\",\"team_id\":\"batt_019659b9dff07592bd45cc718aa943d3\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"XLYkmzlDC5CexH-dKiUXWNwswpM3pUWxHRYCyshrDew\",\"kty\":\"EC\",\"x\":\"U5OBYfWB9ykJiFhnXK8pMgNNaOTq-ZYPxs1yx6Ap7g4\",\"y\":\"Izs5ZQGTqhTXBs-MWrJq4kDx8k5DyyV0y4ZQHI-L2nM\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"dev\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
-        "int-prod.install.json": "{\"id\":\"batt_019659b9dffc7b3487132be6982ea17c\",\"usage\":\"internal_prod\",\"team_id\":\"batt_019659b9dff07592bd45cc718aa943d3\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"D-ndnMiGQgU-0bZriyEgXV1-A6n9iSabfT8BFq8tyoc\",\"kty\":\"EC\",\"x\":\"TQHS0J50eyP9YllyR7HmryNMHtvIRmSr8VzrXPPVx40\",\"y\":\"pjGZrKmKJrtrE9xyY-bn5KRZBOtt7C_X2d0JAuHautM\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"aws\",\"slug\":\"int-prod\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
-        "int-test.install.json": "{\"id\":\"batt_019659b9dffc76d7ad66c222efa61ba4\",\"usage\":\"internal_int_test\",\"team_id\":\"batt_019659b9dff07592bd45cc718aa943d3\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"vavG9nM51Kw3GQl5ZWGlO95m1RKDgcftDx6mREaVuF4\",\"kty\":\"EC\",\"x\":\"SssJFK6v45E_pF49lZVN0Qj_bHdOpjPQuR_B_3ZyOgg\",\"y\":\"ymTXmwu65htyjPEtjDKif3ZigQYX4rUHxeWwwrqQnks\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"int-test\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
-        "jason.install.json": "{\"id\":\"batt_019659b9dffc70c69d1731304024252b\",\"usage\":\"development\",\"team_id\":\"batt_019659b9dff07592bd45cc718aa943d3\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"GJ8RltiD84rDqE3JRmptVeGvSVlP2MwY_lCzxzxboBE\",\"kty\":\"EC\",\"x\":\"AOVH7PncbTZ7foYKNNbINQYZKl90CqSd9aXmHQEVqzM\",\"y\":\"7yXySoSgVbTXY7K7Zfj9_JgVp3nkmguRt9BYRVtM9E4\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"aws\",\"slug\":\"jason\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
-        "local.install.json": "{\"id\":\"batt_019659b9dffc7e7e9e998fc3644f638a\",\"usage\":\"development\",\"team_id\":\"batt_019659b9dff07592bd45cc718aa943d3\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"UuuSya_hv1tAV7-ylOoJIi66lv8vOaglpbVGBA_fIgw\",\"kty\":\"EC\",\"x\":\"8s2nVDLphoxY7hNnVogl6JQRxC3eo_LH5XWHtjxoXgQ\",\"y\":\"oy7xkBpUY9fjcMP_lOKguG8pQ_VumWUnQnFS0zmXtWI\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"local\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}"
+        "batt_019687ec7c0e766fb039570bb2d0e6af.team.json": "{\"id\":\"batt_019687ec7c0e766fb039570bb2d0e6af\",\"name\":\"Batteries Included Team\",\"inserted_at\":null,\"updated_at\":null,\"op_email\":\"elliott@batteriesincl.com\",\"deleted_at\":null}",
+        "dev.install.json": "{\"id\":\"batt_019687ec7c117059bc7406b8d1ffaa67\",\"usage\":\"internal_dev\",\"team_id\":\"batt_019687ec7c0e766fb039570bb2d0e6af\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"HCvYLw4HaZWRbMdhiNMqGU_Bz8HOIZZuVnlkp0OR_Eg\",\"kty\":\"EC\",\"x\":\"5fUxr4dZ5hgPwpd9HK_RazwBu4-k9XoXacULNme1EKw\",\"y\":\"JotnuhiuPSVin19n6oxAAIZGnpYk0pmoC5SSFowl87E\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"dev\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
+        "int-prod.install.json": "{\"id\":\"batt_019687ec7c2272d5993331c4f100e534\",\"usage\":\"internal_prod\",\"team_id\":\"batt_019687ec7c0e766fb039570bb2d0e6af\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"DvWtSZMNATqFlidH1v6HFkTM9kS8Rg4BFBAe1RRps48\",\"kty\":\"EC\",\"x\":\"mxnYgHdOg1EYmZ9ZlBOzng4toanqYUyibRvgp3lcrVY\",\"y\":\"MsvYmXNPJlVj39uJ3xpKs-sJy1SzhboHz8AzVEsZ8k4\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"aws\",\"slug\":\"int-prod\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
+        "int-test.install.json": "{\"id\":\"batt_019687ec7c227f49a6ed7dec216fe557\",\"usage\":\"internal_int_test\",\"team_id\":\"batt_019687ec7c0e766fb039570bb2d0e6af\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"lgCAsTw8g0dxXtAmb9NXvinvRd2HLsIRSrYp1DjSqAk\",\"kty\":\"EC\",\"x\":\"h49rjJhPOHNRDmz--TeU7OBoxqPvO8-LTxIk8s9fcrs\",\"y\":\"SqbNVE8M-QMKA0FLXm8GcUY4c9gCYfreD1MIYCa4mRU\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"int-test\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
+        "jason.install.json": "{\"id\":\"batt_019687ec7c2275b4847728cb182663f2\",\"usage\":\"development\",\"team_id\":\"batt_019687ec7c0e766fb039570bb2d0e6af\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"yO337O2hWChA3Ch68tRqa9TczZ3mxnihYRA98xZq1Z4\",\"kty\":\"EC\",\"x\":\"IWOdxidK1rCK3q9tHXe-4kKH-Yeqi5neOqp_sWHE0Bg\",\"y\":\"p4zyYjmZmfjcZ-VwnR3EiwzpG78oQ7Xt4VVjtehnjos\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"aws\",\"slug\":\"jason\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
+        "local.install.json": "{\"id\":\"batt_019687ec7c227626961850304f0d042e\",\"usage\":\"development\",\"team_id\":\"batt_019687ec7c0e766fb039570bb2d0e6af\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"Ro9gLjs72E5sYZz0NboG_N0TgvTWfgPt3CgyxAt8pWs\",\"kty\":\"EC\",\"x\":\"B_UbWMokjz-tEkbGyrsSwADXQuIhk6KgwAVFmMVeL-M\",\"y\":\"RBbNUOsSgFBZwFiLidG4YQJT02Gl3f7arkMfGK9iSdU\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"local\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}"
       },
       "kind": "ConfigMap",
       "metadata": {
         "annotations": {
-          "battery/hash": "6Y7VY7BNPY6N3XPXWW6Z7FN3DWRNCT6EH2U4JCVNDMFS65TA6EOA===="
+          "battery/hash": "74ZJSHAD52OA3K7ZEJGLJXWPJFFC3OLM7JTVXVLBOOWC7Y3Z43QQ===="
         },
         "labels": {
           "app": "traditional-services",
@@ -754,7 +754,7 @@
           "battery/delete-after": "PT45M",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_019659b9e0027516a163ea5430a49838",
+          "battery/owner": "batt_019687ec7c2b7aa3a408cf519611df08",
           "version": "latest"
         },
         "name": "home-base-seed-data",
@@ -766,7 +766,7 @@
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "47RSOYTAFDBGHBE2JVCLG6AKTN2BBA3YPGD7SZLMCBCWDXFJQ4KA===="
+          "battery/hash": "GIUEHTFCQGNX5EQWJT2AC5W4IAXPTEVFZCVX5ISQAHJ5NC5QEGDQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -776,7 +776,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_019659b9e00271e4b35f83f6a7a216a7",
+          "battery/owner": "batt_019687ec7c2b773083f40f00cc49fcdf",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -800,7 +800,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_019659b9e00271e4b35f83f6a7a216a7",
+              "battery/owner": "batt_019687ec7c2b773083f40f00cc49fcdf",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -813,7 +813,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "6P7R3KP3ZYUPP7BATM5CVTMQTBJFBYGQCHISY4JK6MZ4VFWBLSLVMX3N43HYB4C5"
+                    "value": "QPNRH3PVNETF3JV7BFT234JCOGPNUEDGLQGLDG3J5EOCHGFZVXJTCSENHEFAUDQY"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -861,7 +861,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "NVLCG5WWOEQTJBVCTCFKPIBMMI3A3ZHUZXI2N4ZW6ZA7W5C2X7CA===="
+          "battery/hash": "43W2Q5Q3ZZJBK3DT6WA4HB43RDB4YAFSDZDC4HPR2YTDY4VO2OMA===="
         },
         "labels": {
           "app": "battery-core",
@@ -871,7 +871,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_019659b9e00271e4b35f83f6a7a216a7",
+          "battery/owner": "batt_019687ec7c2b773083f40f00cc49fcdf",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -883,7 +883,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "H43IWAN2VXLAZ6CR5UMZDNLR3JDN3JNT6PECD2TWLHQFYKUUHS7Q===="
+          "battery/hash": "FHNKXKEVRKYW5KXFQLZEZJUNMV75KBSRMDEXDG5W3NWMHSOWB5CA===="
         },
         "labels": {
           "app": "traditional-services",
@@ -893,7 +893,7 @@
           "battery/app": "traditional-services",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_019659b9e0027516a163ea5430a49838",
+          "battery/owner": "batt_019687ec7c2b7aa3a408cf519611df08",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -905,7 +905,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "FLTGSVAKJXY56S5U5J2BUP6LJG5HUDNZFXFMKCDYVJG2W452KJRA===="
+          "battery/hash": "EQKRJMZ3ZD2DMYPF7ZI5FERR54QHMWUVJXUQGSR3DTYCK3AWTQGQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -915,7 +915,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_019659b9e00271e4b35f83f6a7a216a7",
+          "battery/owner": "batt_019687ec7c2b773083f40f00cc49fcdf",
           "version": "latest"
         },
         "name": "bootstrap",
@@ -928,7 +928,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "RGOZP4LEV7WTSG6TA5ZFIDXNC5KVTRT5TMEXDE6OLT4KQQC4GC7A====",
+          "battery/hash": "PLE3N7VVNCHOBH4Q2E7RRSKNHGO3IY3YPNIHH53J2SJU5QYLI4DQ====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -939,7 +939,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_019659b9e00271e4b35f83f6a7a216a7",
+          "battery/owner": "batt_019687ec7c2b773083f40f00cc49fcdf",
           "version": "latest"
         },
         "name": "gp2"
@@ -954,7 +954,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "AZJPL3FJZ42MQMA2SDODDTKISWC53RAWUCIP5WU444XJTDXSP5SQ====",
+          "battery/hash": "ITTC5XCHIYMZIWKIS2G2RDZCWWBTFLM22VXH46VGQJEIW6YBYTJQ====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -965,7 +965,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_019659b9e00271e4b35f83f6a7a216a7",
+          "battery/owner": "batt_019687ec7c2b773083f40f00cc49fcdf",
           "version": "latest"
         },
         "name": "gp2-90032408"
@@ -985,7 +985,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "DXQVCZQ3T72SZBDN7BVGFBADFJLBJTJ4RD4GHKN74BMQUASW32UQ====",
+          "battery/hash": "YONPOLOU4KJBZDECS5MPH754LZP27DXJJKL3VIRESYW36P3NBLKA====",
           "storageclass.kubernetes.io/is-default-class": "true"
         },
         "labels": {
@@ -996,7 +996,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_019659b9e00271e4b35f83f6a7a216a7",
+          "battery/owner": "batt_019687ec7c2b773083f40f00cc49fcdf",
           "version": "latest"
         },
         "name": "gp3-105457460"

--- a/bootstrap/int-test.install.json
+++ b/bootstrap/int-test.install.json
@@ -1,14 +1,14 @@
 {
-  "id": "batt_019659b9dffc76d7ad66c222efa61ba4",
+  "id": "batt_019687ec7c227f49a6ed7dec216fe557",
   "usage": "internal_int_test",
-  "team_id": "batt_019659b9dff07592bd45cc718aa943d3",
+  "team_id": "batt_019687ec7c0e766fb039570bb2d0e6af",
   "default_size": "tiny",
   "control_jwk": {
     "crv": "P-256",
-    "d": "vavG9nM51Kw3GQl5ZWGlO95m1RKDgcftDx6mREaVuF4",
+    "d": "lgCAsTw8g0dxXtAmb9NXvinvRd2HLsIRSrYp1DjSqAk",
     "kty": "EC",
-    "x": "SssJFK6v45E_pF49lZVN0Qj_bHdOpjPQuR_B_3ZyOgg",
-    "y": "ymTXmwu65htyjPEtjDKif3ZigQYX4rUHxeWwwrqQnks"
+    "x": "h49rjJhPOHNRDmz--TeU7OBoxqPvO8-LTxIk8s9fcrs",
+    "y": "SqbNVE8M-QMKA0FLXm8GcUY4c9gCYfreD1MIYCa4mRU"
   },
   "inserted_at": null,
   "updated_at": null,

--- a/bootstrap/int-test.spec.json
+++ b/bootstrap/int-test.spec.json
@@ -9,7 +9,7 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_019659b9e001750aa04b1514f400ef70",
+        "id": "batt_019687ec7c2a700cbde104f4bb6e58db",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -21,13 +21,13 @@
           "ai_namespace": "battery-ai",
           "default_size": "tiny",
           "cluster_name": "int-test",
-          "install_id": "batt_019659b9dffc76d7ad66c222efa61ba4",
+          "install_id": "batt_019687ec7c227f49a6ed7dec216fe557",
           "control_jwk": {
             "crv": "P-256",
-            "d": "vavG9nM51Kw3GQl5ZWGlO95m1RKDgcftDx6mREaVuF4",
+            "d": "lgCAsTw8g0dxXtAmb9NXvinvRd2HLsIRSrYp1DjSqAk",
             "kty": "EC",
-            "x": "SssJFK6v45E_pF49lZVN0Qj_bHdOpjPQuR_B_3ZyOgg",
-            "y": "ymTXmwu65htyjPEtjDKif3ZigQYX4rUHxeWwwrqQnks"
+            "x": "h49rjJhPOHNRDmz--TeU7OBoxqPvO8-LTxIk8s9fcrs",
+            "y": "SqbNVE8M-QMKA0FLXm8GcUY4c9gCYfreD1MIYCa4mRU"
           },
           "upgrade_days_of_week": [
             true,
@@ -52,7 +52,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_019659b9e0017800909ed3443cfc3dcf",
+        "id": "batt_019687ec7c2a722dbcbd8d566ae5b570",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
@@ -68,20 +68,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_019659b9e001727795d32a3ed3726cc5",
-        "type": "ferretdb",
-        "config": {
-          "type": "ferretdb",
-          "ferretdb_image": "ghcr.io/ferretdb/ferretdb:1.24.0",
-          "ferretdb_image_name_override": null,
-          "ferretdb_image_tag_override": null
-        },
-        "group": "data",
-        "inserted_at": null,
-        "updated_at": null
-      },
-      {
-        "id": "batt_019659b9e0017018a0e49fdfc70d259a",
+        "id": "batt_019687ec7c2a71fd89b8dd588d63da75",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -96,7 +83,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_019659b9e0017a1882e03ae4c72c2a06",
+        "id": "batt_019687ec7c2a723ca2a1e2feb292b170",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -109,7 +96,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_019659b9e00171c197ac216d66ad7976",
+        "id": "batt_019687ec7c2a7f2686e673a5a190026c",
         "type": "metallb",
         "config": {
           "type": "metallb",
@@ -125,17 +112,6 @@
           "frrouting_image_tag_override": null
         },
         "group": "net_sec",
-        "inserted_at": null,
-        "updated_at": null
-      },
-      {
-        "id": "batt_019659b9e001747d8f239228f139dfc1",
-        "type": "traditional_services",
-        "config": {
-          "type": "traditional_services",
-          "namespace": "battery-traditional"
-        },
-        "group": "devtools",
         "inserted_at": null,
         "updated_at": null
       }
@@ -184,7 +160,7 @@
           {
             "version": 2,
             "username": "battery-control-user",
-            "password": "A5SM4LSGD4QCXSY3PHLDZ3Q5"
+            "password": "3JMYRKM2772WWXHPFICRWV2E"
           },
           {
             "version": 1,
@@ -217,7 +193,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "T7IDS5EC7BNDHWQIP5Z73USPFM3USHG62EMOTGYLKNRMTAGEFWIQ===="
+          "battery/hash": "NMJS5B52QJBQC3MCQ5EL7T7PNNFSC4TH3HUQCTWD7PS6KKDY5N6Q===="
         },
         "labels": {
           "app": "battery-core",
@@ -227,7 +203,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_019659b9e001750aa04b1514f400ef70",
+          "battery/owner": "batt_019687ec7c2a700cbde104f4bb6e58db",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -245,43 +221,12 @@
         }
       ]
     },
-    "/config_map/home_base_seed_data": {
-      "apiVersion": "v1",
-      "data": {
-        "batt_019659b9dff07592bd45cc718aa943d3.team.json": "{\"id\":\"batt_019659b9dff07592bd45cc718aa943d3\",\"name\":\"Batteries Included Team\",\"inserted_at\":null,\"updated_at\":null,\"op_email\":\"elliott@batteriesincl.com\",\"deleted_at\":null}",
-        "dev.install.json": "{\"id\":\"batt_019659b9dff272b483b1a0b39f3e2e6c\",\"usage\":\"internal_dev\",\"team_id\":\"batt_019659b9dff07592bd45cc718aa943d3\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"XLYkmzlDC5CexH-dKiUXWNwswpM3pUWxHRYCyshrDew\",\"kty\":\"EC\",\"x\":\"U5OBYfWB9ykJiFhnXK8pMgNNaOTq-ZYPxs1yx6Ap7g4\",\"y\":\"Izs5ZQGTqhTXBs-MWrJq4kDx8k5DyyV0y4ZQHI-L2nM\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"dev\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
-        "int-prod.install.json": "{\"id\":\"batt_019659b9dffc7b3487132be6982ea17c\",\"usage\":\"internal_prod\",\"team_id\":\"batt_019659b9dff07592bd45cc718aa943d3\",\"default_size\":\"medium\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"D-ndnMiGQgU-0bZriyEgXV1-A6n9iSabfT8BFq8tyoc\",\"kty\":\"EC\",\"x\":\"TQHS0J50eyP9YllyR7HmryNMHtvIRmSr8VzrXPPVx40\",\"y\":\"pjGZrKmKJrtrE9xyY-bn5KRZBOtt7C_X2d0JAuHautM\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"aws\",\"slug\":\"int-prod\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
-        "int-test.install.json": "{\"id\":\"batt_019659b9dffc76d7ad66c222efa61ba4\",\"usage\":\"internal_int_test\",\"team_id\":\"batt_019659b9dff07592bd45cc718aa943d3\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"vavG9nM51Kw3GQl5ZWGlO95m1RKDgcftDx6mREaVuF4\",\"kty\":\"EC\",\"x\":\"SssJFK6v45E_pF49lZVN0Qj_bHdOpjPQuR_B_3ZyOgg\",\"y\":\"ymTXmwu65htyjPEtjDKif3ZigQYX4rUHxeWwwrqQnks\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"int-test\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
-        "jason.install.json": "{\"id\":\"batt_019659b9dffc70c69d1731304024252b\",\"usage\":\"development\",\"team_id\":\"batt_019659b9dff07592bd45cc718aa943d3\",\"default_size\":\"small\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"GJ8RltiD84rDqE3JRmptVeGvSVlP2MwY_lCzxzxboBE\",\"kty\":\"EC\",\"x\":\"AOVH7PncbTZ7foYKNNbINQYZKl90CqSd9aXmHQEVqzM\",\"y\":\"7yXySoSgVbTXY7K7Zfj9_JgVp3nkmguRt9BYRVtM9E4\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"aws\",\"slug\":\"jason\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}",
-        "local.install.json": "{\"id\":\"batt_019659b9dffc7e7e9e998fc3644f638a\",\"usage\":\"development\",\"team_id\":\"batt_019659b9dff07592bd45cc718aa943d3\",\"default_size\":\"tiny\",\"control_jwk\":{\"crv\":\"P-256\",\"d\":\"UuuSya_hv1tAV7-ylOoJIi66lv8vOaglpbVGBA_fIgw\",\"kty\":\"EC\",\"x\":\"8s2nVDLphoxY7hNnVogl6JQRxC3eo_LH5XWHtjxoXgQ\",\"y\":\"oy7xkBpUY9fjcMP_lOKguG8pQ_VumWUnQnFS0zmXtWI\"},\"inserted_at\":null,\"updated_at\":null,\"kube_provider\":\"kind\",\"slug\":\"local\",\"kube_provider_config\":{},\"user_id\":null,\"deleted_at\":null}"
-      },
-      "kind": "ConfigMap",
-      "metadata": {
-        "annotations": {
-          "battery/hash": "4QFKQSJJOXR5QDFY7YYU7FLHXFBKFBUSF3NLIRZ67CLPBSUNJXQQ===="
-        },
-        "labels": {
-          "app": "traditional-services",
-          "app.kubernetes.io/managed-by": "batteries-included",
-          "app.kubernetes.io/name": "traditional-services",
-          "app.kubernetes.io/version": "latest",
-          "battery/app": "traditional-services",
-          "battery/delete-after": "PT45M",
-          "battery/managed": "true",
-          "battery/managed.direct": "true",
-          "battery/owner": "batt_019659b9e001747d8f239228f139dfc1",
-          "version": "latest"
-        },
-        "name": "home-base-seed-data",
-        "namespace": "battery-traditional"
-      }
-    },
     "/job/bootstrap": {
       "apiVersion": "batch/v1",
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "2I5Z55G6OGFOPWAG2AGYM5USX2GX2CPHXH4TSRIXOZA2YGOLTV6Q===="
+          "battery/hash": "JDEIP2DPSIJTQ6BSEYIP5SWKTIL2TBC6TQRUWPTFINWEFUNR6KPQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -291,7 +236,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_019659b9e001750aa04b1514f400ef70",
+          "battery/owner": "batt_019687ec7c2a700cbde104f4bb6e58db",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -315,7 +260,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_019659b9e001750aa04b1514f400ef70",
+              "battery/owner": "batt_019687ec7c2a700cbde104f4bb6e58db",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -328,7 +273,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "6UV4E7BGSEHGLJ4NW5NZBWHAJWQ2REGA4TAKKFAJCZ6E3XSKLJVSTT2XGIRMN56D"
+                    "value": "BG3DE7WYAPK6ETP7JE62RGJ42LBYIPCP4J6H4H6UW7CXR7I3OVF56JXNZSNDO5NH"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -376,7 +321,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "U5ZLDMYPNM62HSLXHPXBV73GDIUFN6DNLXYFIJBZ5W5QA52F2REQ===="
+          "battery/hash": "TVUZDT5UP5E5UZLVXAEQNG3ICF7DPFSSSRVJDNQ2IOSS5YTYVSLA===="
         },
         "labels": {
           "app": "battery-core",
@@ -386,33 +331,11 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_019659b9e001750aa04b1514f400ef70",
+          "battery/owner": "batt_019687ec7c2a700cbde104f4bb6e58db",
           "istio-injection": "enabled",
           "version": "latest"
         },
         "name": "battery-core"
-      }
-    },
-    "/namespace/battery_traditional": {
-      "apiVersion": "v1",
-      "kind": "Namespace",
-      "metadata": {
-        "annotations": {
-          "battery/hash": "XJQCM5DDRMONIEFI7CD6GTHXD7CMZMGOVH3HIMZGOJ2NM533ZLPQ===="
-        },
-        "labels": {
-          "app": "traditional-services",
-          "app.kubernetes.io/managed-by": "batteries-included",
-          "app.kubernetes.io/name": "traditional-services",
-          "app.kubernetes.io/version": "latest",
-          "battery/app": "traditional-services",
-          "battery/managed": "true",
-          "battery/managed.direct": "true",
-          "battery/owner": "batt_019659b9e001747d8f239228f139dfc1",
-          "istio-injection": "enabled",
-          "version": "latest"
-        },
-        "name": "battery-traditional"
       }
     },
     "/service_account/bootstrap": {
@@ -420,7 +343,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "QLLDQC7A2RGC6SKQBHXU762TZQ2UTCXQ2X4HCVZTHXFTZCXCRSKA===="
+          "battery/hash": "FO7X3MXBPVXVB2V4ENCT4CV44AS2HVM5ZNNXWIUWK2UFD25AFPWA===="
         },
         "labels": {
           "app": "battery-core",
@@ -430,7 +353,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_019659b9e001750aa04b1514f400ef70",
+          "battery/owner": "batt_019687ec7c2a700cbde104f4bb6e58db",
           "version": "latest"
         },
         "name": "bootstrap",

--- a/bootstrap/jason.install.json
+++ b/bootstrap/jason.install.json
@@ -1,14 +1,14 @@
 {
-  "id": "batt_019659b9dffc70c69d1731304024252b",
+  "id": "batt_019687ec7c2275b4847728cb182663f2",
   "usage": "development",
-  "team_id": "batt_019659b9dff07592bd45cc718aa943d3",
+  "team_id": "batt_019687ec7c0e766fb039570bb2d0e6af",
   "default_size": "small",
   "control_jwk": {
     "crv": "P-256",
-    "d": "GJ8RltiD84rDqE3JRmptVeGvSVlP2MwY_lCzxzxboBE",
+    "d": "yO337O2hWChA3Ch68tRqa9TczZ3mxnihYRA98xZq1Z4",
     "kty": "EC",
-    "x": "AOVH7PncbTZ7foYKNNbINQYZKl90CqSd9aXmHQEVqzM",
-    "y": "7yXySoSgVbTXY7K7Zfj9_JgVp3nkmguRt9BYRVtM9E4"
+    "x": "IWOdxidK1rCK3q9tHXe-4kKH-Yeqi5neOqp_sWHE0Bg",
+    "y": "p4zyYjmZmfjcZ-VwnR3EiwzpG78oQ7Xt4VVjtehnjos"
   },
   "inserted_at": null,
   "updated_at": null,

--- a/bootstrap/jason.spec.json
+++ b/bootstrap/jason.spec.json
@@ -9,7 +9,7 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_019659b9e0037ef2ae6d8c9466361767",
+        "id": "batt_019687ec7c2e7b7893cc639318f01277",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -21,13 +21,13 @@
           "ai_namespace": "battery-ai",
           "default_size": "small",
           "cluster_name": "jason",
-          "install_id": "batt_019659b9dffc70c69d1731304024252b",
+          "install_id": "batt_019687ec7c2275b4847728cb182663f2",
           "control_jwk": {
             "crv": "P-256",
-            "d": "GJ8RltiD84rDqE3JRmptVeGvSVlP2MwY_lCzxzxboBE",
+            "d": "yO337O2hWChA3Ch68tRqa9TczZ3mxnihYRA98xZq1Z4",
             "kty": "EC",
-            "x": "AOVH7PncbTZ7foYKNNbINQYZKl90CqSd9aXmHQEVqzM",
-            "y": "7yXySoSgVbTXY7K7Zfj9_JgVp3nkmguRt9BYRVtM9E4"
+            "x": "IWOdxidK1rCK3q9tHXe-4kKH-Yeqi5neOqp_sWHE0Bg",
+            "y": "p4zyYjmZmfjcZ-VwnR3EiwzpG78oQ7Xt4VVjtehnjos"
           },
           "upgrade_days_of_week": [
             true,
@@ -52,7 +52,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_019659b9e0037ea4b3b9d0e73974305f",
+        "id": "batt_019687ec7c2e7bc098f56faefbc46d52",
         "type": "cert_manager",
         "config": {
           "type": "cert_manager",
@@ -78,7 +78,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_019659b9e0037af8a537040da0d78831",
+        "id": "batt_019687ec7c2e7c04a38a2d0d398322a7",
         "type": "battery_ca",
         "config": {
           "type": "battery_ca"
@@ -88,7 +88,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_019659b9e003788c84e70a654f6cd3c4",
+        "id": "batt_019687ec7c2e7998b6351346596a89d2",
         "type": "karpenter",
         "config": {
           "type": "karpenter",
@@ -108,7 +108,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_019659b9e0037bf287c0ef5b121e0854",
+        "id": "batt_019687ec7c2e744fbf8e032d9f6826ea",
         "type": "aws_load_balancer_controller",
         "config": {
           "type": "aws_load_balancer_controller",
@@ -124,7 +124,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_019659b9e003713a8b5762506eeeb1c7",
+        "id": "batt_019687ec7c2e7e5ebe331568b744b972",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
@@ -140,7 +140,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_019659b9e00371278c7c90592e97d406",
+        "id": "batt_019687ec7c2e7cff8a43559cf42fe4a4",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -155,7 +155,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_019659b9e003788b8ed295fc21dc6599",
+        "id": "batt_019687ec7c2e7a06af4c4349ca220865",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -168,7 +168,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_019659b9e003762eaa97b982ea5139a7",
+        "id": "batt_019687ec7c2e799481c8219e7718940b",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -213,7 +213,7 @@
           {
             "version": 1,
             "username": "battery-control-user",
-            "password": "H4MGKTBR6SXZXCX3DK53IQNZ"
+            "password": "WH65HD2Z65QJ3QPQTKEKNCNX"
           }
         ],
         "cpu_requested": 500,
@@ -241,7 +241,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "JAYC43F4Z6JZ2LXC2CEQ7YAEBXIYVVKZLLTOJIJI4PWNIWEQKZZQ===="
+          "battery/hash": "FQOIT7MVRLFADT3DFVZZ5FED37SBV3G2PBIEEBASIBT5FOJDE6LQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -251,7 +251,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_019659b9e0037ef2ae6d8c9466361767",
+          "battery/owner": "batt_019687ec7c2e7b7893cc639318f01277",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -274,7 +274,7 @@
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "IVD6K5C4LOQNM26XXWPLWATJWRP3VPJJPBEOONGEKN3IGRKQJWQQ===="
+          "battery/hash": "ATOEKOILJNFW6KGUULNULCSO76YZHJQRN5BBXM3AA6MNSEFQGGFQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -284,7 +284,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_019659b9e0037ef2ae6d8c9466361767",
+          "battery/owner": "batt_019687ec7c2e7b7893cc639318f01277",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -308,7 +308,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_019659b9e0037ef2ae6d8c9466361767",
+              "battery/owner": "batt_019687ec7c2e7b7893cc639318f01277",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -321,7 +321,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "MVPB5TS2RFJE7UMSRSD6AYUZRIBEQ7RP76AFAFYFE6ONKPVZ7WENN3F5AT6UXKAK"
+                    "value": "J6BK3GBZ6HNYFUBDO4WELTEJTMLDYRXYEXCK33JNJE52RUK46DN2JOMSFGT2GQMF"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -369,7 +369,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "KPPUJBJCTSESE4MPGE6KE4GQVJMOR7CDCFI35XJRSMMDTG4VEFBA===="
+          "battery/hash": "UJDLY6HP2NSSKIXC342N43SSOPR3C5ZQWJEC6GYSZMEPWPIPTUIQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -379,7 +379,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_019659b9e0037ef2ae6d8c9466361767",
+          "battery/owner": "batt_019687ec7c2e7b7893cc639318f01277",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -391,7 +391,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "Q3MBR56JX3WQE6SLF6JGKZNK5D5GQ56TR4KBXEXJK7QQHIZ3CVNA===="
+          "battery/hash": "QXAF7PZIQNHYGA44HHM2IERTRW3MR4G3Y3KCXE3LWAH3ZPQO4M6A===="
         },
         "labels": {
           "app": "battery-core",
@@ -401,7 +401,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_019659b9e0037ef2ae6d8c9466361767",
+          "battery/owner": "batt_019687ec7c2e7b7893cc639318f01277",
           "version": "latest"
         },
         "name": "bootstrap",
@@ -414,7 +414,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "3CGFQBMPOBP7EUV35JJPC7N7PLEVVDYP5Z6V7AQ3DY2XA56PNFIA====",
+          "battery/hash": "66BZSKQYQDPUDRQAJV6IMR3XFXRWKPSGVA2Y4LHJXXXT6UQVSL7Q====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -425,7 +425,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_019659b9e0037ef2ae6d8c9466361767",
+          "battery/owner": "batt_019687ec7c2e7b7893cc639318f01277",
           "version": "latest"
         },
         "name": "gp2"
@@ -440,7 +440,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "CV765ECSTPQEGAGPBR5SONZAHTBMS5TDU5KCIGPX6D3HAJDETBTQ====",
+          "battery/hash": "XRUMCA73FUGN2NDQALZP42DOT5ICA4AX2II6R5PFW2TA4NI57ZYQ====",
           "storageclass.kubernetes.io/is-default-class": "false"
         },
         "labels": {
@@ -451,7 +451,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_019659b9e0037ef2ae6d8c9466361767",
+          "battery/owner": "batt_019687ec7c2e7b7893cc639318f01277",
           "version": "latest"
         },
         "name": "gp2-90032408"
@@ -471,7 +471,7 @@
       "kind": "StorageClass",
       "metadata": {
         "annotations": {
-          "battery/hash": "CY2CU5Z2NHJ3VZ5I3Y55IFJIBBWHLU6FWE6D4VYRQ6S4S733C7CQ====",
+          "battery/hash": "2I2EGZN7E3ASEVWG7SIXJRUPNMVPZOYMPVK7HUCTINWJLNLMQIWQ====",
           "storageclass.kubernetes.io/is-default-class": "true"
         },
         "labels": {
@@ -482,7 +482,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_019659b9e0037ef2ae6d8c9466361767",
+          "battery/owner": "batt_019687ec7c2e7b7893cc639318f01277",
           "version": "latest"
         },
         "name": "gp3-105457460"

--- a/bootstrap/local.install.json
+++ b/bootstrap/local.install.json
@@ -1,14 +1,14 @@
 {
-  "id": "batt_019659b9dffc7e7e9e998fc3644f638a",
+  "id": "batt_019687ec7c227626961850304f0d042e",
   "usage": "development",
-  "team_id": "batt_019659b9dff07592bd45cc718aa943d3",
+  "team_id": "batt_019687ec7c0e766fb039570bb2d0e6af",
   "default_size": "tiny",
   "control_jwk": {
     "crv": "P-256",
-    "d": "UuuSya_hv1tAV7-ylOoJIi66lv8vOaglpbVGBA_fIgw",
+    "d": "Ro9gLjs72E5sYZz0NboG_N0TgvTWfgPt3CgyxAt8pWs",
     "kty": "EC",
-    "x": "8s2nVDLphoxY7hNnVogl6JQRxC3eo_LH5XWHtjxoXgQ",
-    "y": "oy7xkBpUY9fjcMP_lOKguG8pQ_VumWUnQnFS0zmXtWI"
+    "x": "B_UbWMokjz-tEkbGyrsSwADXQuIhk6KgwAVFmMVeL-M",
+    "y": "RBbNUOsSgFBZwFiLidG4YQJT02Gl3f7arkMfGK9iSdU"
   },
   "inserted_at": null,
   "updated_at": null,

--- a/bootstrap/local.spec.json
+++ b/bootstrap/local.spec.json
@@ -9,7 +9,7 @@
     "notebooks": [],
     "batteries": [
       {
-        "id": "batt_019659b9e0037410a2c5873175728277",
+        "id": "batt_019687ec7c2d7979a3c6164a04cdb645",
         "type": "istio",
         "config": {
           "type": "istio",
@@ -24,7 +24,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_019659b9e00378b0999f1201b141c7fa",
+        "id": "batt_019687ec7c2d7b76847304fb474b9d1f",
         "type": "istio_gateway",
         "config": {
           "type": "istio_gateway",
@@ -37,7 +37,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_019659b9e00371e78a4d2f08e40288ee",
+        "id": "batt_019687ec7c2d7b3d8a750d9a5d7b1396",
         "type": "battery_core",
         "config": {
           "type": "battery_core",
@@ -49,13 +49,13 @@
           "ai_namespace": "battery-ai",
           "default_size": "tiny",
           "cluster_name": "local",
-          "install_id": "batt_019659b9dffc7e7e9e998fc3644f638a",
+          "install_id": "batt_019687ec7c227626961850304f0d042e",
           "control_jwk": {
             "crv": "P-256",
-            "d": "UuuSya_hv1tAV7-ylOoJIi66lv8vOaglpbVGBA_fIgw",
+            "d": "Ro9gLjs72E5sYZz0NboG_N0TgvTWfgPt3CgyxAt8pWs",
             "kty": "EC",
-            "x": "8s2nVDLphoxY7hNnVogl6JQRxC3eo_LH5XWHtjxoXgQ",
-            "y": "oy7xkBpUY9fjcMP_lOKguG8pQ_VumWUnQnFS0zmXtWI"
+            "x": "B_UbWMokjz-tEkbGyrsSwADXQuIhk6KgwAVFmMVeL-M",
+            "y": "RBbNUOsSgFBZwFiLidG4YQJT02Gl3f7arkMfGK9iSdU"
           },
           "upgrade_days_of_week": [
             true,
@@ -80,7 +80,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_019659b9e0037e5ebcb78ed71d2ef5eb",
+        "id": "batt_019687ec7c2d73a387337ab7a7a6d312",
         "type": "metallb",
         "config": {
           "type": "metallb",
@@ -100,7 +100,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_019659b9e0037ff086ec95596927a1ba",
+        "id": "batt_019687ec7c2d76ecaf52c683bb494984",
         "type": "cloudnative_pg",
         "config": {
           "type": "cloudnative_pg",
@@ -116,7 +116,7 @@
         "updated_at": null
       },
       {
-        "id": "batt_019659b9e0037a67be17506f5d4c5d09",
+        "id": "batt_019687ec7c2d79bf9d83f544c0f87537",
         "type": "stale_resource_cleaner",
         "config": {
           "type": "stale_resource_cleaner",
@@ -161,7 +161,7 @@
           {
             "version": 1,
             "username": "battery-control-user",
-            "password": "ETR5UUV3XQMRR7RCR7Y4DFU5"
+            "password": "YO5VFMRHCNSTMVSJARLF5G5M"
           }
         ],
         "cpu_requested": 500,
@@ -189,7 +189,7 @@
       "kind": "ClusterRoleBinding",
       "metadata": {
         "annotations": {
-          "battery/hash": "QSDKYFOO3IFVUIIPNTDDE2XO5Z27EF5HIWKCRF3ZEDHKG2TJN2AQ===="
+          "battery/hash": "RMKNXNRVKTX2GRJKIHLPLSUYMDR3WUOU3OBLMXFZWX7BCO2GEHBA===="
         },
         "labels": {
           "app": "battery-core",
@@ -199,7 +199,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_019659b9e00371e78a4d2f08e40288ee",
+          "battery/owner": "batt_019687ec7c2d7b3d8a750d9a5d7b1396",
           "version": "latest"
         },
         "name": "batteries-included:bootstrap"
@@ -222,7 +222,7 @@
       "kind": "Job",
       "metadata": {
         "annotations": {
-          "battery/hash": "NKCGK3K4IWZIYHQIMXD42EDECHZNMEVD3EDE3LDGEAALO2XCGHVA===="
+          "battery/hash": "FO5APOCC7UDXVLYWOBM4BQ3SOWFVFGKBC7EL2OLR4IFNDH36F3IA===="
         },
         "labels": {
           "app": "battery-core",
@@ -232,7 +232,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_019659b9e00371e78a4d2f08e40288ee",
+          "battery/owner": "batt_019687ec7c2d7b3d8a750d9a5d7b1396",
           "sidecar.istio.io/inject": "false",
           "version": "latest"
         },
@@ -256,7 +256,7 @@
               "battery/component": "bootstrap",
               "battery/managed": "true",
               "battery/managed.indirect": "true",
-              "battery/owner": "batt_019659b9e00371e78a4d2f08e40288ee",
+              "battery/owner": "batt_019687ec7c2d7b3d8a750d9a5d7b1396",
               "component": "bootstrap",
               "sidecar.istio.io/inject": "false",
               "version": "latest"
@@ -269,7 +269,7 @@
                 "env": [
                   {
                     "name": "RELEASE_COOKIE",
-                    "value": "4XB4IOCACR7EJ3MHPDBDPTABEB4MK2SXNO5X6DWXUJ3DBWU6F4EVH5TAOXM5RKW3"
+                    "value": "Z46TYGIOHP6F2WXXKM4N4RQMG3UEB65BGF3ZJXJ3TYBNXGTMEH7VSE5B6F27ADQ7"
                   },
                   {
                     "name": "RELEASE_DISTRIBUTION",
@@ -317,7 +317,7 @@
       "kind": "Namespace",
       "metadata": {
         "annotations": {
-          "battery/hash": "H4SUNCWRJC5YELJ23RH5S44UWZ2BSTFK2NW24C45FRU47WELZBXQ===="
+          "battery/hash": "F2BPLRCFLM5KHSFY65BGSJZRIT56I4MD44UYEGGDXZBFCIV4KTEQ===="
         },
         "labels": {
           "app": "battery-core",
@@ -327,7 +327,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_019659b9e00371e78a4d2f08e40288ee",
+          "battery/owner": "batt_019687ec7c2d7b3d8a750d9a5d7b1396",
           "istio-injection": "enabled",
           "version": "latest"
         },
@@ -339,7 +339,7 @@
       "kind": "ServiceAccount",
       "metadata": {
         "annotations": {
-          "battery/hash": "NBZ4RFYSZLLRYB4CMUVCRNQ6GGA5BZ7LTJHRISAEKIAGNXLL5MEQ===="
+          "battery/hash": "U5O5MGZX6QF46WA7ITFCRDE37O2RXP34A2J42LATY6NQG2WKTF6Q===="
         },
         "labels": {
           "app": "battery-core",
@@ -349,7 +349,7 @@
           "battery/app": "battery-core",
           "battery/managed": "true",
           "battery/managed.direct": "true",
-          "battery/owner": "batt_019659b9e00371e78a4d2f08e40288ee",
+          "battery/owner": "batt_019687ec7c2d7b3d8a750d9a5d7b1396",
           "version": "latest"
         },
         "name": "bootstrap",

--- a/bootstrap/team.json
+++ b/bootstrap/team.json
@@ -1,5 +1,5 @@
 {
-  "id": "batt_019659b9dff07592bd45cc718aa943d3",
+  "id": "batt_019687ec7c0e766fb039570bb2d0e6af",
   "name": "Batteries Included Team",
   "inserted_at": null,
   "updated_at": null,


### PR DESCRIPTION
We removed redis and ferretdb from int-test so re-gen without those.