### PR TITLE
ci: partition int tests

### DIFF
--- a/.github/actions/setup-ci/action.yml
+++ b/.github/actions/setup-ci/action.yml
@@ -28,7 +28,7 @@ runs:
       uses: actions/cache/restore@v4
       with:
         path: |
-          /home/runner/.local/state/bi/dev
+          /home/runner/.local/share/bi/dev/
         key: ${{ runner.os }}-bi-${{ env.BI_REVISION }}
         restore-keys: |
           ${{ runner.os }}-bi-

--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -16,9 +16,13 @@ jobs:
   elixir-int-test:
     runs-on: ubuntu-latest-l
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    timeout-minutes: 25
+    timeout-minutes: 15
     permissions:
       contents: read
+    strategy:
+      matrix:
+        partition: [1, 2, 3]
+        num_partitions: [3]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -26,11 +30,17 @@ jobs:
 
       - name: Setup CI
         uses: ./.github/actions/setup-ci
+        with:
+          bi_cache: true
+          elixir_cache: true
+          go_cache: false
 
       - name: Run integration tests
+        env:
+          MIX_TEST_PARTITION: ${{ matrix.partition }}
         run: |
           bin/bix go ensure-bi
-          bin/bix elixir int-test
+          bin/bix elixir int-test --partitions=${{ matrix.num_partitions }}
 
       - name: Upload results on failure
         if: failure()


### PR DESCRIPTION
Now that we're caching the `bi` binary, we can get initial startup time of the integration tests to ~15 seconds.

That opens up the possibility of partitioning them across a few runners without wasting a ton of large runner time and money.

See: https://github.com/batteries-included/batteries-included/actions/runs/15116778489?pr=2014