### PR TITLE
chore(ci): allow int test jobs to finish if other partition fails

### DIFF
--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -52,6 +52,7 @@ jobs:
     permissions:
       contents: read
     strategy:
+      fail-fast: false
       matrix:
         partition: [1, 2, 3, 4]
         num_partitions: [4]


### PR DESCRIPTION
If a partition fails, this won't fail the remaining partitions.

That makes for easier rerunning of failed partitions.

When we start testing against PRs, we'll probably want to change it.