### PR TITLE
chore: bump stable bi version

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/defaults/versions.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/defaults/versions.ex
@@ -2,5 +2,5 @@ defmodule CommonCore.Defaults.Versions do
   @moduledoc false
 
   @spec bi_stable_version() :: String.t()
-  def bi_stable_version, do: "0.69.0"
+  def bi_stable_version, do: "0.70.0"
 end


### PR DESCRIPTION
Description:
I'll release 0.70.0 so that documentation can point at the new scripts and talk about start-local with that.

Test Plan:
- CI