### PR TITLE
feat: allow starting a kind only cluster with bi

### DIFF
--- a/bi/cmd/start_local.go
+++ b/bi/cmd/start_local.go
@@ -1,0 +1,58 @@
+/*
+Copyright © 2024 Elliott Clark <elliott@batteriesincl.com>
+*/
+package cmd
+
+import (
+	"bi/pkg/local"
+	"bi/pkg/log"
+	"bi/pkg/start"
+	"fmt"
+	"log/slog"
+
+	"github.com/spf13/cobra"
+)
+
+var startLocalCmd = &cobra.Command{
+	Use:   "start-local",
+	Short: "Start a local Batteries Included Installation",
+	Long: `This will start a local Batteries Included Installation using Kind and Docker.
+It will create a local kubernetes cluster and start the installation process.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		slog.Debug("Starting local Batteries Included Installation")
+
+		baseURL, err := cmd.Flags().GetString("home-base")
+		if err != nil {
+			return fmt.Errorf("failed to get home-base flag: %w", err)
+		}
+
+		ctx := cmd.Context()
+
+		install, err := local.CreateNewLocalInstall(ctx, baseURL)
+		if err != nil {
+			return fmt.Errorf("failed to create local installation: %w", err)
+		}
+
+		slog.Debug("Created new local installation ", slog.Any("ID", install.ID))
+		env, err := local.InitLocalInstallEnv(ctx, install, baseURL)
+		if err != nil {
+			return fmt.Errorf("failed to initialize local install environment: %w", err)
+		}
+
+		slog.Debug("Initialized local install environment")
+
+		if err := log.CollectDebugLogs(env.DebugLogPath(cmd.CommandPath())); err != nil {
+			return err
+		}
+
+		return start.StartInstall(ctx, env, false)
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(startLocalCmd)
+
+	// Flag for where to talk to home base
+	startLocalCmd.Flags().String("home-base", "https://home.batteriesincl.com", "The URL of the home base to use for the local installation")
+}

--- a/bi/go.mod
+++ b/bi/go.mod
@@ -93,7 +93,7 @@ require (
 	github.com/go-openapi/jsonpointer v0.21.1 // indirect
 	github.com/go-openapi/jsonreference v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.1 // indirect
-	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
+	github.com/go-viper/mapstructure/v2 v2.3.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/glog v1.2.5 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect

--- a/bi/go.sum
+++ b/bi/go.sum
@@ -157,8 +157,8 @@ github.com/go-openapi/swag v0.23.1 h1:lpsStH0n2ittzTnbaSloVZLuB5+fvSY/+hnagBjSNZ
 github.com/go-openapi/swag v0.23.1/go.mod h1:STZs8TbRvEQQKUA+JZNAm3EWlgaOBGpyFDqQnDHMef0=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
-github.com/go-viper/mapstructure/v2 v2.2.1 h1:ZAaOCxANMuZx5RCeg0mBdEZk7DZasvvZIxtHqx8aGss=
-github.com/go-viper/mapstructure/v2 v2.2.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/go-viper/mapstructure/v2 v2.3.0 h1:27XbWsHIqhbdR5TIC911OfYvgSaW93HM+dX7970Q7jk=
+github.com/go-viper/mapstructure/v2 v2.3.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=

--- a/bi/pkg/local/create.go
+++ b/bi/pkg/local/create.go
@@ -1,0 +1,77 @@
+package local
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+
+	jose "github.com/go-jose/go-jose/v4"
+)
+
+type Installation struct {
+	ID   string `json:"id"`
+	Slug string `json:"slug"`
+}
+
+func CreateNewLocalInstall(ctx context.Context, baseURL string) (*Installation, error) {
+	// From base_url PUT to "/api/v1/installations/new_local" that will
+	// return a new Install that can be used to start a local installation
+
+	createURL := fmt.Sprintf("%s/api/v1/installations/new_local", baseURL)
+	req, err := http.NewRequest(http.MethodPut, createURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+	defer res.Body.Close()
+
+	installBytes, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading install: %w", err)
+	}
+	parsed, err := parseCreateResponse(installBytes)
+	if err != nil {
+		slog.Error("Failed to parse create response", slog.String("response", string(installBytes)), slog.Any("error", err))
+		return nil, fmt.Errorf("failed to parse create response: %w", err)
+	}
+	slog.Debug("Parsed InstallSpec", slog.Any("install", parsed))
+
+	return parsed, nil
+}
+
+func parseCreateResponse(installBytes []byte) (*Installation, error) {
+	type biJWT struct {
+		JWS json.RawMessage `json:"jwt"`
+	}
+	jwt := &biJWT{}
+	// we need the `jwt` key of the response. parse the whole thing first
+	err := json.Unmarshal(installBytes, jwt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal into temporary structure: %w", err)
+	}
+
+	// remarshal back into a string for go-jose
+	bs, err := jwt.JWS.MarshalJSON()
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal JWS back into string: %w", err)
+	}
+
+	jws, err := jose.ParseSigned(string(bs), []jose.SignatureAlgorithm{jose.ES256})
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse signed payload: %w", err)
+	}
+	payload := jws.UnsafePayloadWithoutVerification()
+	var install Installation
+	if err := json.Unmarshal(payload, &install); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal install spec: %w", err)
+	}
+
+	return &install, nil
+}

--- a/bi/pkg/local/init.go
+++ b/bi/pkg/local/init.go
@@ -1,0 +1,22 @@
+package local
+
+import (
+	"bi/pkg/installs"
+	"context"
+	"fmt"
+)
+
+func InitLocalInstallEnv(ctx context.Context, install *Installation, baseURL string) (*installs.InstallEnv, error) {
+	url := fmt.Sprintf("%s/api/v1/installations/%s/spec", baseURL, install.ID)
+
+	env, err := installs.NewEnv(ctx, url)
+	if err != nil {
+		return nil, fmt.Errorf("error creating new install env: %w", err)
+	}
+	err = env.Init(ctx, true)
+	if err != nil {
+		return nil, fmt.Errorf("error initializing install env: %w", err)
+	}
+
+	return env, nil
+}

--- a/platform_umbrella/apps/home_base/lib/home_base/customer_installs.ex
+++ b/platform_umbrella/apps/home_base/lib/home_base/customer_installs.ex
@@ -100,6 +100,16 @@ defmodule HomeBase.CustomerInstalls do
     |> Repo.insert()
   end
 
+  @spec create_local_installation!() :: Installation.t()
+  def create_local_installation! do
+    # This local only development installation isn't owned
+    # by any user or team.
+    # It can only bootstrap into kind with a small size
+    args = %{usage: :development, kube_provider: :kind, default_size: :tiny, user_id: nil, team_id: nil}
+    {:ok, installation} = create_installation(args)
+    installation
+  end
+
   @spec update_installation(CommonCore.Installation.t(), any()) :: {:ok, CommonCore.Installation.t()} | {:error, any()}
   @doc """
   Updates a installation.

--- a/platform_umbrella/apps/home_base_web/lib/home_base_web/controllers/installs/local_installation_controller.ex
+++ b/platform_umbrella/apps/home_base_web/lib/home_base_web/controllers/installs/local_installation_controller.ex
@@ -1,0 +1,14 @@
+defmodule HomeBaseWeb.LocalInstallationController do
+  use HomeBaseWeb, :controller
+
+  alias HomeBase.CustomerInstalls
+
+  def create(conn, _params) do
+    local_installation = CustomerInstalls.create_local_installation!()
+
+    conn
+    |> put_status(:created)
+    |> put_view(json: HomeBaseWeb.JwtJSON)
+    |> render(:show, jwt: CommonCore.JWK.sign_to_control_server(local_installation))
+  end
+end

--- a/platform_umbrella/apps/home_base_web/lib/home_base_web/router.ex
+++ b/platform_umbrella/apps/home_base_web/lib/home_base_web/router.ex
@@ -105,6 +105,8 @@ defmodule HomeBaseWeb.Router do
 
     get "/stable_versions", StableVersionsController, :show
 
+    put "/installations/new_local", LocalInstallationController, :create
+
     scope "/installations/:installation_id" do
       resources "/usage_reports", StoredUsageReportController, only: [:create]
       resources "/host_reports", StoredHostReportController, only: [:create]


### PR DESCRIPTION
Description:
- This adds the `start-local` command that will start a local installation with kind for development.
- This adds an api to create a new installation with those defaults

Test Plan:
- go run bi start-local --home-base started an install on my local machine.