### PR TITLE
feat: use imported snapshot to determine required batteries

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/projects/project_snapshot.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/projects/project_snapshot.ex
@@ -15,4 +15,30 @@ defmodule CommonCore.Projects.ProjectSnapshot do
     embeds_many :traditional_services, CommonCore.TraditionalServices.Service
     embeds_many :model_instances, CommonCore.Ollama.ModelInstance
   end
+
+  @field_batteries %{
+    postgres_clusters: :cloudnative_pg,
+    ferret_services: :ferretdb,
+    redis_instances: :redis,
+    jupyter_notebooks: :notebooks,
+    knative_services: :knative,
+    traditional_services: :traditional_services,
+    model_instances: :ollama
+  }
+
+  def required_batteries(snapshot) do
+    # For each embed list in the project snapshot
+    # return the needed battery if the list of embeds isn't empty.
+    snapshot
+    |> Map.from_struct()
+    |> Map.take(Map.keys(@field_batteries))
+    |> Enum.map(fn {field, embeds} ->
+      if Enum.empty?(embeds) do
+        nil
+      else
+        Map.get(@field_batteries, field)
+      end
+    end)
+    |> Enum.filter(& &1)
+  end
 end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/batteries_form.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/batteries_form.ex
@@ -6,6 +6,7 @@ defmodule ControlServerWeb.Projects.BatteriesForm do
 
   alias CommonCore.Batteries.Catalog
   alias CommonCore.Batteries.CatalogBattery
+  alias ControlServerWeb.Projects.ImportSnapshotForm
 
   @description """
   All of the required batteries for this project are already toggled and will be installed in the next step.
@@ -258,6 +259,10 @@ defmodule ControlServerWeb.Projects.BatteriesForm do
     |> Enum.uniq()
   end
 
+  defp required_from_step({ImportSnapshotForm, %{snapshot: snapshot}}) do
+    CommonCore.Projects.ProjectSnapshot.required_batteries(snapshot)
+  end
+
   # This takes a single step form and figured out the batteries needed for that step.
   defp required_from_step({_, v}) do
     Enum.map(Map.keys(v), &required_batteries_from_form_name/1)
@@ -274,5 +279,5 @@ defmodule ControlServerWeb.Projects.BatteriesForm do
   defp required_batteries_from_form_name("knative"), do: [:knative]
   defp required_batteries_from_form_name("ollama"), do: [:ollama]
   defp required_batteries_from_form_name("traditional"), do: [:traditional_services]
-  defp required_batteries_from_form_name(_), do: nil
+  defp required_batteries_from_form_name(_), do: []
 end


### PR DESCRIPTION
Description:
On a new snapshot one of the options is to include a snapshot. When we do that we should make sure that the batteries are installed. 

Test Plan:
installed the open web ui project and it worked without needing to install batteries.