### PR TITLE
ci: fix docker workflow concurrency

### DIFF
--- a/.github/workflows/bix_docker.yml
+++ b/.github/workflows/bix_docker.yml
@@ -28,7 +28,7 @@ defaults:
 
 # only allow 1 run per commit concurrently
 concurrency:
-  group: ${{ github.workflow }}-${{ github.sha }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/bix_docker.yml
+++ b/.github/workflows/bix_docker.yml
@@ -26,10 +26,10 @@ defaults:
   run:
     shell: bash
 
-# only allow 1 run for PRs
+# only allow 1 run per commit concurrently
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !contains(github.ref, 'master') }}
+  group: ${{ github.workflow }}-${{ github.sha }}
+  cancel-in-progress: true
 
 jobs:
   build-images:

--- a/.github/workflows/bix_docker.yml
+++ b/.github/workflows/bix_docker.yml
@@ -28,7 +28,8 @@ defaults:
 
 # only allow 1 run per commit concurrently
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group:
+    ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Even though `cancel-in-progress` was false on master, it'd still cancel pending workflows (i.e. hadn't started yet) if a new workflow was triggered (e.g. from a merge to master).

This change limits it so that there's only a single concurrent run per commit which should prevent the many dependabot runs while leaving master unrestricted.