### PR TITLE
fix: projects show page should watch for kube events

### DIFF
--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/projects/show.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/projects/show.ex
@@ -16,13 +16,27 @@ defmodule ControlServerWeb.Live.ProjectsShow do
   alias CommonCore.Batteries.Catalog
   alias CommonCore.Projects.Project
   alias ControlServer.Projects
+  alias EventCenter.KubeState, as: KubeEventCenter
   alias KubeServices.KubeState
   alias KubeServices.SystemState.SummaryBatteries
   alias KubeServices.SystemState.SummaryURLs
 
+  # This is what kube resouces we will watch for changes to
+  # and update the pods list in this LiveView.
+  @resource_type :pod
+
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
+    if connected?(socket) do
+      :ok = KubeEventCenter.subscribe(@resource_type)
+    end
+
     {:ok, socket}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_info(_unused, socket) do
+    {:noreply, assign_pods(socket)}
   end
 
   @impl Phoenix.LiveView


### PR DESCRIPTION
Description:
SO that the kubestatus live updates this page should have been watching for kube update.

Test Plan:
- CI