### PR TITLE
chore: remove unused cert manager image

### DIFF
--- a/bin/bi-source
+++ b/bin/bi-source
@@ -115,7 +115,7 @@ check_format_npm_code() {
 do_fmt() {
     local type="${1:-""}"
     case "$type" in
-    mix | elixir)
+    mix | elixir | ex)
         log "Formatting ${YELLOW}mix${NOFORMAT}"
         format_mix_code "platform_umbrella"
         ;;
@@ -156,7 +156,7 @@ do_fmt() {
 do_check_fmt() {
     local type="${1:-""}"
     case "$type" in
-    mix | elixir)
+    mix | elixir | ex)
         log "Checking format ${YELLOW}mix${NOFORMAT}"
         check_format_mix_code "platform_umbrella"
         ;;

--- a/image_registry.yaml
+++ b/image_registry.yaml
@@ -49,13 +49,6 @@ cert_manager_controller:
     - v1.15.1
     - v1.15.4
     - v1.16.4
-cert_manager_ctl:
-  default_tag: v1.16.4
-  name: quay.io/jetstack/cert-manager-ctl
-  tags:
-    - v1.15.1
-    - v1.15.4
-    - v1.16.4
 cert_manager_webhook:
   default_tag: v1.16.4
   name: quay.io/jetstack/cert-manager-webhook

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/cert_manager_config.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/cert_manager_config.ex
@@ -3,13 +3,21 @@ defmodule CommonCore.Batteries.CertManagerConfig do
 
   use CommonCore, :embedded_schema
 
+  alias CommonCore.Ecto.Schema
+
   batt_polymorphic_schema type: :cert_manager do
     defaultable_image_field :acmesolver_image, image_id: :cert_manager_acmesolver
     defaultable_image_field :cainjector_image, image_id: :cert_manager_cainjector
     defaultable_image_field :controller_image, image_id: :cert_manager_controller
-    defaultable_image_field :ctl_image, image_id: :cert_manager_ctl
     defaultable_image_field :webhook_image, image_id: :cert_manager_webhook
 
     field :email, :string
+  end
+
+  @ctl_keys_to_drop ~w(ctl_image ctl_image_name_override ctl_image_tag_override)a
+  def load(data) do
+    data
+    |> Map.drop(@ctl_keys_to_drop ++ Enum.map(@ctl_keys_to_drop, &Atom.to_string/1))
+    |> then(&Schema.schema_load(__MODULE__, &1))
   end
 end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/batteries/cert_manager_form.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/batteries/cert_manager_form.ex
@@ -27,7 +27,6 @@ defmodule ControlServerWeb.Batteries.CertManagerForm do
             {@form[:acmesolver_image].value}<br />
             {@form[:cainjector_image].value}<br />
             {@form[:controller_image].value}<br />
-            {@form[:ctl_image].value}<br />
             {@form[:webhook_image].value}
           </.image>
 
@@ -47,12 +46,6 @@ defmodule ControlServerWeb.Batteries.CertManagerForm do
             field={@form[:controller_image_tag_override]}
             image_id={:cert_manager_controller}
             label="Controller Version"
-          />
-
-          <.image_version
-            field={@form[:ctl_image_tag_override]}
-            image_id={:cert_manager_ctl}
-            label="CTL Version"
           />
 
           <.image_version


### PR DESCRIPTION
The `cert_manager_ctl` image went away after 1.14.x and we haven't used it since then either.