### PR TITLE
fix(verify): make trivy cluster RBAC test work

### DIFF
--- a/platform_umbrella/apps/verify/test/trivy_test.exs
+++ b/platform_umbrella/apps/verify/test/trivy_test.exs
@@ -48,7 +48,7 @@ defmodule Verify.TrivyTest do
     |> visit(@trivy_report_path)
     |> assert_has(@cluster_rbac_link)
     |> click(@cluster_rbac_link)
-    |> assert_has(table_row(text: "clusterrole-edit"))
+    |> assert_has(table_row(text: "clusterrole-"))
   end
 
   verify "infra assessments ran and are visible", %{session: session} do


### PR DESCRIPTION
We really are just asserting that a cluster RBAC audit has been completed. Doesn't matter which one so don't wait for a specific one.