### PR TITLE
chore(elixir): remove floki dep where unused

### DIFF
--- a/platform_umbrella/apps/control_server/mix.exs
+++ b/platform_umbrella/apps/control_server/mix.exs
@@ -56,8 +56,7 @@ defmodule ControlServer.MixProject do
       {:typed_ecto_schema, "~> 0.4"},
       {:yaml_elixir, "~> 2.6"},
       {:ymlr, "~> 5.0"},
-      {:ex_machina, "~> 2.7", only: [:dev, :test]},
-      {:floki, "~> 0.36", only: [:dev, :test]}
+      {:ex_machina, "~> 2.7", only: [:dev, :test]}
     ]
   end
 

--- a/platform_umbrella/apps/control_server_web/mix.exs
+++ b/platform_umbrella/apps/control_server_web/mix.exs
@@ -49,7 +49,6 @@ defmodule ControlServerWeb.MixProject do
       {:gettext, "~> 0.20"},
       {:inflex, "~> 2.1"},
       {:jason, "~> 1.4"},
-      {:floki, "~> 0.36"},
 
       # K8s uses mint and mint_web_socket for HTTP requests
       # If it's detected as a dependency.
@@ -74,7 +73,8 @@ defmodule ControlServerWeb.MixProject do
       {:phoenix_live_reload, "~> 1.5", only: :dev},
       # Testing
       {:ex_machina, "~> 2.7", only: [:dev, :test]},
-      {:heyya, "~> 1.0", only: [:dev, :test]}
+      {:heyya, "~> 1.0", only: [:dev, :test]},
+      {:floki, "~> 0.36", only: :test}
     ]
   end
 

--- a/platform_umbrella/apps/home_base_web/mix.exs
+++ b/platform_umbrella/apps/home_base_web/mix.exs
@@ -41,7 +41,6 @@ defmodule HomeBaseWeb.MixProject do
       {:bandit, "~> 1.4"},
       {:websock_adapter, "~> 0.5"},
       {:gettext, "~> 0.20"},
-      {:floki, "~> 0.36"},
       {:jason, "~> 1.4"},
       {:phoenix, "~> 1.7"},
       {:phoenix_ecto, "~> 4.6"},


### PR DESCRIPTION
I don't see where this is being used outside of a couple of tests.