### PR TITLE
fix: allow not choosing a project to import

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/projects/project_snapshot.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/projects/project_snapshot.ex
@@ -26,6 +26,8 @@ defmodule CommonCore.Projects.ProjectSnapshot do
     model_instances: :ollama
   }
 
+  def required_batteries(nil), do: []
+
   def required_batteries(snapshot) do
     # For each embed list in the project snapshot
     # return the needed battery if the list of embeds isn't empty.

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/import_snapshot_form.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/components/projects/import_snapshot_form.ex
@@ -46,7 +46,7 @@ defmodule ControlServerWeb.Projects.ImportSnapshotForm do
   defp assign_snapshot(socket) do
     socket
     |> assign(:snapshot, nil)
-    |> assign(:form, nil)
+    |> assign(:form, to_form(%{}))
   end
 
   defp title(nil), do: "No snapshot selected"
@@ -173,12 +173,31 @@ defmodule ControlServerWeb.Projects.ImportSnapshotForm do
     """
   end
 
+  defp empty_state(assigns) do
+    ~H"""
+    <.form
+      id={"form_#{@id}"}
+      class={@class}
+      for={@form}
+      phx-target={@myself}
+      phx-change="validate"
+      phx-submit="submit"
+    >
+      <.subform title="No snapshot selected">
+        <p>
+          No snapshot selected to import, skipping import step.
+        </p>
+      </.subform>
+    </.form>
+    """
+  end
+
   @impl Phoenix.LiveComponent
   def render(assigns) do
     ~H"""
     <div class="contents">
       <.form
-        :if={@form != nil && @snapshot != nil}
+        :if={@snapshot != nil}
         for={@form}
         id={"form_#{@id}"}
         class={@class}
@@ -196,6 +215,14 @@ defmodule ControlServerWeb.Projects.ImportSnapshotForm do
           <.model_instances_list snapshot={@snapshot} />
         </.subform>
       </.form>
+
+      <.empty_state
+        :if={@snapshot == nil}
+        id={"empty_state_#{@id}"}
+        class={@class}
+        myself={@myself}
+        form={@form}
+      />
     </div>
     """
   end

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/projects/new.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/projects/new.ex
@@ -231,6 +231,9 @@ defmodule ControlServerWeb.Live.ProjectsNew do
 
   defp create_traditional(_project, _traditional_data, _pg, _redis), do: {:ok, nil}
 
+  defp import_snapshot(_project, %{snapshot: nil}), do: {:ok, nil}
+  defp import_snapshot(_project, nil), do: {:ok, nil}
+
   defp import_snapshot(project, %{snapshot: snapshot}) do
     ControlServer.Projects.Snapshoter.apply_snapshot(project, snapshot)
   end


### PR DESCRIPTION
Description:
- Add an empty state for display when importing
- No batteries are required when there's nothing to import so change `ProjectSnapshot.required_batteries/1`
- Handle no import in the final step of the project form

Test Plan:
- Tested locally