### PR TITLE
feat: add bi debug list-local

### DIFF
--- a/bi/cmd/debug/list_local.go
+++ b/bi/cmd/debug/list_local.go
@@ -1,0 +1,28 @@
+package debug
+
+import (
+	"bi/pkg/installs"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var listLocalCmd = &cobra.Command{
+	Use:   "list-local",
+	Short: "List all possible installations on the local machine",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+
+		return installs.ListInstallations(ctx, func(install *installs.InstallEnv) error {
+			// print tab separated values
+			// slug, path, provider
+			fmt.Printf("%s\t%s\t%s\n", install.Slug, install.InstallStateHome(), install.Spec.KubeCluster.Provider)
+			return nil
+		})
+	},
+}
+
+func init() {
+	debugCmd.AddCommand(listLocalCmd)
+}

--- a/bi/pkg/installs/env.go
+++ b/bi/pkg/installs/env.go
@@ -30,7 +30,7 @@ type InstallEnv struct {
 func (env *InstallEnv) init(ctx context.Context) error {
 	slog.Debug("Initializing install", slog.String("slug", env.Slug))
 	// Create the install directory in the xdg state home
-	if err := os.MkdirAll(env.installStateHome(), 0o700); err != nil {
+	if err := os.MkdirAll(env.InstallStateHome(), 0o700); err != nil {
 		return fmt.Errorf("error creating install directory: %w", err)
 	}
 

--- a/bi/pkg/installs/list.go
+++ b/bi/pkg/installs/list.go
@@ -1,0 +1,55 @@
+package installs
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+)
+
+func ListInstallations(ctx context.Context, fn func(*InstallEnv) error) error {
+	// Read all directories in the base install path
+	// For each directory, try and read the install spec
+	// If it exists, call the function with the installation
+	basePath := baseInstallPath()
+
+	entries, err := os.ReadDir(basePath)
+	if err != nil {
+		return fmt.Errorf("error reading base install path %s: %w", basePath, err)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			slog.Warn("Skipping non-directory entry in base install path",
+				slog.String("entry", entry.Name()))
+			continue
+		}
+
+		slug := entry.Name()
+		installPath := filepath.Join(basePath, slug)
+		env, err := NewEnv(ctx, slug)
+		if err != nil {
+			slog.Warn("Error creating install environment",
+				slog.String("slug", slug), slog.String("path", installPath), slog.Any("error", err))
+			continue
+		}
+		if err := env.Init(ctx, false); err != nil {
+			slog.Warn("Error initializing install environment",
+				slog.String("slug", slug), slog.String("path", installPath), slog.Any("error", err))
+			continue
+		}
+
+		if err := fn(env); err != nil {
+			return err
+		}
+		slog.Debug("Listed installation",
+			slog.String("slug", env.Slug),
+			slog.String("path", installPath),
+			slog.String("spec", env.SpecPath()),
+			slog.String("summary", env.SummaryPath()),
+			slog.String("kubeconfig", env.KubeConfigPath()),
+			slog.String("wireguard", env.WireGuardConfigPath()))
+
+	}
+	return nil
+}

--- a/bi/pkg/installs/paths.go
+++ b/bi/pkg/installs/paths.go
@@ -40,6 +40,10 @@ func (env *InstallEnv) WireGuardConfigPath() string {
 	return filepath.Join(xdg.StateHome, "bi", "installs", env.Slug, "wireguard.yaml")
 }
 
-func (env *InstallEnv) installStateHome() string {
+func (env *InstallEnv) InstallStateHome() string {
 	return filepath.Join(xdg.StateHome, "bi", "installs", env.Slug)
+}
+
+func baseInstallPath() string {
+	return filepath.Join(xdg.StateHome, "bi", "installs")
 }

--- a/bi/pkg/installs/write.go
+++ b/bi/pkg/installs/write.go
@@ -29,7 +29,7 @@ func (env *InstallEnv) WriteAll(ctx context.Context) error {
 
 func (env *InstallEnv) Remove() error {
 	// Remove all files in the install directory
-	installHome := env.installStateHome()
+	installHome := env.InstallStateHome()
 
 	slog.Debug("Removing install directory", slog.String("path", installHome))
 	if err := os.RemoveAll(installHome); err != nil {


### PR DESCRIPTION
Description:
Add a debug command (debug because it's slighty a foot cannon) that will print all specs that are a local. This is useful for cleaning up, etc. However there are a lot of reasons the local FS can can out of sync with what other systems.

Test Plan:
- go run bi debug list-local
- remove spec files the listing went away