### PR TITLE
fix(verify): try to robustify keycloak tests once more

### DIFF
--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/k8/deployment/show.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/k8/deployment/show.ex
@@ -80,10 +80,11 @@ defmodule ControlServerWeb.Live.DeploymentShow do
     </.page_header>
 
     <div class="flex flex-col gap-8 mb-10">
-      <div class="flex flex-wrap gap-4 mt-6">
+      <div id="badges" class="flex flex-wrap gap-4 mt-6">
         <.badge>
           <:item label="Total Replicas">{Map.get(@status, "replicas", 0)}</:item>
           <:item label="Available Replicas">{Map.get(@status, "availableReplicas", 0)}</:item>
+          <:item label="Ready Replicas">{Map.get(@status, "readyReplicas", 0)}</:item>
           <:item label="Generations">{Map.get(@status, "observedGeneration", 0)}</:item>
         </.badge>
       </div>

--- a/platform_umbrella/apps/control_server_web/lib/control_server_web/live/k8/stateful_set/show.ex
+++ b/platform_umbrella/apps/control_server_web/lib/control_server_web/live/k8/stateful_set/show.ex
@@ -62,11 +62,12 @@ defmodule ControlServerWeb.Live.StatefulSetShow do
     <.page_header title={@name} back_link={~p"/kube/stateful_sets"} />
 
     <div class="flex flex-col gap-8 mb-10">
-      <div class="flex flex-wrap gap-4 mt-6">
+      <div id="badges" class="flex flex-wrap gap-4 mt-6">
         <.badge>
           <:item label="Total Replicas">{Map.get(@status, "replicas", 0)}</:item>
           <:item label="Available Replicas">{Map.get(@status, "availableReplicas", 0)}</:item>
           <:item label="Updated Replicas">{Map.get(@status, "updatedReplicas", 0)}</:item>
+          <:item label="Ready Replicas">{Map.get(@status, "readyReplicas", 0)}</:item>
           <:item label="Generations">{Map.get(@status, "observedGeneration", 0)}</:item>
         </.badge>
       </div>

--- a/platform_umbrella/apps/verify/test/forgejo_test.exs
+++ b/platform_umbrella/apps/verify/test/forgejo_test.exs
@@ -9,12 +9,9 @@ defmodule Verify.ForegejoTest do
 
   verify "forgejo is running", %{session: session} do
     session
-    # this also asserts on e.g. pg-forgejo-1-initdb, unfortunately
+    |> assert_pod_succeeded("pg-forgejo-1-initdb")
     |> assert_pod_running("pg-forgejo-1")
-    # so check it again?
-    |> assert_pod_running("pg-forgejo-1")
-    # the actual pod won't come up until the DB is available
-    |> assert_pod_running("forgejo-0")
+    |> assert_pods_in_sts_running("battery-core", "forgejo")
     # now let's make sure we can access the running service
     |> visit("/devtools")
     |> click_external(Query.css("a", text: "Forgejo"))

--- a/platform_umbrella/apps/verify/test/victoria_metrics_test.exs
+++ b/platform_umbrella/apps/verify/test/victoria_metrics_test.exs
@@ -7,12 +7,17 @@ defmodule Verify.VictoriaMetricsTest do
     images: ~w(grafana)a ++ @victoria_metrics
 
   verify "victoria metrics is running", %{session: session} do
+    ns = "battery-core"
+
     session
-    |> assert_pod_running("vm-operator")
-    |> assert_pod_running("vmagent-main-agent")
-    |> assert_pod_running("vmstorage-main-cluster-0")
-    |> assert_pod_running("vmselect-main-cluster-0")
-    |> assert_pod_running("vminsert-main-cluster-")
+    # these are roughly the order that these are created
+    # so check each in turn
+    |> assert_pods_in_deployment_running(ns, "vm-operator")
+    |> assert_pods_in_deployment_running(ns, "vmagent-main-agent")
+    |> assert_pods_in_sts_running(ns, "vmstorage-main-cluster")
+    |> assert_pods_in_sts_running(ns, "vmselect-main-cluster")
+    |> assert_pods_in_deployment_running(ns, "vminsert-main-cluster")
+    # now try to access the running services
     |> visit("/monitoring")
     |> click_external(Query.css("a", text: "VM Agent"))
     |> assert_has(Query.css("h2", text: "vmagent"))


### PR DESCRIPTION
- [x] creates an assertion for pod completion / success (useful for e.g. initdb)
- [x] allows using the workload statuses to determine if workload is "ready" as opposed to just "running"
- [x] use these to track each step of keycloak bootstrap