### PR TITLE
fix(verify): wait for battery to be installed

### DIFF
--- a/platform_umbrella/apps/verify/test/support/battery_install_worker.ex
+++ b/platform_umbrella/apps/verify/test/support/battery_install_worker.ex
@@ -48,6 +48,8 @@ defmodule Verify.BatteryInstallWorker do
     session
     |> visit("batteries/#{battery.group}/new/#{battery.type}")
     |> click(Query.text("Install Battery"))
+    # click the only link - Done - in the modal
+    |> find(Query.css("#install-modal-container"), &click(&1, Query.link("")))
     |> take_screenshot(name: "post_install_#{battery.type}")
 
     {:reply, :ok, state}


### PR DESCRIPTION
This should fix the cert_manager failures on master. I'm not sure why we need to click the "Done" link but if fails without it and passes with it. /shrug