### PR TITLE
ci: update int test timeout

### DIFF
--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -66,7 +66,7 @@ jobs:
   elixir-int-test:
     runs-on: ubuntu-latest-l
     needs: save-images
-    timeout-minutes: 15
+    timeout-minutes: 20
     permissions:
       contents: read
     strategy:


### PR DESCRIPTION
Saw one that timed out. They don't typically take 15 minutes but a little bump could help. 