### PR TITLE
chore: ignore verify for docker (re)builds

### DIFF
--- a/docker/platform.dockerfile.dockerignore
+++ b/docker/platform.dockerfile.dockerignore
@@ -14,6 +14,9 @@
 
 ### re-ignore anything within the above dirs
 
+# ignore verify. it's not containerized.
+platform_umbrella/apps/verify
+
 # ignore pre-compiled assets
 platform_umbrella/apps/*/priv/static/assets
 


### PR DESCRIPTION
This allows iterating on integration tests locally without having to rebuild the images if only the integration test has changed.