### PR TITLE
feat: bix s set-version should bump stable bi when possibl

### DIFF
--- a/bin/bi-source
+++ b/bin/bi-source
@@ -270,6 +270,16 @@ do_set_version() {
         -name mix.exs \
         -print)
 
+    log "Changing stable bi version in CommonCore.Defaults.Versions"
+    # Change the stable version in CommonCore.Defaults.Versions
+    # in ROOT_DIR/platform_umbrella/apps/common_core/lib/common_core/defaults/versions.ex
+    # There should be a line of the form:
+    # @stable_version "0.73.0"
+    # Where the string is the old version
+
+    sed -i.bak "s/@stable_version \"${old_version}\"/@stable_version \"${new_version}\"/g" "${ROOT_DIR}/platform_umbrella/apps/common_core/lib/common_core/defaults/versions.ex"
+    rm "${ROOT_DIR}/platform_umbrella/apps/common_core/lib/common_core/defaults/versions.ex.bak"
+
     # Change the base version in the bin/lib/common-functions.sh
     sed -i.bak "s/BASE_VERSION=\"${old_version}\"/BASE_VERSION=\"${new_version}\"/g" "${ROOT_DIR}/bin/lib/common-functions.sh"
     rm "${ROOT_DIR}/bin/lib/common-functions.sh.bak"

--- a/platform_umbrella/apps/common_core/lib/common_core/defaults/versions.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/defaults/versions.ex
@@ -1,6 +1,8 @@
 defmodule CommonCore.Defaults.Versions do
   @moduledoc false
 
+  @stable_version "0.74.0"
+
   @spec bi_stable_version() :: String.t()
-  def bi_stable_version, do: "0.74.0"
+  def bi_stable_version, do: @stable_version
 end


### PR DESCRIPTION
Description:
If the stable version of bi was the last release (somone hasn't needed to pin the version) then we should advance the stable bi version when setting a new version

Test Plan:
- Tried it locally.