### PR TITLE
feat(bi): allow running multiple kind clusters

### DIFF
--- a/bi/go.mod
+++ b/bi/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.29.17
 	github.com/aws/aws-sdk-go-v2/service/sts v1.34.0
 	github.com/aws/smithy-go v1.22.4
-	github.com/dghubble/ipnets v1.0.0
 	github.com/docker/docker v28.3.0+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/go-jose/go-jose/v4 v4.1.0

--- a/bi/go.sum
+++ b/bi/go.sum
@@ -98,8 +98,6 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dghubble/ipnets v1.0.0 h1:Le6gidpJWOnprQo8ujsJt6Funkx2MwY2fGPk09BmXSY=
-github.com/dghubble/ipnets v1.0.0/go.mod h1:dAOeeP2iY6LIjwfmhQRdcgwEBj/aSMEoKk4KEy1wHdE=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/djherbis/times v1.6.0 h1:w2ctJ92J8fBvWPxugmXIv7Nz7Q3iDMKNx9v5ocVH20c=

--- a/bi/pkg/cluster/kind/kind.go
+++ b/bi/pkg/cluster/kind/kind.go
@@ -196,7 +196,7 @@ func (c *KindClusterProvider) WriteWireGuardConfig(ctx context.Context, w io.Wri
 	c.wgGateway.Nameservers = []netip.Addr{c.wgGateway.Address} // The gateway is hosting a DNS server.
 
 	// Get the CIDR of the `kind` network.
-	c.wgGateway.VPCSubnets, err = getKindNetwork(ctx)
+	_, c.wgGateway.VPCSubnets, err = getKindNetworks(ctx)
 	if err != nil {
 		return true, err
 	}

--- a/bi/pkg/cluster/kind/net.go
+++ b/bi/pkg/cluster/kind/net.go
@@ -7,7 +7,7 @@ import (
 	"log/slog"
 	"net"
 
-	"github.com/dghubble/ipnets"
+	"github.com/apparentlymart/go-cidr/cidr"
 
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/network"
@@ -16,43 +16,38 @@ import (
 
 // Given a kind network, return the MetalLB IPs
 func GetMetalLBIPs(ctx context.Context) (string, error) {
-	networks, err := getKindNetwork(ctx)
+	existing, networks, err := getKindNetworks(ctx)
 	if err != nil {
 		return "", err
 	}
 
-	slog.Debug("Found kind networks: ", slog.Int("networks", len(networks)))
+	slog.Debug("Found kind networks: ", slog.Int("networks", len(networks)), slog.Int("existing", existing))
 	for _, subnet := range networks {
-		if subnet.IP.To4() != nil {
-			split, err := split(subnet)
-			if err != nil {
-				return "", fmt.Errorf("error splitting network: %w", err)
-			}
-
-			slog.Debug("Found kind network", slog.Any("split", split))
-			return split.String(), nil
+		if subnet.IP.To4() == nil {
+			continue
 		}
+
+		split, err := split(subnet, existing)
+		if err != nil {
+			return "", fmt.Errorf("error splitting network: %w", err)
+		}
+
+		slog.Debug("Found kind network", slog.Any("split", split))
+		return split.String(), nil
+
 	}
 
 	return "", errors.New("no kind networks found")
 }
 
 // Given a Network such as 172.18.0.0/16
-// Return the bottom half of the network, such as 172.18.128.0/17
-func split(ipNet *net.IPNet) (*net.IPNet, error) {
-	shift := calculate_shift(ipNet)
-	subnets, err := ipnets.SubnetShift(ipNet, shift)
-	if err != nil {
-		return nil, fmt.Errorf("unable to shift subnet: %w", err)
-	}
-	if len(subnets) <= 1 {
-		return nil, fmt.Errorf("no upper subnets found")
-	}
-
-	return subnets[1], nil
+// Return the bottom half of the network, such as 172.18.1.0/24
+func split(ipNet *net.IPNet, count int) (*net.IPNet, error) {
+	shift := calculateShift(ipNet)
+	return cidr.Subnet(ipNet, shift, count+1)
 }
 
-func calculate_shift(ipNet *net.IPNet) int {
+func calculateShift(ipNet *net.IPNet) int {
 	ones, _ := ipNet.Mask.Size()
 
 	if ones >= 24 {
@@ -62,10 +57,10 @@ func calculate_shift(ipNet *net.IPNet) int {
 	return 24 - ones
 }
 
-func getKindNetwork(ctx context.Context) ([]*net.IPNet, error) {
+func getKindNetworks(ctx context.Context) (int, []*net.IPNet, error) {
 	dockerClient, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
-		return nil, err
+		return 0, nil, err
 	}
 	defer dockerClient.Close()
 
@@ -73,23 +68,31 @@ func getKindNetwork(ctx context.Context) ([]*net.IPNet, error) {
 		Filters: filters.NewArgs(filters.Arg("name", "kind")),
 	})
 	if err != nil {
-		return nil, err
+		return 0, nil, err
 	}
 
 	if len(networks) == 0 {
-		return nil, errors.New("no kind networks found")
+		return 0, nil, errors.New("no kind networks found")
+	}
+
+	if len(networks) > 1 {
+		return 0, nil, errors.New("multiple kind networks found")
+	}
+
+	// we have to do an inspect to get the full details
+	network, err := dockerClient.NetworkInspect(ctx, networks[0].ID, network.InspectOptions{})
+	if err != nil {
+		return 0, nil, err
 	}
 
 	var ipNets []*net.IPNet
-	for _, network := range networks {
-		for _, config := range network.IPAM.Config {
-			_, ipNet, err := net.ParseCIDR(config.Subnet)
-			if err != nil {
-				return nil, fmt.Errorf("error parsing subnet: %w", err)
-			}
-			ipNets = append(ipNets, ipNet)
+	for _, config := range network.IPAM.Config {
+		_, ipNet, err := net.ParseCIDR(config.Subnet)
+		if err != nil {
+			return 0, nil, fmt.Errorf("error parsing subnet: %w", err)
 		}
+		ipNets = append(ipNets, ipNet)
 	}
 
-	return ipNets, nil
+	return len(network.Containers), ipNets, nil
 }

--- a/bi/pkg/cluster/kind/net_test.go
+++ b/bi/pkg/cluster/kind/net_test.go
@@ -1,0 +1,43 @@
+package kind
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_split(t *testing.T) {
+	testCases := []struct {
+		sub, expected string
+		existing      int
+		errExpected   bool
+	}{
+		{sub: "172.0.0.0/8", expected: "172.0.1.0/24", existing: 0},
+		{sub: "172.0.0.0/8", expected: "172.0.2.0/24", existing: 1},
+		{sub: "172.0.0.0/8", expected: "172.0.6.0/24", existing: 5},
+		{sub: "172.18.0.0/16", expected: "172.18.1.0/24", existing: 0},
+		{sub: "172.18.0.0/16", expected: "172.18.6.0/24", existing: 5},
+		{sub: "172.18.1.0/24", expected: "172.18.1.128/25", existing: 0},
+		{sub: "172.18.1.1/26", expected: "172.18.1.32/27", existing: 0},
+		{sub: "172.18.1.1/26", expected: "", existing: 2, errExpected: true},
+		{sub: "172.18.1.1/32", expected: "", existing: 0, errExpected: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("subnet: %s, existing: %d", tc.sub, tc.existing), func(t *testing.T) {
+			_, ipnet, err := net.ParseCIDR(tc.sub)
+			require.NoError(t, err)
+
+			got, err := split(ipnet, tc.existing)
+			if tc.errExpected {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, got.String())
+		})
+	}
+}

--- a/static/src/pages/copyrights.md
+++ b/static/src/pages/copyrights.md
@@ -139,7 +139,6 @@ licenses for them.
 | github.com/cloudflare/circl                                          | https://github.com/cloudflare/circl                        | BSD-3-Clause |
 | github.com/cyphar/filepath-securejoin                                | https://github.com/cyphar/filepath-securejoin              | BSD-3-Clause |
 | github.com/davecgh/go-spew/spew                                      | https://github.com/davecgh/go-spew                         | ISC          |
-| github.com/dghubble/ipnets                                           | https://github.com/dghubble/ipnets                         | MIT          |
 | github.com/distribution/reference                                    | https://github.com/distribution/reference                  | Apache-2.0   |
 | github.com/djherbis/times                                            | https://github.com/djherbis/times                          | MIT          |
 | github.com/docker/docker                                             | https://github.com/docker/docker                           | Apache-2.0   |


### PR DESCRIPTION
Offsets the metallb ip address pools based on the existing containers so that multiple clusters can be run simultaneously.

### Test plan:
- [x] cluster with gateway is still accessible
- [x] dev cluster still works
- [x] int-test still works
- [x] combinations of the above are all accessible simultaneously

What other scenarios need testing?