### PR TITLE
fix: maybe_add_config was flakey because it re-used session

### DIFF
--- a/platform_umbrella/apps/verify/test/support/battery_install_worker.ex
+++ b/platform_umbrella/apps/verify/test/support/battery_install_worker.ex
@@ -93,11 +93,9 @@ defmodule Verify.BatteryInstallWorker do
   defp type_id_query(battery, opts \\ []), do: Query.css("##{battery.type}", opts)
 
   defp maybe_add_config(session, config) do
-    Enum.each(config, fn {key, val} ->
-      fill_in_name(session, "battery_config[#{Atom.to_string(key)}]", val)
+    Enum.reduce(config, session, fn {key, val}, acc ->
+      fill_in_name(acc, "battery_config[#{Atom.to_string(key)}]", val)
     end)
-
-    session
   end
 
   @spec set_session(GenServer.name(), Wallaby.Session.t()) :: term()


### PR DESCRIPTION
Description:
This changes from re-using the a single session to configure the battery, to using the returned session from fill_in_name

Test Plan:
will run on CI with label: int-test