### PR TITLE
refactor(verify): prep for potentially running async

### DIFF
--- a/platform_umbrella/apps/verify/lib/verify/application.ex
+++ b/platform_umbrella/apps/verify/lib/verify/application.ex
@@ -7,11 +7,14 @@ defmodule Verify.Application do
 
   @impl Application
   def start(_type, _args) do
+    Application.put_env(:wallaby, :screenshot_dir, Path.join(Verify.PathHelper.tmp_dir!(), "bi-int-test"))
+
     children = [
+      Verify.SessionURLAgent,
       {Task.Supervisor, [name: Verify.TaskSupervisor]},
       {CommonCore.Installs.Generator, [name: Verify.Installs.Generator]},
       {Verify.KindInstallWorker, [name: Verify.KindInstallWorker]},
-      # for BatteryInstallWorker
+      # for BatteryInstall & ImagePull workers
       {Registry, keys: :unique, name: Verify.Registry}
     ]
 

--- a/platform_umbrella/apps/verify/lib/verify/session_url_agent.ex
+++ b/platform_umbrella/apps/verify/lib/verify/session_url_agent.ex
@@ -1,0 +1,20 @@
+defmodule Verify.SessionURLAgent do
+  @moduledoc false
+  use Agent
+
+  @me __MODULE__
+
+  def start_link(_opts) do
+    Agent.start_link(fn -> %{} end, name: @me)
+  end
+
+  # This would be a Wallaby.Session.t() struct but it is test only so can't use here
+  @spec get(struct() | String.t()) :: String.t()
+  def get(%{} = session), do: get(session.id)
+  def get(session_id) when is_binary(session_id), do: Agent.get(@me, &Map.get(&1, session_id))
+
+  # This would be a Wallaby.Session.t() struct but it is test only so can't use here
+  @spec put(struct() | String.t(), String.t()) :: :ok
+  def put(%{} = session, url), do: put(session.id, url)
+  def put(session_id, url) when is_binary(session_id), do: Agent.update(@me, &Map.put(&1, session_id, url))
+end

--- a/platform_umbrella/apps/verify/test/keycloak_test.exs
+++ b/platform_umbrella/apps/verify/test/keycloak_test.exs
@@ -4,8 +4,8 @@ defmodule Verify.KeycloakTest do
     batteries: [keycloak: %{admin_username: "batteryadmin", admin_password: "password"}],
     images: ~w(keycloak)a
 
-  setup_all do
-    {:ok, session} = start_session()
+  setup_all %{control_url: url} do
+    {:ok, session} = start_session(url)
 
     check_keycloak_running(session)
 

--- a/platform_umbrella/apps/verify/test/knative_test.exs
+++ b/platform_umbrella/apps/verify/test/knative_test.exs
@@ -20,8 +20,8 @@ defmodule Verify.KnativeTest do
   @show_knative_path ~r(/knative/services/[\d\w-]+/show$)
 
   # make sure knative is fully running before tests start
-  setup_all do
-    {:ok, session} = start_session()
+  setup_all %{control_url: url} do
+    {:ok, session} = start_session(url)
 
     session
     # wait a sec for knative to "install"

--- a/platform_umbrella/apps/verify/test/sso_test.exs
+++ b/platform_umbrella/apps/verify/test/sso_test.exs
@@ -12,11 +12,11 @@ defmodule Verify.SSOTest do
   @user "test"
   @password "password"
 
-  setup_all %{battery_install_worker: install_pid, image_pull_worker: pull_pid} do
+  setup_all %{battery_install_worker: install_pid, image_pull_worker: pull_pid, control_url: url} do
     # we don't need to wait for these. We can install and setup SSO while these are pulling
     prepull_images(pull_pid, ~w(grafana smtp4dev oauth2_proxy)a)
 
-    {:ok, session} = start_session()
+    {:ok, session} = start_session(url)
 
     session =
       session
@@ -28,7 +28,7 @@ defmodule Verify.SSOTest do
     Wallaby.end_session(session)
 
     # having an already logged in session will be helpful
-    {:ok, session} = start_session()
+    {:ok, session} = start_session(url)
 
     authenticated_session =
       session

--- a/platform_umbrella/apps/verify/test/support/test_case.ex
+++ b/platform_umbrella/apps/verify/test/support/test_case.ex
@@ -70,13 +70,11 @@ defmodule Verify.TestCase do
         # Stopping will also remove specs
         on_exit(&Verify.KindInstallWorker.stop_all/0)
 
+        # check that we have all of the pre-pulled images before installing batteries
         :ok = wait_for_images(image_pid, @images)
 
-        Application.put_env(:wallaby, :screenshot_dir, tmp_dir)
-        Application.put_env(:wallaby, :base_url, url)
-
         # install any requested batteries
-        {:ok, session} = start_session()
+        {:ok, session} = start_session(url)
 
         install_pid =
           start_supervised!({
@@ -109,8 +107,8 @@ defmodule Verify.TestCase do
 
   def __setup do
     quote do
-      setup do
-        {:ok, session} = start_session()
+      setup %{control_url: url} do
+        {:ok, session} = start_session(url)
 
         on_exit(fn -> Wallaby.end_session(session) end)
         {:ok, [session: session]}

--- a/platform_umbrella/apps/verify/test/support/util.ex
+++ b/platform_umbrella/apps/verify/test/support/util.ex
@@ -168,52 +168,59 @@ defmodule Verify.TestCase.Util do
     DateTime.diff(end_time, DateTime.utc_now(), :millisecond)
   end
 
-  @spec start_session() :: {:ok, Wallaby.Session.t()} | {:error, Wallaby.reason()}
-  def start_session do
-    Wallaby.start_session(
-      # Indirectly this is the max time that an image can take to pull
-      # because most of our tests end up asseting that there's a row in the
-      # pods table. That assestion waits for the max_wait_time
-      # before failing.
-      # So if the image takes longer than this to pull, the test will fail
-      max_wait_time: 300_000,
-      capabilities: %{
-        headless: true,
-        javascriptEnabled: true,
-        loadImages: true,
-        chromeOptions: %{
-          args: [
-            # Lets act like the world is run on macbooks that
-            # all of sillion valley uses
-            #
-            # Fix this at some point
-            "window-size=1920,1080",
-            # We don't want to see the browser
-            "--headless",
-            "--fullscreen",
-            # Incognito mode means no caching for real
-            # Unfortunately, chrome doesn't allow http requests at all incognito
-            # "--incognito",
-            # Seems to be better for stability
-            "--no-sandbox",
-            # Yeah this will run in CI
-            "--disable-gpu",
-            # Disable dev shm usage
-            # This is needed for CI environments like GitHub Actions
-            # where /dev/shm is super small
-            #
-            # See
-            # https://github.com/elixir-wallaby/wallaby/issues/468#issuecomment-1113520767
-            "--disable-dev-shm-usage",
-            # Please google go away
-            "--disable-extensions",
-            "--disable-login-animations",
-            "--no-default-browser-check",
-            "--no-first-run",
-            "--ignore-certificate-errors"
-          ]
-        }
-      }
-    )
+  @spec start_session(String.t()) :: {:ok, Wallaby.Session.t()} | {:error, Wallaby.reason()}
+  def start_session(url) do
+    case Wallaby.start_session(
+           # Indirectly this is the max time that an image can take to pull
+           # because most of our tests end up asseting that there's a row in the
+           # pods table. That assestion waits for the max_wait_time
+           # before failing.
+           # So if the image takes longer than this to pull, the test will fail
+           max_wait_time: 300_000,
+           capabilities: %{
+             headless: true,
+             javascriptEnabled: true,
+             loadImages: true,
+             chromeOptions: %{
+               args: [
+                 # Lets act like the world is run on macbooks that
+                 # all of sillion valley uses
+                 #
+                 # Fix this at some point
+                 "window-size=1920,1080",
+                 # We don't want to see the browser
+                 "--headless",
+                 "--fullscreen",
+                 # Incognito mode means no caching for real
+                 # Unfortunately, chrome doesn't allow http requests at all incognito
+                 # "--incognito",
+                 # Seems to be better for stability
+                 "--no-sandbox",
+                 # Yeah this will run in CI
+                 "--disable-gpu",
+                 # Disable dev shm usage
+                 # This is needed for CI environments like GitHub Actions
+                 # where /dev/shm is super small
+                 #
+                 # See
+                 # https://github.com/elixir-wallaby/wallaby/issues/468#issuecomment-1113520767
+                 "--disable-dev-shm-usage",
+                 # Please google go away
+                 "--disable-extensions",
+                 "--disable-login-animations",
+                 "--no-default-browser-check",
+                 "--no-first-run",
+                 "--ignore-certificate-errors"
+               ]
+             }
+           }
+         ) do
+      {:ok, session} = result ->
+        :ok = Verify.SessionURLAgent.put(session, url)
+        result
+
+      result ->
+        result
+    end
   end
 end

--- a/platform_umbrella/apps/verify/test/trivy_test.exs
+++ b/platform_umbrella/apps/verify/test/trivy_test.exs
@@ -14,8 +14,8 @@ defmodule Verify.TrivyTest do
 
   # TODO: use this module to assert that there are no vulnerabilities?
 
-  setup_all do
-    {:ok, session} = start_session()
+  setup_all %{control_url: url} do
+    {:ok, session} = start_session(url)
 
     {:ok, _} =
       session


### PR DESCRIPTION
If multiple modules are running concurrently, we can't rely on the wallaby env for module specific settings.

- use session specific URL lookup
- don't use module specific screenshot dir