### PR TITLE
fix(bix): exit gracefully on cleanup

### DIFF
--- a/bin/lib/common-functions.sh
+++ b/bin/lib/common-functions.sh
@@ -92,10 +92,11 @@ try_portforward() {
 }
 
 cleanup() {
+    local code="$?"
     trap - ERR EXIT
     # We're going to be sending SIGTERM to ourselves
     # Handle it gracefully
-    trap 'exit 0' SIGINT SIGTERM
+    trap 'exit "$code"' SIGINT SIGTERM
 
     # We can end up in cleanup from a few different places and colors might not be set
     safe_colors

--- a/bin/lib/common-functions.sh
+++ b/bin/lib/common-functions.sh
@@ -93,6 +93,9 @@ try_portforward() {
 
 cleanup() {
     trap - ERR EXIT
+    # We're going to be sending SIGTERM to ourselves
+    # Handle it gracefully
+    trap 'exit 0' SIGINT SIGTERM
 
     # We can end up in cleanup from a few different places and colors might not be set
     safe_colors


### PR DESCRIPTION
I was focused on fixing the dangling port forward and missed that we're now killing ourselves and leaving a non-zero exit code.

```bash
zsh: terminated  bix m deps.get

 /batteries-included
❌143 ❯ bix m deps.get
```