### PR TITLE
chore: bump bi version to 0.69.0

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/defaults/versions.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/defaults/versions.ex
@@ -2,5 +2,5 @@ defmodule CommonCore.Defaults.Versions do
   @moduledoc false
 
   @spec bi_stable_version() :: String.t()
-  def bi_stable_version, do: "0.68.0"
+  def bi_stable_version, do: "0.69.0"
 end


### PR DESCRIPTION
Description:
The bi binary includes the new start-local command.

Test Plan:
Release incoming