### PR TITLE
fix: use pre tags to allow copying with no extra spaces

### DIFF
--- a/platform_umbrella/apps/common_ui/lib/common_ui/components/script.ex
+++ b/platform_umbrella/apps/common_ui/lib/common_ui/components/script.ex
@@ -29,7 +29,7 @@ defmodule CommonUI.Components.Script do
     >
       <div class="relative flex-1 h-full">
         <div class="flex items-center absolute inset-0 whitespace-nowrap overflow-auto px-5">
-          <span id={@id}>{String.replace(@template, "@src", @src)}</span>
+          <pre id={@id}>{String.replace(@template, "@src", @src)}</pre>
         </div>
       </div>
 

--- a/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/script_test/test_default_script_component.heyya_snap
+++ b/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/script_test/test_default_script_component.heyya_snap
@@ -1,7 +1,7 @@
 <div class="relative flex items-center rounded-lg overflow-hidden h-14 bg-gray-darkest-tint text-white text-lg tracking-tighter font-mono font-bold ">
   <div class="relative flex-1 h-full">
     <div class="flex items-center absolute inset-0 whitespace-nowrap overflow-auto px-5">
-      <span id="foobar">/bin/bash -c &quot;$(curl -fsSL https://install.example.com/8ej3l)&quot;</span>
+      <pre id="foobar">/bin/bash -c &quot;$(curl -fsSL https://install.example.com/8ej3l)&quot;</pre>
     </div>
   </div>
 

--- a/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/script_test/test_script_with_custom_link.heyya_snap
+++ b/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/script_test/test_script_with_custom_link.heyya_snap
@@ -1,7 +1,7 @@
 <div class="relative flex items-center rounded-lg overflow-hidden h-14 bg-gray-darkest-tint text-white text-lg tracking-tighter font-mono font-bold ">
   <div class="relative flex-1 h-full">
     <div class="flex items-center absolute inset-0 whitespace-nowrap overflow-auto px-5">
-      <span id="foobar">wget https://install.example.com/8ej3l</span>
+      <pre id="foobar">wget https://install.example.com/8ej3l</pre>
     </div>
   </div>
 

--- a/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/script_test/test_script_with_template_component.heyya_snap
+++ b/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/script_test/test_script_with_template_component.heyya_snap
@@ -1,7 +1,7 @@
 <div class="relative flex items-center rounded-lg overflow-hidden h-14 bg-gray-darkest-tint text-white text-lg tracking-tighter font-mono font-bold ">
   <div class="relative flex-1 h-full">
     <div class="flex items-center absolute inset-0 whitespace-nowrap overflow-auto px-5">
-      <span id="foobar">wget https://install.example.com/8ej3l</span>
+      <pre id="foobar">wget https://install.example.com/8ej3l</pre>
     </div>
   </div>
 


### PR DESCRIPTION
Description:
This should fix: #1849

Basically pre tags are copied without surroudning spaces by default in a web browser. So this PR changes to use pre tags rather than span.

Test Plan:
CI