### PR TITLE
refactor(verify): pull images earlier and improve keycloak test

### DIFF
--- a/platform_umbrella/apps/verify/test/keycloak_test.exs
+++ b/platform_umbrella/apps/verify/test/keycloak_test.exs
@@ -21,21 +21,11 @@ defmodule Verify.KeycloakTest do
   end
 
   verify "can access keycloak console", %{session: session, requested_batteries: batteries} do
-    config = Keyword.fetch!(batteries, :keycloak)
-
-    session =
-      session
-      |> visit("/keycloak/realm/master")
-      |> assert_has(h3("Keycloak"))
-      |> click(Query.link("Admin Console"))
+    %{admin_username: username, admin_password: password} = Keyword.fetch!(batteries, :keycloak)
 
     session
-    |> window_handles()
-    |> List.last()
-    |> then(&focus_window(session, &1))
-    |> assert_has(Query.css("div.kc-logo-text"))
-    |> fill_in(Query.text_field("username"), with: config.admin_username)
-    |> fill_in(Query.text_field("password"), with: config.admin_password)
-    |> click(Query.button("Sign In"))
+    |> visit("/keycloak/realm/master")
+    |> login_keycloak(username, password)
+    |> assert_has(Query.css("#kc-main-content-page-container"))
   end
 end

--- a/platform_umbrella/apps/verify/test/keycloak_test.exs
+++ b/platform_umbrella/apps/verify/test/keycloak_test.exs
@@ -1,10 +1,8 @@
 defmodule Verify.KeycloakTest do
-  use Verify.Images
-
   use Verify.TestCase,
     async: false,
-    batteries: ~w(keycloak traditional_services)a,
-    images: ~w(keycloak oauth2_proxy)a ++ [@echo_server]
+    batteries: [keycloak: %{admin_username: "batteryadmin", admin_password: "password"}],
+    images: ~w(keycloak)a
 
   @keycloak_realm_path "/keycloak/realms"
 
@@ -14,7 +12,6 @@ defmodule Verify.KeycloakTest do
     session
     |> assert_pods_in_sts_running("battery-core", "keycloak")
     |> visit(@keycloak_realm_path)
-    |> sleep(15_000)
     # wait for the admin realm
     |> assert_has(table_row(minimum: 1))
     # wait for the default realm
@@ -23,9 +20,22 @@ defmodule Verify.KeycloakTest do
     Wallaby.end_session(session)
   end
 
-  verify "can access keycloak console", %{session: session} do
+  verify "can access keycloak console", %{session: session, requested_batteries: batteries} do
+    config = Keyword.fetch!(batteries, :keycloak)
+
+    session =
+      session
+      |> visit("/keycloak/realm/master")
+      |> assert_has(h3("Keycloak"))
+      |> click(Query.link("Admin Console"))
+
     session
-    |> visit(@keycloak_realm_path)
-    |> find(table_row(at: 0), &click(&1, Query.link("Keycloak Admin")))
+    |> window_handles()
+    |> List.last()
+    |> then(&focus_window(session, &1))
+    |> assert_has(Query.css("div.kc-logo-text"))
+    |> fill_in(Query.text_field("username"), with: config.admin_username)
+    |> fill_in(Query.text_field("password"), with: config.admin_password)
+    |> click(Query.button("Sign In"))
   end
 end

--- a/platform_umbrella/apps/verify/test/support/battery_install_worker.ex
+++ b/platform_umbrella/apps/verify/test/support/battery_install_worker.ex
@@ -4,7 +4,7 @@ defmodule Verify.BatteryInstallWorker do
   use TypedStruct
 
   import Verify.TestCase.Helpers
-  import Wallaby.Browser
+  import Wallaby.Browser, except: [visit: 2]
 
   alias CommonCore.Batteries.CatalogBattery
   alias Wallaby.Query

--- a/platform_umbrella/apps/verify/test/support/helpers.ex
+++ b/platform_umbrella/apps/verify/test/support/helpers.ex
@@ -1,85 +1,18 @@
 defmodule Verify.TestCase.Helpers do
-  @moduledoc false
+  @moduledoc """
+  Contains test helpers (i.e. assertions and repeated actions)
+  """
 
   import ExUnit.Assertions
-  import Wallaby.Browser
+  import Wallaby.Browser, except: [visit: 2]
 
-  alias Verify.PathHelper
   alias Wallaby.Query
-
-  require Logger
 
   @backspaces Enum.map(0..100, fn _ -> :backspace end)
   @deletes Enum.map(0..100, fn _ -> :delete end)
 
   @container_panel Query.css("#containers_panel-containers")
   @port_panel Query.css("#ports_panel")
-
-  # Adapted from Wallaby.Feature.feature/3
-  @doc """
-  `verify` wraps ExUnit.test so that test failures take a screenshot and runs `bi rage`.
-
-  The context will automatically be populated with:
-  - A wallaby session set to the correct URL: `session`
-  - A module specific temp directory. This directory is automatically uploaded on failure in CI: `tmp_dir`
-  - The tested version: `tested_version`
-  - The URL of the control server: `control_url`
-  - The name/pid of the BatteryInstallWorker: `battery_install_worker`
-  - The path to the kube config file for the cluster: `kube_config_path`
-  - The name/pid of the ImagePullWorker: `image_pull_worker`
-  - The list of requested images and batteries: `requested_{batteries,images}`
-  """
-  defmacro verify(message, context \\ quote(do: _), contents) do
-    %{module: mod, file: file, line: line} = __CALLER__
-
-    contents =
-      quote do
-        try do
-          unquote(contents)
-          :ok
-        rescue
-          e ->
-            out = unquote(__MODULE__).rage_output_for_test(unquote(mod), unquote(message))
-
-            Wallaby.Feature.Utils.take_screenshots_for_sessions(self(), unquote(message))
-            # taking a screenshot writes the paths without a final newline so add it here
-            IO.write("\n")
-            Verify.KindInstallWorker.rage(unquote(mod), out)
-
-            reraise(e, __STACKTRACE__)
-        end
-      end
-
-    context = Macro.escape(context)
-    contents = Macro.escape(contents, unquote: true)
-
-    quote bind_quoted: [
-            mod: mod,
-            file: file,
-            line: line,
-            context: context,
-            contents: contents,
-            message: message
-          ] do
-      name = ExUnit.Case.register_test(mod, file, line, :verification, message, [:verify])
-
-      def unquote(name)(unquote(context)), do: unquote(contents)
-    end
-  end
-
-  @spec get_tmp_dir(module()) :: String.t()
-  def get_tmp_dir(mod) do
-    Path.join([PathHelper.tmp_dir!(), "bi-int-test", Atom.to_string(mod)])
-  end
-
-  @spec rage_output_for_test(module(), binary()) :: String.t()
-  def rage_output_for_test(mod, message) do
-    tmp_dir = get_tmp_dir(mod)
-    name = String.replace(message, " ", "_")
-
-    time = :second |> :erlang.system_time() |> to_string()
-    Path.join([tmp_dir, "#{time}_#{name}.json"])
-  end
 
   def table_row(opts \\ []), do: Query.css("table tbody tr", opts)
   def h3(text, opts \\ []), do: Query.css("h3", Keyword.put(opts, :text, text))
@@ -208,50 +141,6 @@ defmodule Verify.TestCase.Helpers do
     end
   end
 
-  def wait_for_images(images, pid, timeout \\ 60_000)
-
-  def wait_for_images([] = _images, _pid, _timeout), do: :ok
-
-  def wait_for_images(images, pid, timeout) do
-    start_time = DateTime.utc_now()
-    end_time = DateTime.add(start_time, timeout, :millisecond)
-
-    :ok = do_wait_on_images(images, pid, end_time, remaining(end_time))
-
-    diff = DateTime.diff(DateTime.utc_now(), start_time, :millisecond)
-    Logger.debug("Finished checking in #{diff} milliseconds")
-    :ok
-  end
-
-  # there's no more images to check
-  defp do_wait_on_images([] = _images, _pid, _end_time, _remaining), do: :ok
-
-  # we're out of time
-  defp do_wait_on_images(_images, _pid, _end_time, remaining) when remaining < 0, do: :ok
-
-  # still have images to check
-  defp do_wait_on_images(images, pid, end_time, _remaining) do
-    waiting =
-      Enum.filter(images, fn image ->
-        case Verify.ImagePullWorker.image_status(pid, image) do
-          # if we're still pulling, keep the image
-          status when status in ~w(running retrying)a ->
-            Process.sleep(500)
-            true
-
-          # else remove it
-          _ ->
-            false
-        end
-      end)
-
-    do_wait_on_images(waiting, pid, end_time, remaining(end_time))
-  end
-
-  defp remaining(end_time) do
-    DateTime.diff(end_time, DateTime.utc_now(), :millisecond)
-  end
-
   defp assert_workflow_pods_running(session, workload, path) do
     # make sure the page is available
     {:ok, _} =
@@ -337,5 +226,62 @@ defmodule Verify.TestCase.Helpers do
   rescue
     Wallaby.StaleReferenceError ->
       {:error, :stale_reference}
+  end
+
+  def login_keycloak(session, username, password) do
+    session =
+      session
+      |> assert_has(h3("Keycloak"))
+      |> click(Query.link("Admin Console"))
+
+    session
+    |> window_handles()
+    |> List.last()
+    |> then(&focus_window(session, &1))
+    |> assert_has(Query.css("div.kc-logo-text"))
+    |> fill_in(Query.text_field("username"), with: username)
+    |> fill_in(Query.text_field("password"), with: password)
+    |> click(Query.button("Sign In"))
+  end
+
+  def create_keycloak_user(session, email, user, password) do
+    session =
+      session
+      # from the net_sec page
+      |> visit("/net_sec")
+      |> assert_has(h3("Realms"))
+      # go to the admin realm view page
+      |> click(Query.css("td", text: "Keycloak"))
+      |> assert_has(h3("Keycloak"))
+      # create the new user
+      |> click(Query.button("New User"))
+      |> assert_has(Query.css("h2", text: "New User"))
+      |> fill_in(Query.text_field("user_representation[email]"), with: email)
+      |> fill_in(Query.text_field("user_representation[username]"), with: user)
+      |> click(Query.button("Create User"))
+      |> assert_has(Query.css("p", text: "User has been created!"))
+
+    # get the temp password
+    temp_password = text(session, Query.css("pre"))
+
+    session
+    # exit the modal
+    |> click(Query.css("#temp-password-modal-container button"))
+    # login to keycloak
+    |> login_keycloak(user, temp_password)
+    |> assert_has(Query.css("h1", text: "Update password"))
+    |> fill_in(Query.text_field("password-new"), with: password)
+    |> fill_in(Query.text_field("password-confirm"), with: password)
+    |> click(Query.button("Submit"))
+    |> assert_has(Query.css("#kc-main-content-page-container"))
+  end
+
+  @doc """
+  Overrides `Wallaby.Browser.visit/2` with a small delay to reduce flakiness
+  """
+  def visit(parent, path) do
+    parent
+    |> Wallaby.Browser.visit(path)
+    |> sleep(100)
   end
 end

--- a/platform_umbrella/apps/verify/test/support/test_case.ex
+++ b/platform_umbrella/apps/verify/test/support/test_case.ex
@@ -2,28 +2,32 @@ defmodule Verify.TestCase do
   @moduledoc false
   use ExUnit.CaseTemplate
 
-  alias CommonCore.Batteries.Catalog
-  alias Verify.BatteryInstallWorker
-
-  require Logger
-
   using options do
     install_spec = Keyword.get(options, :install_spec, :int_test)
     batteries = Keyword.get(options, :batteries, [])
     images = Keyword.get(options, :images, [])
 
     quote do
-      use Wallaby.DSL
+      unquote(__prelude(batteries, images))
+      unquote(__setup_all(batteries, images, install_spec))
+      unquote(__setup())
+    end
+  end
 
-      import Verify.TestCase,
-        only: [
-          start_session: 0,
-          install_batteries: 2,
-          uninstall_batteries: 2
-        ]
-
+  def __prelude(batteries, images) do
+    quote do
+      # copied from `use Wallaby.DSL`
+      # we want to override visit/2
+      import Kernel, except: [tap: 2]
       import Verify.TestCase.Helpers
+      import Verify.TestCase.Util
+      import Wallaby.Browser, except: [visit: 2]
 
+      alias Wallaby.Browser
+      alias Wallaby.Element
+      alias Wallaby.Query
+
+      # Kernel.tap/2 was introduced in 1.12 and conflicts with Browser.tap/2
       require Logger
 
       ExUnit.Case.register_module_attribute(__MODULE__, :batteries, accumulate: true)
@@ -34,6 +38,12 @@ defmodule Verify.TestCase do
 
       @moduletag :cluster_test
 
+      @args ["--class=bi-int-test"]
+    end
+  end
+
+  def __setup_all(batteries, images, install_spec) do
+    quote do
       setup_all do
         batteries = unquote(batteries)
         images = unquote(images)
@@ -47,7 +57,7 @@ defmodule Verify.TestCase do
           })
 
         # kick off image pull as early as possible
-        unquote(__MODULE__).prepull_images(image_pid, images)
+        prepull_images(image_pid, images)
 
         Logger.debug("Starting Kind for spec: #{unquote(install_spec)}")
         tmp_dir = get_tmp_dir(__MODULE__)
@@ -94,101 +104,17 @@ defmodule Verify.TestCase do
            tmp_dir: tmp_dir
          ]}
       end
+    end
+  end
 
+  def __setup do
+    quote do
       setup do
         {:ok, session} = start_session()
-        on_exit(fn -> Wallaby.end_session(session) end)
 
+        on_exit(fn -> Wallaby.end_session(session) end)
         {:ok, [session: session]}
       end
     end
-  end
-
-  def prepull_images(_pid, []), do: :ok
-
-  def prepull_images(pid, images) do
-    Enum.each(images, &Verify.ImagePullWorker.pull_image(pid, &1))
-  end
-
-  def install_batteries(worker_pid, batteries \\ [])
-
-  def install_batteries(worker_pid, battery) when is_atom(battery), do: install_battery(worker_pid, {battery, %{}})
-
-  def install_batteries(_worker_pid, []), do: :ok
-
-  def install_batteries(worker_pid, batteries) do
-    Enum.map(batteries, &install_battery(worker_pid, &1))
-  end
-
-  defp install_battery(pid, type) when is_atom(type), do: install_battery(pid, {type, %{}})
-
-  defp install_battery(pid, {type, config}) do
-    case Catalog.get(type) do
-      nil ->
-        raise "Couldn't find battery: #{inspect(type)}"
-
-      battery ->
-        BatteryInstallWorker.install_battery(pid, battery, config)
-    end
-  end
-
-  def uninstall_batteries(worker_pid, battery) when is_atom(battery), do: uninstall_batteries(worker_pid, [battery])
-
-  def uninstall_batteries(_worker_pid, []), do: :ok
-
-  def uninstall_batteries(worker_pid, batteries) do
-    Enum.map(batteries, fn type ->
-      case Catalog.get(type) do
-        nil ->
-          raise "Couldn't find battery: #{inspect(type)}"
-
-        battery ->
-          BatteryInstallWorker.uninstall_battery(worker_pid, battery)
-      end
-    end)
-  end
-
-  @spec start_session() :: {:ok, Wallaby.Session.t()} | {:error, Wallaby.reason()}
-  def start_session do
-    Wallaby.start_session(
-      max_wait_time: 60_000,
-      capabilities: %{
-        headless: true,
-        javascriptEnabled: true,
-        loadImages: true,
-        chromeOptions: %{
-          args: [
-            # Lets act like the world is run on macbooks that
-            # all of sillion valley uses
-            #
-            # Fix this at some point
-            "window-size=1920,1080",
-            # We don't want to see the browser
-            "--headless",
-            "--fullscreen",
-            # Incognito mode means no caching for real
-            # Unfortunately, chrome doesn't allow http requests at all incognito
-            # "--incognito",
-            # Seems to be better for stability
-            "--no-sandbox",
-            # Yeah this will run in CI
-            "--disable-gpu",
-            # Disable dev shm usage
-            # This is needed for CI environments like GitHub Actions
-            # where /dev/shm is super small
-            #
-            # See
-            # https://github.com/elixir-wallaby/wallaby/issues/468#issuecomment-1113520767
-            "--disable-dev-shm-usage",
-            # Please google go away
-            "--disable-extensions",
-            "--disable-login-animations",
-            "--no-default-browser-check",
-            "--no-first-run",
-            "--ignore-certificate-errors"
-          ]
-        }
-      }
-    )
   end
 end

--- a/platform_umbrella/apps/verify/test/support/util.ex
+++ b/platform_umbrella/apps/verify/test/support/util.ex
@@ -1,0 +1,214 @@
+defmodule Verify.TestCase.Util do
+  @moduledoc """
+  Contains utility functions and macros.
+  Don't import / alias Wallaby here. Move those to `Helpers`
+  """
+  alias CommonCore.Batteries.Catalog
+  alias Verify.BatteryInstallWorker
+  alias Verify.ImagePullWorker
+  alias Verify.PathHelper
+
+  require Logger
+
+  # Adapted from Wallaby.Feature.feature/3
+  @doc """
+  `verify` wraps ExUnit.test so that test failures take a screenshot and runs `bi rage`.
+
+  The context will automatically be populated with:
+  - A wallaby session set to the correct URL: `session`
+  - A module specific temp directory. This directory is automatically uploaded on failure in CI: `tmp_dir`
+  - The tested version: `tested_version`
+  - The URL of the control server: `control_url`
+  - The name/pid of the BatteryInstallWorker: `battery_install_worker`
+  - The path to the kube config file for the cluster: `kube_config_path`
+  - The name/pid of the ImagePullWorker: `image_pull_worker`
+  - The list of requested images and batteries: `requested_{batteries,images}`
+  """
+  defmacro verify(message, context \\ quote(do: _), contents) do
+    %{module: mod, file: file, line: line} = __CALLER__
+
+    contents =
+      quote do
+        try do
+          unquote(contents)
+          :ok
+        rescue
+          e ->
+            out = unquote(__MODULE__).rage_output_for_test(unquote(mod), unquote(message))
+
+            Wallaby.Feature.Utils.take_screenshots_for_sessions(self(), unquote(message))
+            # taking a screenshot writes the paths without a final newline so add it here
+            IO.write("\n")
+            Verify.KindInstallWorker.rage(unquote(mod), out)
+
+            reraise(e, __STACKTRACE__)
+        end
+      end
+
+    context = Macro.escape(context)
+    contents = Macro.escape(contents, unquote: true)
+
+    quote bind_quoted: [
+            mod: mod,
+            file: file,
+            line: line,
+            context: context,
+            contents: contents,
+            message: message
+          ] do
+      name = ExUnit.Case.register_test(mod, file, line, :verification, message, [:verify])
+
+      def unquote(name)(unquote(context)), do: unquote(contents)
+    end
+  end
+
+  @spec prepull_images(GenServer.name(), list(atom() | String.t())) :: :ok
+  def prepull_images(_pid, []), do: :ok
+
+  def prepull_images(pid, images) do
+    Enum.each(images, &ImagePullWorker.pull_image(pid, &1))
+  end
+
+  @spec install_batteries(GenServer.name(), list(atom() | {atom() | map()})) :: :ok | list(atom())
+  def install_batteries(worker_pid, batteries \\ [])
+
+  def install_batteries(worker_pid, battery) when is_atom(battery), do: install_battery(worker_pid, {battery, %{}})
+
+  def install_batteries(_worker_pid, []), do: :ok
+
+  def install_batteries(worker_pid, batteries) do
+    Enum.map(batteries, &install_battery(worker_pid, &1))
+  end
+
+  defp install_battery(pid, type) when is_atom(type), do: install_battery(pid, {type, %{}})
+
+  defp install_battery(pid, {type, config}) do
+    case Catalog.get(type) do
+      nil ->
+        raise "Couldn't find battery: #{inspect(type)}"
+
+      battery ->
+        BatteryInstallWorker.install_battery(pid, battery, config)
+    end
+  end
+
+  @spec uninstall_batteries(GenServer.name(), list(atom())) :: :ok | list(term())
+  def uninstall_batteries(worker_pid, battery) when is_atom(battery), do: uninstall_batteries(worker_pid, [battery])
+
+  def uninstall_batteries(_worker_pid, []), do: :ok
+
+  def uninstall_batteries(worker_pid, batteries) do
+    Enum.map(batteries, fn type ->
+      case Catalog.get(type) do
+        nil ->
+          raise "Couldn't find battery: #{inspect(type)}"
+
+        battery ->
+          BatteryInstallWorker.uninstall_battery(worker_pid, battery)
+      end
+    end)
+  end
+
+  @spec get_tmp_dir(module()) :: String.t()
+  def get_tmp_dir(mod) do
+    Path.join([PathHelper.tmp_dir!(), "bi-int-test", Atom.to_string(mod)])
+  end
+
+  @spec rage_output_for_test(module(), binary()) :: String.t()
+  def rage_output_for_test(mod, message) do
+    tmp_dir = get_tmp_dir(mod)
+    name = String.replace(message, " ", "_")
+
+    time = :second |> :erlang.system_time() |> to_string()
+    Path.join([tmp_dir, "#{time}_#{name}.json"])
+  end
+
+  @spec wait_for_images(list(), GenServer.name(), non_neg_integer()) :: :ok
+  def wait_for_images(images, pid, timeout \\ 60_000)
+
+  def wait_for_images([] = _images, _pid, _timeout), do: :ok
+
+  def wait_for_images(images, pid, timeout) do
+    start_time = DateTime.utc_now()
+    end_time = DateTime.add(start_time, timeout, :millisecond)
+
+    :ok = do_wait_on_images(images, pid, end_time, remaining(end_time))
+
+    diff = DateTime.diff(DateTime.utc_now(), start_time, :millisecond)
+    Logger.debug("Finished checking in #{diff} milliseconds")
+    :ok
+  end
+
+  # there's no more images to check
+  defp do_wait_on_images([] = _images, _pid, _end_time, _remaining), do: :ok
+
+  # we're out of time
+  defp do_wait_on_images(_images, _pid, _end_time, remaining) when remaining < 0, do: :ok
+
+  # still have images to check
+  defp do_wait_on_images(images, pid, end_time, _remaining) do
+    waiting =
+      Enum.filter(images, fn image ->
+        case Verify.ImagePullWorker.image_status(pid, image) do
+          # if we're still pulling, keep the image
+          status when status in ~w(running retrying)a ->
+            Process.sleep(500)
+            true
+
+          # else remove it
+          _ ->
+            false
+        end
+      end)
+
+    do_wait_on_images(waiting, pid, end_time, remaining(end_time))
+  end
+
+  defp remaining(end_time) do
+    DateTime.diff(end_time, DateTime.utc_now(), :millisecond)
+  end
+
+  @spec start_session() :: {:ok, Wallaby.Session.t()} | {:error, Wallaby.reason()}
+  def start_session do
+    Wallaby.start_session(
+      max_wait_time: 60_000,
+      capabilities: %{
+        headless: true,
+        javascriptEnabled: true,
+        loadImages: true,
+        chromeOptions: %{
+          args: [
+            # Lets act like the world is run on macbooks that
+            # all of sillion valley uses
+            #
+            # Fix this at some point
+            "window-size=1920,1080",
+            # We don't want to see the browser
+            "--headless",
+            "--fullscreen",
+            # Incognito mode means no caching for real
+            # Unfortunately, chrome doesn't allow http requests at all incognito
+            # "--incognito",
+            # Seems to be better for stability
+            "--no-sandbox",
+            # Yeah this will run in CI
+            "--disable-gpu",
+            # Disable dev shm usage
+            # This is needed for CI environments like GitHub Actions
+            # where /dev/shm is super small
+            #
+            # See
+            # https://github.com/elixir-wallaby/wallaby/issues/468#issuecomment-1113520767
+            "--disable-dev-shm-usage",
+            # Please google go away
+            "--disable-extensions",
+            "--disable-login-animations",
+            "--no-default-browser-check",
+            "--no-first-run",
+            "--ignore-certificate-errors"
+          ]
+        }
+      }
+    )
+  end
+end


### PR DESCRIPTION
We can start trying to pull images even before kind starts. Just keep retrying and as soon as the container is ready, it'll start pulling while we're still bootstrapping. Should save a lil bit off each test.

Additionally, update keycloak test to make sure we can log in.