### PR TITLE
fix: disable keycloak 26.3.0

### DIFF
--- a/registry-tool/cmd/flags.go
+++ b/registry-tool/cmd/flags.go
@@ -29,4 +29,7 @@ var DefaultIgnoredImages = []string{
 
 	// Major Redis version bump breaks things
 	"quay.io/opstree/redis",
+
+	// 26.3.0 breaks Integration tests
+	"ghcr.io/batteries-included/keycloak",
 }


### PR DESCRIPTION
Description:
Re-enable updates.

Test Plan:
- IT tests