### PR TITLE
fix(bi): don't install unneeded plugins

### DIFF
--- a/bi/cmd/aws/outputs.go
+++ b/bi/cmd/aws/outputs.go
@@ -31,7 +31,7 @@ var outputsCmd = &cobra.Command{
 			return err
 		}
 
-		p := cluster.NewPulumiProvider(env.Spec.Slug)
+		p := cluster.NewPulumiProvider(env.Spec)
 
 		ctx := cmd.Context()
 

--- a/bi/pkg/installs/env.go
+++ b/bi/pkg/installs/env.go
@@ -58,7 +58,7 @@ func (env *InstallEnv) init(ctx context.Context) error {
 		gatewayEnabled := needsLocalGateway && (dockerDesktop || podman)
 		env.clusterProvider = kind.NewClusterProvider(slog.Default(), env.Slug, gatewayEnabled)
 	case "aws":
-		env.clusterProvider = cluster.NewPulumiProvider(env.Slug)
+		env.clusterProvider = cluster.NewPulumiProvider(env.Spec)
 	case "provided":
 	default:
 		return fmt.Errorf("unknown provider: %s", provider)

--- a/bi/pkg/specs/battery_spec.go
+++ b/bi/pkg/specs/battery_spec.go
@@ -25,10 +25,19 @@ func (s *InstallSpec) GetBatteryConfigField(typ, field string) (any, error) {
 	}
 	return cfg, nil
 }
+
 func (s *InstallSpec) GetCoreNamespace() (string, error) {
 	ns, err := s.GetBatteryConfigField("battery_core", "core_namespace")
 	if err != nil {
 		return "", err
 	}
 	return ns.(string), nil
+}
+
+func (s *InstallSpec) GetCoreUsage() (string, error) {
+	usage, err := s.GetBatteryConfigField("battery_core", "usage")
+	if err != nil {
+		return "", err
+	}
+	return usage.(string), nil
 }

--- a/bi/pkg/specs/local_gateway.go
+++ b/bi/pkg/specs/local_gateway.go
@@ -3,9 +3,9 @@ package specs
 import "strings"
 
 func (spec *InstallSpec) NeedsLocalGateway() (bool, error) {
-	usage, err := spec.GetBatteryConfigField("battery_core", "usage")
+	usage, err := spec.GetCoreUsage()
 	if err != nil {
 		return false, err
 	}
-	return spec.KubeCluster.Provider == "kind" && !strings.HasPrefix(usage.(string), "internal"), nil
+	return spec.KubeCluster.Provider == "kind" && !strings.HasPrefix(usage, "internal"), nil
 }

--- a/bi/pkg/specs/print.go
+++ b/bi/pkg/specs/print.go
@@ -11,13 +11,13 @@ import (
 func (spec *InstallSpec) PrintAccessInfo(ctx context.Context, kubeClient kube.KubeClient, slug string) error {
 	// Print the control server URL
 	// This should only be called after `WaitForBootstrap`
-	usage, err := spec.GetBatteryConfigField("battery_core", "usage")
+	usage, err := spec.GetCoreUsage()
 	if err != nil {
 		return fmt.Errorf("failed to determine if control server is running in cluster: %w", err)
 	}
 
 	// If we're running in dev mode then assume the control server will be run via `bix dev`
-	if usage.(string) == "internal_dev" {
+	if usage == "internal_dev" {
 		slog.Debug("Control server is not running in cluster")
 		return nil
 	}

--- a/bi/pkg/specs/wait.go
+++ b/bi/pkg/specs/wait.go
@@ -21,13 +21,13 @@ import (
 type testFn[T any] func(convertedAPIObject *T) (done bool, err error)
 
 func (spec *InstallSpec) WaitForBootstrap(ctx context.Context, kubeClient kube.KubeClient) error {
-	usage, err := spec.GetBatteryConfigField("battery_core", "usage")
+	usage, err := spec.GetCoreUsage()
 	if err != nil {
 		return fmt.Errorf("failed to determine if control server is running in cluster: %w", err)
 	}
 
 	// no need to wait for anything else if the control server isn't running in cluster
-	if usage.(string) == "internal_dev" {
+	if usage == "internal_dev" {
 		slog.Debug("control server not running in cluster, skipping wait")
 		return nil
 	}

--- a/bi/pkg/specs/write_summary.go
+++ b/bi/pkg/specs/write_summary.go
@@ -30,7 +30,7 @@ func (spec *InstallSpec) WriteSummaryToKube(ctx context.Context, kubeClient kube
 		return fmt.Errorf("unable to marshal state summary: %w", err)
 	}
 
-	ns, err := spec.GetBatteryConfigField("battery_core", "core_namespace")
+	ns, err := spec.GetCoreNamespace()
 	if err != nil {
 		return fmt.Errorf("unable to find namespace: %w", err)
 	}


### PR DESCRIPTION
pulumi will install the needed plugins without us needing to keep them in sync.

Address some other `TODO`s while I was in there.