### PR TITLE
feat: seed static projects into internal_prod home

### DIFF
--- a/platform_umbrella/apps/home_base/lib/home_base/batteries_installs.ex
+++ b/platform_umbrella/apps/home_base/lib/home_base/batteries_installs.ex
@@ -1,0 +1,25 @@
+defmodule HomeBase.BatteriesInstalls do
+  @moduledoc false
+  use HomeBase, :context
+
+  alias CommonCore.Installation
+
+  def list_internal_prod_installations do
+    from(i in Installation)
+    |> where_usage(:internal_prod)
+    |> where_team(CommonCore.Accounts.AdminTeams.admin_team_ids())
+    |> Repo.all()
+  end
+
+  defp where_usage(query, usage) do
+    from(i in query,
+      where: i.usage == ^usage
+    )
+  end
+
+  defp where_team(query, team_ids) do
+    from(i in query,
+      where: i.team_id in ^team_ids
+    )
+  end
+end

--- a/platform_umbrella/apps/home_base/lib/home_base/projects/projects.ex
+++ b/platform_umbrella/apps/home_base/lib/home_base/projects/projects.ex
@@ -9,10 +9,10 @@ defmodule HomeBase.Projects do
   alias HomeBase.Projects.StoredProjectSnapshot
   alias HomeBase.Repo
 
-  def create_stored_project_snapshot(attrs \\ %{}) do
+  def create_stored_project_snapshot(attrs \\ %{}, repo \\ Repo) do
     %StoredProjectSnapshot{}
     |> StoredProjectSnapshot.changeset(attrs)
-    |> Repo.insert()
+    |> repo.insert()
   end
 
   def snapshots_for(%{} = owner) do
@@ -54,6 +54,20 @@ defmodule HomeBase.Projects do
   # of the snapshot. Use with caution.
   def get_stored_project_snapshot!(id) do
     Repo.get!(StoredProjectSnapshot, id)
+  end
+
+  def create_or_get_stored_project_snapshot(attrs) do
+    Repo.transaction(fn repo ->
+      id = Map.get(attrs, :id)
+
+      case repo.get(StoredProjectSnapshot, id) do
+        nil ->
+          create_stored_project_snapshot(attrs, repo)
+
+        snapshot ->
+          {:ok, snapshot}
+      end
+    end)
   end
 
   defp owning_installations(%Installation{team_id: nil, user_id: nil, id: id} = _installation) do

--- a/platform_umbrella/apps/home_base/lib/home_base/projects/static_projects.ex
+++ b/platform_umbrella/apps/home_base/lib/home_base/projects/static_projects.ex
@@ -1,0 +1,28 @@
+defmodule HomeBase.Projects.StaticProjects do
+  @moduledoc false
+  use CommonCore.IncludeResource,
+    rag_v0: "priv/stored_projects/batt_0197313f7c447c85ab2462d284f01077.json"
+
+  def static_projects(install_id \\ nil) do
+    Map.new([{"batt_0197313f7c447c85ab2462d284f01077", :rag_v0}], fn {id, resource} ->
+      {id, to_stored(id, to_snapshot(resource, install_id))}
+    end)
+  end
+
+  defp to_stored(id, snapshot) do
+    HomeBase.Projects.StoredProjectSnapshot.new!(
+      id: id,
+      snapshot: snapshot,
+      installation_id: nil,
+      visibility: :public
+    )
+  end
+
+  defp to_snapshot(resource, install_id) do
+    resource
+    |> get_resource()
+    |> Jason.decode!()
+    |> Map.put("installation_id", install_id)
+    |> CommonCore.Projects.ProjectSnapshot.new!()
+  end
+end

--- a/platform_umbrella/apps/home_base/lib/home_base/release.ex
+++ b/platform_umbrella/apps/home_base/lib/home_base/release.ex
@@ -53,6 +53,8 @@ defmodule HomeBase.Release do
       Logger.warning("File does not exist: #{path}. Skipping seed.")
     end
 
+    :ok = do_seed_static_projects()
+
     Logger.debug("Seed task done!")
     :ok
   end
@@ -107,6 +109,13 @@ defmodule HomeBase.Release do
       end
     end)
     |> HomeBase.Seed.seed_files()
+  end
+
+  defp do_seed_static_projects do
+    Logger.info("Seeding static projects...")
+
+    HomeBase.Seed.seed_static_projects()
+    :ok
   end
 
   def rollback(repo, version) do

--- a/platform_umbrella/apps/home_base/lib/home_base/seed.ex
+++ b/platform_umbrella/apps/home_base/lib/home_base/seed.ex
@@ -43,8 +43,19 @@ defmodule HomeBase.Seed do
 
   def seed_static_projects do
     :ok = load_app()
+    [prod_install | _] = HomeBase.BatteriesInstalls.list_internal_prod_installations()
 
-    Logger.info("Seeding static projects")
+    prod_install.id
+    |> HomeBase.Projects.StaticProjects.static_projects()
+    |> Enum.each(fn {id, stored_project} ->
+      case HomeBase.Projects.create_or_get_stored_project_snapshot(stored_project) do
+        {:ok, _} ->
+          Logger.info("Seeded static project #{id}")
+
+        {:error, reason} ->
+          Logger.error("Failed to seed static project #{id}: #{inspect(reason)}")
+      end
+    end)
   end
 
   @start_apps [:postgrex, :ecto, :ecto_sql, :home_base]


### PR DESCRIPTION
Description:
- Add HomeBase.Release.do_seed_static_projects
- Add HomeBase.Seed.seed_static_projects
- Add HomeBase.BatteriesInstalls
- Add HomeBase.BatteriesInstalls.list_internal_prod_installations
- Add HomeBase.Projects.StaticProjects

This uses IncludeResource to embed the project snapshots that we want to always be publicly visible. Then during the seed stage (which is called on init) we check to see if a stored project snapshot with that same id exists. If it doesn't then we create it. If it does then nothing happens. Notice that this will mean that there are no project updates only insert. So versioning will be by adding a new stored project snapshot for each version. Deleting will have to come from a ui later.

Test Plan:
- bix l bootstrap && bix l dev
- Create a new project importing, choosing the BI.Example that was visible.
- The import worked