### PR TITLE
fix: yaml parsing errors in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     directory: '/'
     schedule:
       interval: daily
-      time: 00:01
+      time: '00:01'
       timezone: America/Chicago
     groups:
       actions-deps:
@@ -16,7 +16,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-      time: 00:01
+      time: '00:01'
       timezone: America/Chicago
     groups:
       dependencies:
@@ -27,7 +27,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-      time: 00:01
+      time: '00:05'
       timezone: America/Chicago
     groups:
       dependencies:
@@ -42,7 +42,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-      time: 00:01
+      time: '00:01'
       timezone: America/Chicago
     groups:
       dependencies:
@@ -53,7 +53,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-      time: 00:01
+      time: '00:01'
       timezone: America/Chicago
     groups:
       dependencies:
@@ -63,7 +63,7 @@ updates:
     directory: '/platform_umbrella/'
     schedule:
       interval: daily
-      time: 00:01
+      time: '00:25'
       timezone: America/Chicago
     labels:
       - dependencies
@@ -73,7 +73,7 @@ updates:
     directory: '/bi/'
     schedule:
       interval: daily
-      time: 00:01
+      time: '00:01'
       timezone: America/Chicago
     groups:
       dependencies:
@@ -83,7 +83,7 @@ updates:
     directory: '/pastebin-go/assets/'
     schedule:
       interval: monthly
-      time: 00:01
+      time: '00:01'
       timezone: America/Chicago
     groups:
       dependencies:
@@ -93,7 +93,7 @@ updates:
     directory: '/pastebin-go/'
     schedule:
       interval: monthly
-      time: 00:01
+      time: '00:01'
       timezone: America/Chicago
     groups:
       dependencies:


### PR DESCRIPTION
Description:
Dependabot was complaining about our new time config: 
https://github.com/batteries-included/batteries-included/runs/43917758949

```
The property '#/updates/0/schedule/time' of type integer did not match the following type: string
The property '#/updates/1/schedule/time' of type integer did not match the following type: string
The property '#/updates/2/schedule/time' of type integer did not match the following type: string
The property '#/updates/3/schedule/time' of type integer did not match the following type: string
The property '#/updates/4/schedule/time' of type integer did not match the following type: string
The property '#/updates/5/schedule/time' of type integer did not match the following type: string
The property '#/updates/6/schedule/time' of type integer did not match the following type: string
The property '#/updates/7/schedule/time' of type integer did not match the following type: string
The property '#/updates/8/schedule/time' of type integer did not match the following type: string
```

That's because the yaml specs says that if the first character of a value is a digit then it's a number (float if there are .'s and integer otherwise). So this wraps the values, and staggers start time of anything that had a int-tet label

Test Plan: