### PR TITLE
feat: regenerate static specs on registry PR

### DIFF
--- a/.github/workflows/bix_registry.yml
+++ b/.github/workflows/bix_registry.yml
@@ -31,8 +31,6 @@ jobs:
 
       - name: Setup CI
         uses: ./.github/actions/setup-ci
-        with:
-          elixir_cache: 'false'
 
       - name: Update registry and create PR
         run: bin/bix registry create-pr

--- a/bin/bi-registry
+++ b/bin/bi-registry
@@ -111,6 +111,14 @@ do_create_pr() {
         return 0
     fi
 
+    # If we advanced some tags then we might have changed versions
+    # that we use in static specs for bootstraping. So if advance
+    # was successful then we need to regenerate static specs.
+    if [[ $advance_exit_code -eq 0 ]]; then
+        log "Regenerating static specs after advancing default tags"
+        bi-source gen-static-specs
+    fi
+
     log "${GREEN}Formatting image_registry.yaml${NOFORMAT}"
 
     bi-source fmt yaml
@@ -135,6 +143,12 @@ do_create_pr() {
     git checkout -b "$branch"
 
     git add ../image_registry.yaml
+    # Add bootstrap specs to git if they were changed by advancing the registry
+    if [[ $advance_exit_code -eq 0 ]]; then
+        log "Adding bootstrap specs to git"
+        git add ../bootstrap/*.json
+    fi
+
     git -c user.name="bi-registry-bot" \
         -c user.email="elliott+registrybot@batteriesincl.com" \
         commit -m "${title}" -m "${message}" \

--- a/bin/bi-source
+++ b/bin/bi-source
@@ -219,7 +219,6 @@ do_gen_static_specs() {
     # around for developers. It makes tests fail.
     VERSION_OVERRIDE=''${VERSION_OVERRIDE:-"latest"} run_mix \
         "do" \
-        clean, \
         deps.get, \
         compile --force, \
         gen.static.installations "${ROOT_DIR}/bootstrap"


### PR DESCRIPTION
Description:
When the registry PR advances the default tag, its possible that we have changed one of the images that are used for bootstrapping. So whenever that's happened we should gen-static-specs

Test Plan:
/shrug
This created #2240 which includes a static spec regen. Everything in that PR looks good.