### PR TITLE
feat: add list command to registry-tool

### DIFF
--- a/registry-tool/cmd/advance_defaults.go
+++ b/registry-tool/cmd/advance_defaults.go
@@ -13,28 +13,6 @@ import (
 
 var advanceDefaultsCmdFlags SharedRegistryFlags
 
-var advanceIgnoredImages = []string{
-	// This isn't a real image
-	"ecto/schema/test",
-	// Metallb images fail to bootstrap with our config
-	"quay.io/metallb/speaker", "quay.io/metallb/controller", "quay.io/frrouting/frr",
-	// AWS things aren't integration tested yet
-	"public.ecr.aws/karpenter/controller",
-	// AWS isn't integration tested yet
-	"public.ecr.aws/eks/aws-load-balancer-controller",
-	// Grafana JS is broken
-	//
-	// https://github.com/grafana/grafana/issues/105582
-	//
-	// Error:
-	// ```
-	//  Uncaught TypeError: Cannot read properties of undefined (reading 'keys')
-	// ```
-	"docker.io/grafana/grafana",
-	// Victoria Metrics is needs CRDS and a refresh
-	"docker.io/victoriametrics/operator",
-}
-
 var advanceDefaultsCmd = &cobra.Command{
 	Use:     "advance-defaults",
 	Example: "registry-tool advance-defaults <registry-file>",
@@ -73,7 +51,7 @@ This is useful for ensuring that the default tag always points to the latest ver
 }
 
 func init() {
-	advanceDefaultsCmd.Flags().StringSliceVarP(&advanceDefaultsCmdFlags.ignoredImages, "ignored-images", "I", advanceIgnoredImages, "List of images to ignore")
+	advanceDefaultsCmd.Flags().StringSliceVarP(&advanceDefaultsCmdFlags.ignoredImages, "ignored-images", "I", DefaultIgnoredImages, "List of images to ignore")
 	advanceDefaultsCmd.Flags().BoolVarP(&advanceDefaultsCmdFlags.dryRun, "dry-run", "D", false, "Perform a dry run without making changes")
 	RootCmd.AddCommand(advanceDefaultsCmd)
 }

--- a/registry-tool/cmd/flags.go
+++ b/registry-tool/cmd/flags.go
@@ -4,3 +4,25 @@ type SharedRegistryFlags struct {
 	ignoredImages []string
 	dryRun        bool
 }
+
+var DefaultIgnoredImages = []string{
+	// This isn't a real image
+	"ecto/schema/test",
+	// Metallb images fail to bootstrap with our config
+	"quay.io/metallb/speaker", "quay.io/metallb/controller", "quay.io/frrouting/frr",
+	// AWS things aren't integration tested yet
+	"public.ecr.aws/karpenter/controller",
+	// AWS isn't integration tested yet
+	"public.ecr.aws/eks/aws-load-balancer-controller",
+	// Grafana JS is broken
+	//
+	// https://github.com/grafana/grafana/issues/105582
+	//
+	// Error:
+	// ```
+	//  Uncaught TypeError: Cannot read properties of undefined (reading 'keys')
+	// ```
+	"docker.io/grafana/grafana",
+	// Victoria Metricss needs new CRDS and a refresh
+	"docker.io/victoriametrics/operator",
+}

--- a/registry-tool/cmd/list.go
+++ b/registry-tool/cmd/list.go
@@ -1,0 +1,63 @@
+/*
+Copyright © 2025 Elliott Clark
+*/
+package cmd
+
+import (
+	"fmt"
+	"registry-tool/pkg/registry"
+	"slices"
+
+	"github.com/spf13/cobra"
+)
+
+var listIgnoredImages []string
+
+var listCmd = &cobra.Command{
+	Use:     "list",
+	Example: "registry-tool list <registry-file>",
+	Args:    cobra.ExactArgs(1), // Ensure exactly one argument is provided
+	Short:   "List images in the registry",
+	Long:    `A command to list all images in the registry, with filtering options.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		file := args[0]
+		filterAdvancable, _ := cmd.Flags().GetBool("advancable")
+
+		// if the filterAdvancable flag is set and the user hasn't provided a list
+		// of ignored images, set the default ignored images
+		if filterAdvancable && !cmd.Flags().Changed("ignored-images") {
+			listIgnoredImages = DefaultIgnoredImages
+		}
+
+		reg, err := registry.Read(file)
+		if err != nil {
+			return fmt.Errorf("failed to read registry file %q: %w", file, err)
+		}
+		// List the images in the registry
+		for _, record := range reg.Records() {
+			if filterAdvancable && record.DefaultTag == record.MaxTag() {
+				// If the advancable flag is set, only list
+				// images where the default tag can be advanced
+				continue
+			}
+
+			if slices.Contains(listIgnoredImages, record.Name) {
+				continue // Skip ignored images
+			}
+			fmt.Printf("%s\n", record.Name)
+		}
+		return nil
+	},
+}
+
+func init() {
+	// Advancable flag means filter for images where the default tag can be advanced
+	listCmd.Flags().BoolP("advancable", "a", false, "List only images where the default tag can be advanced")
+
+	// By default we don't ignore any images, but the user can specify a list of images to ignore
+	// however when the advancable flag is set, we set the default ignored images
+	// to the DefaultIgnoredImages, so that we can filter out images that are not advancable
+	// and the user doesn't have to specify them.
+	listCmd.Flags().StringSliceVarP(&listIgnoredImages, "ignored-images", "I", []string{}, "List of images to ignore")
+	RootCmd.AddCommand(listCmd)
+}

--- a/registry-tool/cmd/update_tags.go
+++ b/registry-tool/cmd/update_tags.go
@@ -51,6 +51,8 @@ latest versions that match each image's configured tag pattern.`,
 }
 
 func init() {
+	// Notice that we don't use the DefaultIgnoredImages here,
+	// as we want to keep updating even while we can't upgrade some images.
 	updateTagsCmd.Flags().StringSliceVarP(&updateFlags.ignoredImages, "ignored-images", "I", []string{"ecto/schema/test"}, "List of images to ignore")
 	updateTagsCmd.Flags().BoolVarP(&updateFlags.dryRun, "dry-run", "D", false, "Perform a dry run without making changes")
 	RootCmd.AddCommand(updateTagsCmd)

--- a/registry-tool/pkg/registry/registry_updater.go
+++ b/registry-tool/pkg/registry/registry_updater.go
@@ -112,6 +112,7 @@ func (u *RegistryUpdater) updateImageTags(key string, record ImageRecord) error 
 	newTags := versions.MergeSortedUnique(record.Tags, validTags)
 	// If the new tags are the same as the existing ones, skip updating
 	if slices.Equal(newTags, record.Tags) {
+		slog.Debug("no new tags to update", "image", record.Name, "tags", newTags)
 		return nil
 	}
 


### PR DESCRIPTION
Description:
Add list and a flad to filter to advancable images. This should help us script upgrading each image

Test Plan:
`go run registry-tool list ../image_registry.yaml -a` 
`go run registry-tool list ../image_registry.yaml -a -I ''` 
`go run registry-tool list ../image_registry.yaml`