### PR TITLE
ci: fix random naming issue

### DIFF
--- a/platform_umbrella/apps/verify/test/postgres_test.exs
+++ b/platform_umbrella/apps/verify/test/postgres_test.exs
@@ -3,17 +3,13 @@ defmodule Verify.PostgresTest do
 
   @new_postgres_path "/postgres/new"
   @new_postgres_header h3("New Postgres Cluster")
-  @save_button Query.button("Save")
 
   verify "can start a postgres cluster", %{session: session} do
-    cluster_name = "int-test-#{:rand.uniform(10_000)}"
+    cluster_name =
+      "int-test-#{:rand.uniform(10_000)}"
 
     session
-    # create new cluster
-    |> visit(@new_postgres_path)
-    |> assert_has(@new_postgres_header)
-    |> fill_in(Query.text_field("cluster[name]"), with: cluster_name)
-    |> click(@save_button)
+    |> create_pg_cluster(cluster_name)
     # verify show page
     |> assert_has(h3("Postgres Cluster", minimum: 1))
     |> assert_has(h3(cluster_name))

--- a/platform_umbrella/apps/verify/test/redis_test.exs
+++ b/platform_umbrella/apps/verify/test/redis_test.exs
@@ -3,7 +3,7 @@ defmodule Verify.RedisTest do
 
   @new_path "/redis/new"
   @new_redis_header h3("New Redis Instance")
-  @name_field Query.text_field("redis_instance[name]")
+  @name_field "redis_instance[name]"
   @save_button Query.button("Save Redis")
   @size_select Query.select("Size")
   @type_select Query.select("Type")
@@ -15,7 +15,7 @@ defmodule Verify.RedisTest do
     # create new instance
     |> visit(@new_path)
     |> assert_has(@new_redis_header)
-    |> fill_in(@name_field, with: instance_name)
+    |> fill_in_name(@name_field, instance_name)
     |> click(@save_button)
     # verify show page
     |> assert_has(h3(instance_name))
@@ -48,7 +48,7 @@ defmodule Verify.RedisTest do
     # create new
     |> visit(@new_path)
     |> assert_has(@new_redis_header)
-    |> fill_in(@name_field, with: instance_name)
+    |> fill_in_name(@name_field, instance_name)
     |> find(@type_select, fn select ->
       click(select, Query.option("Cluster"))
     end)
@@ -73,7 +73,7 @@ defmodule Verify.RedisTest do
     # create new
     |> visit(@new_path)
     |> assert_has(@new_redis_header)
-    |> fill_in(@name_field, with: instance_name)
+    |> fill_in_name(@name_field, instance_name)
     |> find(@type_select, fn select ->
       click(select, Query.option("Replication"))
     end)

--- a/platform_umbrella/apps/verify/test/support/helpers.ex
+++ b/platform_umbrella/apps/verify/test/support/helpers.ex
@@ -94,4 +94,19 @@ defmodule Verify.TestCase.Helpers do
       |> assert_has(table_row(text: "Running", count: 1))
     end)
   end
+
+  def create_pg_cluster(session, cluster_name) do
+    session
+    # create new cluster
+    |> visit("/postgres/new")
+    |> assert_has(h3("New Postgres Cluster"))
+    |> fill_in_name("cluster[name]", cluster_name)
+    |> click(Query.button("Save"))
+  end
+
+  def fill_in_name(session, field_name, text_to_fill) do
+    find(session, Query.text_field(field_name), fn e ->
+      Wallaby.Element.send_keys(e, Enum.map(0..100, fn _ -> :backspace end) ++ [text_to_fill])
+    end)
+  end
 end


### PR DESCRIPTION
I figured out why we were having issues with naming.
We auto-generate and re-set the names for e.g. postgres clusters on validation.
When wallaby clears and sets the value, it causes phoenix to reset the name in between clearing and setting. We can use set_value to send 100 backspaces and then the name we want and it works just fine!

This is needed to e.g. pick the postgres cluster for ferretdb.