### PR TITLE
test: wait longer and earlier for keycloak

### DIFF
--- a/platform_umbrella/apps/verify/test/support/helpers.ex
+++ b/platform_umbrella/apps/verify/test/support/helpers.ex
@@ -249,6 +249,8 @@ defmodule Verify.TestCase.Helpers do
     |> visit(@keycloak_realm_path)
     # wait for the admin realm
     |> assert_has(table_row(minimum: 1))
+    |> trigger_k8s_deploy()
+    |> visit(@keycloak_realm_path)
     # wait for the default realm
     |> assert_has(table_row(minimum: 2))
   end

--- a/platform_umbrella/apps/verify/test/support/util.ex
+++ b/platform_umbrella/apps/verify/test/support/util.ex
@@ -171,7 +171,12 @@ defmodule Verify.TestCase.Util do
   @spec start_session() :: {:ok, Wallaby.Session.t()} | {:error, Wallaby.reason()}
   def start_session do
     Wallaby.start_session(
-      max_wait_time: 60_000,
+      # Indirectly this is the max time that an image can take to pull
+      # because most of our tests end up asseting that there's a row in the
+      # pods table. That assestion waits for the max_wait_time
+      # before failing.
+      # So if the image takes longer than this to pull, the test will fail
+      max_wait_time: 300_000,
       capabilities: %{
         headless: true,
         javascriptEnabled: true,


### PR DESCRIPTION
Description:
Keycloak sso test is the last problem child. So this is an attempt to get the integration tests to pass on CI well. It first waits for keycloak's postgres cluster to be up. Then it starts waiting for the statefulset to be good. I also increased the max_wait_time so that waiting for the table row to appear can wait longer. For me I can't get this to fail on my machine any more. However CI was always the fun

Test Plan:
- Ran locally
- CI