### PR TITLE
fix(verify): robustify deployment checking

### DIFF
--- a/platform_umbrella/apps/verify/lib/verify/kind_install_worker.ex
+++ b/platform_umbrella/apps/verify/lib/verify/kind_install_worker.ex
@@ -95,7 +95,7 @@ defmodule Verify.KindInstallWorker do
     spec = path |> File.read!() |> Jason.decode!()
     slug = Map.fetch!(spec, "slug")
 
-    Logger.info("Stopping Kind install with path = #{path} slug #{slug}")
+    Logger.info("Stopping Kind install with path: #{path}, slug: #{slug}, bi: #{bi}")
 
     {_, 0} = System.cmd(bi, ["stop", slug])
 

--- a/platform_umbrella/apps/verify/test/support/helpers.ex
+++ b/platform_umbrella/apps/verify/test/support/helpers.ex
@@ -102,9 +102,19 @@ defmodule Verify.TestCase.Helpers do
   end
 
   def assert_pods_in_deployment_running(session, namespace, deployment) do
+    deployment_url = "/kube/deployment/#{namespace}/#{deployment}/show"
+
+    # make sure the deployment page is available
+    {:ok, _} =
+      :wallaby
+      |> Application.get_env(:base_url)
+      |> Path.join(deployment_url)
+      |> build_retryable_get()
+      |> retry()
+
     session =
       session
-      |> visit("/kube/deployment/#{namespace}/#{deployment}/show")
+      |> visit(deployment_url)
       # check we're on the pods page for the deployment
       |> assert_has(h3(deployment))
 


### PR DESCRIPTION
If we don't have an updated summary, the deployment page may 404 and wallaby won't reload it.

I watched it happen locally with the istio csr test. I've been running just the cert_manager tests with this patch for 30 min already and haven't seen a failure yet. :crossed_fingers: 