### PR TITLE
fix: make switch properly get wrapped in label

### DIFF
--- a/platform_umbrella/apps/common_ui/lib/common_ui/components/input.ex
+++ b/platform_umbrella/apps/common_ui/lib/common_ui/components/input.ex
@@ -523,7 +523,7 @@ defmodule CommonUI.Components.Input do
 
   def input(%{type: "switch"} = assigns) do
     ~H"""
-    <div phx-feedback-for={if !@force_feedback, do: @name} class="contents">
+    <label phx-feedback-for={if !@force_feedback, do: @name} class="contents">
       <div class={["justify-self-end cursor-pointer", @class]}>
         <input
           :if={boolean?(@value)}
@@ -556,7 +556,7 @@ defmodule CommonUI.Components.Input do
       </div>
 
       <.error id={@id} errors={@errors} class="mt-0" />
-    </div>
+    </label>
     """
   end
 

--- a/platform_umbrella/apps/common_ui/storybook/components/input/switch.story.exs
+++ b/platform_umbrella/apps/common_ui/storybook/components/input/switch.story.exs
@@ -12,7 +12,7 @@ defmodule Storybook.Components.Input.Switch do
         attributes: %{
           type: "switch",
           name: "foo",
-          value: "bar",
+          value: "false",
           checked: false
         }
       },

--- a/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/input_test/test_switch_input_component_disabled_with_boolean.heyya_snap
+++ b/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/input_test/test_switch_input_component_disabled_with_boolean.heyya_snap
@@ -1,4 +1,4 @@
-<div phx-feedback-for="foo" class="contents">
+<label phx-feedback-for="foo" class="contents">
   <div class="justify-self-end cursor-pointer ">
     <input type="hidden" name="foo" value="false" disabled>
 
@@ -8,4 +8,4 @@
   </div>
 
   
-</div>
+</label>

--- a/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/input_test/test_switch_input_component_with_boolean.heyya_snap
+++ b/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/input_test/test_switch_input_component_with_boolean.heyya_snap
@@ -1,4 +1,4 @@
-<div phx-feedback-for="foo" class="contents">
+<label phx-feedback-for="foo" class="contents">
   <div class="justify-self-end cursor-pointer ">
     <input type="hidden" name="foo" value="false">
 
@@ -8,4 +8,4 @@
   </div>
 
   
-</div>
+</label>

--- a/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/input_test/test_switch_input_component_with_error.heyya_snap
+++ b/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/input_test/test_switch_input_component_with_error.heyya_snap
@@ -1,4 +1,4 @@
-<div phx-feedback-for="foo" class="contents">
+<label phx-feedback-for="foo" class="contents">
   <div class="justify-self-end cursor-pointer ">
     
 
@@ -22,4 +22,4 @@
     
   
 </div>
-</div>
+</label>

--- a/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/input_test/test_switch_input_component_with_label.heyya_snap
+++ b/platform_umbrella/apps/common_ui/test/__snapshots__/common_ui/components/input_test/test_switch_input_component_with_label.heyya_snap
@@ -1,5 +1,11 @@
-<label phx-feedback-for="foo" class="contents">
-  <div class="justify-self-end cursor-pointer ">
+<label phx-feedback-for="foo" class="inline-flex flex-wrap items-center justify-between gap-2 cursor-pointer select-none ">
+  <div class="flex items-center gap-2 text-sm text-gray-darkest dark:text-gray-lighter inline-flex">
+  <span>foo</span>
+
+  
+</div>
+
+  <div>
     
 
     <input type="checkbox" name="foo" value="bar" checked class="peer sr-only">
@@ -7,5 +13,6 @@
     <div class="relative w-[44px] h-[24px] rounded-full bg-gray-lightest border border-gray-lighter hover:border-primary dark:bg-gray-darkest-tint dark:border-gray-darker dark:hover:border-gray-dark after:content-[&#39;&#39;] after:absolute after:top-[3px] after:start-[3px] after:w-[16px] after:h-[16px] after:rounded-full after:bg-gray after:transition-all peer-checked:after:translate-x-[20px] peer-checked:after:bg-primary peer-disabled:cursor-not-allowed peer-disabled:hover:border-gray-lighter peer-disabled:after:bg-gray-lighter peer-checked:peer-disabled:after:bg-primary/50 dark:peer-checked:peer-disabled:after:bg-primary/30 dark:peer-disabled:hover:border-gray-darker dark:peer-disabled:after:bg-gray-darker-tint/50"></div>
   </div>
 
+  
   
 </label>

--- a/platform_umbrella/apps/common_ui/test/common_ui/components/input_test.exs
+++ b/platform_umbrella/apps/common_ui/test/common_ui/components/input_test.exs
@@ -194,6 +194,14 @@ defmodule CommonUI.Components.InputTest do
       <.input type="switch" id="foo" name="foo" value="true" checked disabled />
       """
     end
+
+    component_snapshot_test "with label" do
+      assigns = %{}
+
+      ~H"""
+      <.input type="switch" id="foo" name="foo" value="bar" label="foo" checked />
+      """
+    end
   end
 
   describe "range input component" do


### PR DESCRIPTION
Description:
using a label is what allows the embedded checkbox input be clickable. So this fixes switches

Test Plan:
Tests added and updated
Common UI/Visual
![image](https://github.com/user-attachments/assets/d8aa2d46-720a-4783-a4b8-9081285e73b4)
![image](https://github.com/user-attachments/assets/a87064a7-6006-4d8c-9ddc-f61f188f0b11)
