### PR TITLE
feat: add mix command to export a stored project snapshot to json

### DIFF
--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/ollama/form_component.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/ollama/form_component.ex
@@ -128,7 +128,7 @@ defmodule ControlServerWeb.Live.OllamaFormComponent do
             <.model_form form={@form} action={@action} />
           </.panel>
           <.panel variant="gray">
-            <.size_form form={@form} />
+            <.details_form form={@form} projects={@projects} />
           </.panel>
         </.grid>
       </.form>

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/ollama/form_subcomponents.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/ollama/form_subcomponents.ex
@@ -33,8 +33,9 @@ defmodule ControlServerWeb.OllamaFormSubcomponents do
 
   attr :class, :any, default: nil
   attr :form, :any, required: true
+  attr :projects, :list, default: []
 
-  def size_form(assigns) do
+  def details_form(assigns) do
     ~H"""
     <.fieldset class={@class}>
       <.field>
@@ -67,10 +68,22 @@ defmodule ControlServerWeb.OllamaFormSubcomponents do
         <:label>GPU Count</:label>
         <.input field={@form[:gpu_count]} type="number" placeholder="0" />
       </.field>
+
+      <.field>
+        <:label>Project</:label>
+        <.input
+          type="select"
+          field={@form[:project_id]}
+          placeholder="No Project"
+          placeholder_selectable={true}
+          options={Enum.map(@projects, &{&1.name, &1.id})}
+        />
+      </.field>
     </.fieldset>
     """
   end
 
   defp gpu_node_type?(node_type) when is_binary(node_type), do: node_type |> String.to_existing_atom() |> gpu_node_type?()
+
   defp gpu_node_type?(node_type), do: node_type in GPU.node_types_with_gpus()
 end

--- a/platform_umbrella/apps/home_base/lib/home_base/projects/projects.ex
+++ b/platform_umbrella/apps/home_base/lib/home_base/projects/projects.ex
@@ -50,6 +50,12 @@ defmodule HomeBase.Projects do
     Repo.one(query)
   end
 
+  # This should only be used for internal purposes, since it doesn't check ownership
+  # of the snapshot. Use with caution.
+  def get_stored_project_snapshot!(id) do
+    Repo.get!(StoredProjectSnapshot, id)
+  end
+
   defp owning_installations(%Installation{team_id: nil, user_id: nil, id: id} = _installation) do
     values = [%{id: id}]
     types = %{id: BatteryUUID}

--- a/platform_umbrella/apps/home_base/lib/home_base/seed.ex
+++ b/platform_umbrella/apps/home_base/lib/home_base/seed.ex
@@ -41,6 +41,12 @@ defmodule HomeBase.Seed do
     :ok
   end
 
+  def seed_static_projects do
+    :ok = load_app()
+
+    Logger.info("Seeding static projects")
+  end
+
   @start_apps [:postgrex, :ecto, :ecto_sql, :home_base]
   defp load_app do
     Enum.each(@start_apps, fn app ->

--- a/platform_umbrella/apps/home_base/lib/mix/tasks/export_stored_project.ex
+++ b/platform_umbrella/apps/home_base/lib/mix/tasks/export_stored_project.ex
@@ -1,0 +1,45 @@
+defmodule Mix.Tasks.HomeBase.ExportStoredProject do
+  @moduledoc """
+  Mix task that takes in an ID of a stored project snapshot
+  pulls that from the database and then writes it to a yaml
+  file for use in IncludedResources.
+  """
+  use Mix.Task
+
+  @start_apps [:postgrex, :ecto, :ecto_sql, :home_base]
+  @shutdown_abnormal {:shutdown, 1}
+  @shutdown_normal {:shutdown, 0}
+
+  # Run is always going to exit.
+  # That's expected
+  @dialyzer {:nowarn_function, run: 1}
+
+  def run(args) do
+    case args do
+      [id] ->
+        export_project(id)
+        exit(@shutdown_normal)
+
+      _ ->
+        Mix.raise("Expected one argument: the project ID")
+        exit(@shutdown_abnormal)
+    end
+  end
+
+  defp export_project(id) do
+    {:ok, _} = Application.ensure_all_started(@start_apps)
+    stored_project = HomeBase.Projects.get_stored_project_snapshot!(id)
+    write_snapshot_to_file!(stored_project)
+  end
+
+  defp ensure_priv_directory do
+    parent = Application.app_dir(:home_base, "priv/stored_projects")
+    File.mkdir_p!(parent)
+  end
+
+  defp write_snapshot_to_file!(stored_project) do
+    path = Application.app_dir(:home_base, "priv/stored_projects/#{stored_project.id}.json")
+    ensure_priv_directory()
+    File.write!(path, Jason.encode!(stored_project.snapshot, pretty: true))
+  end
+end

--- a/platform_umbrella/apps/home_base/lib/mix/tasks/make_admin.ex
+++ b/platform_umbrella/apps/home_base/lib/mix/tasks/make_admin.ex
@@ -7,7 +7,7 @@ defmodule Mix.Tasks.HomeBase.MakeAdmin do
   use Mix.Task
 
   @start_apps [:postgrex, :ecto, :ecto_sql, :home_base]
-  @shutdown_adnormal {:shutdown, 1}
+  @shutdown_abnormal {:shutdown, 1}
   @shutdown_normal {:shutdown, 0}
 
   # Run is always going to exit.
@@ -23,7 +23,7 @@ defmodule Mix.Tasks.HomeBase.MakeAdmin do
 
       _ ->
         Mix.shell().error("Error: Please pass a user email as the first argument")
-        exit(@shutdown_adnormal)
+        exit(@shutdown_abnormal)
     end
   end
 end

--- a/platform_umbrella/apps/home_base/priv/stored_projects/batt_0197313f7c447c85ab2462d284f01077.json
+++ b/platform_umbrella/apps/home_base/priv/stored_projects/batt_0197313f7c447c85ab2462d284f01077.json
@@ -1,0 +1,132 @@
+{
+  "name": "BI.Example: Local RAG + GPT Notebook",
+  "description": "## Project Info\n\nSpin up a local hosted RAG stack with one click. This will start the following:\n\n- A Postgres cluster with PGVector\n- An embedding model\n- A GPT llm\n- A notebook",
+  "knative_services": [],
+  "traditional_services": [],
+  "model_instances": [
+    {
+      "id": "batt_0197312d6c2a72199e36344537f8d6d8",
+      "name": "example-rag-gpt-embed",
+      "node_type": "default",
+      "inserted_at": "2025-06-02T15:05:49.866469Z",
+      "updated_at": "2025-06-02T15:05:49.866469Z",
+      "virtual_size": null,
+      "num_instances": 1,
+      "model": "nomic-embed-text",
+      "cpu_requested": 500,
+      "cpu_limits": null,
+      "memory_requested": 536870912,
+      "memory_limits": 536870912,
+      "project_id": "batt_0197312bd33c7d42a1445661db88e1fe",
+      "gpu_count": 0
+    },
+    {
+      "id": "batt_0197312e0910741fbfb9ca6eaea342a4",
+      "name": "example-rag-gpt-llm",
+      "node_type": "default",
+      "inserted_at": "2025-06-02T15:06:30.032755Z",
+      "updated_at": "2025-06-02T15:06:30.032755Z",
+      "virtual_size": null,
+      "num_instances": 1,
+      "model": "llama3.1:8b",
+      "cpu_requested": 4000,
+      "cpu_limits": null,
+      "memory_requested": 8589934592,
+      "memory_limits": 8589934592,
+      "project_id": "batt_0197312bd33c7d42a1445661db88e1fe",
+      "gpu_count": 0
+    }
+  ],
+  "postgres_clusters": [
+    {
+      "id": "batt_0197312cbdb673a484a9468c93587a0d",
+      "name": "example-rag-gpt",
+      "type": "standard",
+      "database": {
+        "name": "app",
+        "owner": "root"
+      },
+      "storage_class": "standard",
+      "inserted_at": "2025-06-02T15:05:05.206804Z",
+      "updated_at": "2025-06-02T15:05:05.206804Z",
+      "virtual_size": null,
+      "num_instances": 1,
+      "users": [
+        {
+          "position": null,
+          "username": "root",
+          "roles": [
+            "login",
+            "superuser"
+          ],
+          "credential_namespaces": [
+            "battery-core"
+          ]
+        },
+        {
+          "position": null,
+          "username": "notebook",
+          "roles": [
+            "superuser",
+            "login"
+          ],
+          "credential_namespaces": [
+            "battery-data",
+            "battery-ai"
+          ]
+        }
+      ],
+      "password_versions": [
+        {
+          "version": 2,
+          "username": "notebook",
+          "password": "Z4AWD5TQM3GA34CYCT3FBPJJ"
+        },
+        {
+          "version": 1,
+          "username": "root",
+          "password": "GCPQC3SC54DWHDGW5Z3B7FOX"
+        }
+      ],
+      "cpu_requested": 500,
+      "cpu_limits": 500,
+      "memory_requested": 536870912,
+      "memory_limits": 536870912,
+      "project_id": "batt_0197312bd33c7d42a1445661db88e1fe",
+      "backup_config": null,
+      "storage_size": 536870912,
+      "restore_from_backup": null,
+      "virtual_storage_size_range_value": null
+    }
+  ],
+  "redis_instances": [],
+  "ferret_services": [],
+  "jupyter_notebooks": [
+    {
+      "id": "batt_019731322cd47cd38e61db8b4919cf6b",
+      "name": "example-rag-gpt",
+      "node_type": "default",
+      "image": "quay.io/jupyter/datascience-notebook:lab-4.4.3",
+      "storage_class": null,
+      "inserted_at": "2025-06-02T15:11:01.332194Z",
+      "updated_at": "2025-06-02T15:11:01.332194Z",
+      "virtual_size": null,
+      "env_values": [
+        {
+          "name": "DATABASE_URL",
+          "value": null,
+          "source_name": "cloudnative-pg.pg-example-rag-gpt.notebook",
+          "source_type": "secret",
+          "source_key": "dsn",
+          "source_optional": false
+        }
+      ],
+      "cpu_requested": 500,
+      "cpu_limits": 500,
+      "memory_requested": 536870912,
+      "memory_limits": 536870912,
+      "project_id": "batt_0197312bd33c7d42a1445661db88e1fe",
+      "storage_size": 536870912
+    }
+  ]
+}


### PR DESCRIPTION
Description:
This adds a mix command that we can use to store a project snapshot into a json file. These json files will later be used to seed the data into home base database. Thus giving us batteries included example projects

This also includes other fixes needed:
- Add ollama project select form So that we can create an ollama model instance for a project
- Rename the subform name to show it's not just size anymore.
- adnormal -> abnormal
- Add a get stored project that doesn't take an install

Test Plan:
- Exported one