### PR TITLE
build: try and stop double trigger/cancel

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
       actions-deps:
         patterns:
           - '*'
+    labels:
+      - dependencies
+      - automation
   - package-ecosystem: npm
     directory: '/platform_umbrella/apps/common_ui/assets/'
     schedule:
@@ -22,6 +25,10 @@ updates:
       dependencies:
         patterns:
           - '*'
+    labels:
+      - dependencies
+      - automation
+      - javascript
   - package-ecosystem: npm
     directory: '/platform_umbrella/apps/control_server_web/assets/'
     schedule:
@@ -37,6 +44,7 @@ updates:
       - dependencies
       - javascript
       - int-test
+      - automation
   - package-ecosystem: npm
     directory: '/platform_umbrella/apps/home_base_web/assets/'
     schedule:
@@ -48,6 +56,10 @@ updates:
       dependencies:
         patterns:
           - '*'
+    labels:
+      - dependencies
+      - automation
+      - javascript
   - package-ecosystem: npm
     directory: '/static/'
     schedule:
@@ -59,6 +71,10 @@ updates:
       dependencies:
         patterns:
           - '*'
+    labels:
+      - dependencies
+      - automation
+      - javascript
   - package-ecosystem: 'mix'
     directory: '/platform_umbrella/'
     schedule:
@@ -69,6 +85,7 @@ updates:
       - dependencies
       - elixir
       - int-test
+      - automation
   - package-ecosystem: 'gomod'
     directory: '/bi/'
     schedule:
@@ -79,6 +96,9 @@ updates:
       dependencies:
         patterns:
           - '*'
+    labels:
+      - dependencies
+      - automation
   - package-ecosystem: npm
     directory: '/pastebin-go/assets/'
     schedule:
@@ -89,6 +109,10 @@ updates:
       dependencies:
         patterns:
           - '*'
+    labels:
+      - dependencies
+      - automation
+      - javascript
   - package-ecosystem: 'gomod'
     directory: '/pastebin-go/'
     schedule:
@@ -99,3 +123,6 @@ updates:
       dependencies:
         patterns:
           - '*'
+    labels:
+      - dependencies
+      - automation

--- a/.github/workflows/bix_docker.yml
+++ b/.github/workflows/bix_docker.yml
@@ -7,15 +7,13 @@ name: BIX Docker
       - master
     tags:
       - '*'
-
   pull_request:
     branches:
       - master
-    types:
-      - opened
-      - synchronize
-      - labeled
-      - reopened
+  # Allow manual dispatch for the times
+  # when we want to run int-tests after
+  # opening a PR
+  workflow_dispatch:
 
 permissions:
   id-token: write
@@ -25,12 +23,6 @@ permissions:
 defaults:
   run:
     shell: bash
-
-# only allow 1 run per commit concurrently
-concurrency:
-  group:
-    ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: true
 
 jobs:
   build-images:


### PR DESCRIPTION
Description:
Lots of PR's are having issues with canceled jobs that never complete. I think that's because we are canceling too many which is happening because we are triggering too many. This removes the 'on' triggers and canceling logic to try

Test Plan:
- CI