### PR TITLE
feat: add dropdown option to add model instance to a project

### DIFF
--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/projects/show.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/projects/show.ex
@@ -244,6 +244,12 @@ defmodule ControlServerWeb.Live.ProjectsShow do
           </.dropdown_link>
 
           <.dropdown_link navigate={
+            add_link(:ollama, ~p"/model_instances/new?project_id=#{@project.id}")
+          }>
+            Add Model Instance
+          </.dropdown_link>
+
+          <.dropdown_link navigate={
             add_link(:notebooks, ~p"/notebooks/new?project_id=#{@project.id}")
           }>
             Add Jupyter Notebook

--- a/platform_umbrella/apps/control_server_web/test/live/projects/show_pages_live_test.exs
+++ b/platform_umbrella/apps/control_server_web/test/live/projects/show_pages_live_test.exs
@@ -42,10 +42,21 @@ defmodule ControlServerWeb.Projects.ShowPagesLiveTest do
       |> assert_html(redis.name)
     end
 
-    test "jupyter_notebooks page renders", %{conn: conn, project: project, jupyter_notebook: notebook} do
+    test "jupyter_notebooks page renders", %{
+      conn: conn,
+      project: project,
+      jupyter_notebook: notebook
+    } do
       conn
       |> start(~p|/projects/#{project.id}/jupyter_notebooks|)
       |> assert_html(notebook.name)
+    end
+
+    test "show page has a link to add a new model instance", %{conn: conn, project: project} do
+      conn
+      |> start(~p|/projects/#{project.id}/show|)
+      |> assert_html("Add Model Instance")
+      |> click("a", "Add Model Instance")
     end
   end
 end


### PR DESCRIPTION
Description:
Projects should be able to start ollama model instances from the show page. This adds a drop down link to do that. It follows the pattern of what's there before.

Test Plan:
- Tests added
- CI