### PR TITLE
chore: update ferretdb version

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/defaults/images.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/defaults/images.ex
@@ -66,8 +66,8 @@ defmodule CommonCore.Defaults.Images do
     ferretdb:
       Image.new!(%{
         name: "ghcr.io/ferretdb/ferretdb",
-        tags: ~w(1.23.0 1.24.0),
-        default_tag: "1.24.0"
+        tags: ~w(1.23.0 1.24.0 1.24.1),
+        default_tag: "1.24.1"
       }),
     forgejo:
       Image.new!(%{


### PR DESCRIPTION
Description:
- 1.24.1 just dropped as a patch for the 1.x line. This updates to that

Test Plan:
- CI
- Tested locally