### PR TITLE
feat: add visibility field to StoredProjectSnapshot

### DIFF
--- a/platform_umbrella/apps/home_base/lib/home_base/projects/projects.ex
+++ b/platform_umbrella/apps/home_base/lib/home_base/projects/projects.ex
@@ -20,7 +20,7 @@ defmodule HomeBase.Projects do
 
     query =
       from s in StoredProjectSnapshot,
-        where: s.installation_id in subquery(owning_ids) or is_nil(s.installation_id),
+        where: s.installation_id in subquery(owning_ids) or s.visibility == :public,
         order_by: [desc: s.inserted_at],
         select: %{
           id: s.id,

--- a/platform_umbrella/apps/home_base/lib/home_base/projects/stored_project_snapshot.ex
+++ b/platform_umbrella/apps/home_base/lib/home_base/projects/stored_project_snapshot.ex
@@ -9,6 +9,9 @@ defmodule HomeBase.Projects.StoredProjectSnapshot do
   batt_schema "stored_project_snapshots" do
     belongs_to :installation, CommonCore.Installation
 
+    # The visibility of the snapshot
+    field :visibility, Ecto.Enum, default: :private, values: [:private, :public]
+
     embeds_one :snapshot, CommonCore.Projects.ProjectSnapshot, on_replace: :delete
 
     # This is when they told us

--- a/platform_umbrella/apps/home_base/priv/repo/migrations/20250530153311_add_visibility_flag_stored_snapshot.exs
+++ b/platform_umbrella/apps/home_base/priv/repo/migrations/20250530153311_add_visibility_flag_stored_snapshot.exs
@@ -1,0 +1,12 @@
+defmodule HomeBase.Repo.Migrations.AddVisibilityFlagStoredSnapshot do
+  use Ecto.Migration
+
+  def change do
+    alter table(:stored_project_snapshots) do
+      add :visibility, :string, default: "private", null: false
+    end
+
+    create index(:stored_project_snapshots, [:visibility])
+    create index(:stored_project_snapshots, [:installation_id, :visibility])
+  end
+end

--- a/platform_umbrella/apps/home_base/test/support/factory.ex
+++ b/platform_umbrella/apps/home_base/test/support/factory.ex
@@ -33,7 +33,7 @@ defmodule HomeBase.Factory do
   end
 
   def stored_project_snapshot_factory do
-    %StoredProjectSnapshot{}
+    %StoredProjectSnapshot{visibility: :private}
   end
 
   def team_factory do


### PR DESCRIPTION
Description:
- Add visibility field to ecto schema
- Add migration to add the field and index
- Change snapshots_for to use the new field

For now this won't be on the UI it will only be used to seed example projects into the home base of our install.

Test Plan:
- Old tests pass
- New test added showing that visibility is followed