### PR TITLE
fix: compile keycloak with the theme jar included and blakclist old rel

### DIFF
--- a/docker/keycloak.dockerfile
+++ b/docker/keycloak.dockerfile
@@ -19,6 +19,7 @@ ARG KC_FEATURES=preview
 ARG KC_HEALTH_ENABLED=true
 ARG KC_METRICS_ENABLED=true
 ARG KC_HTTP_RELATIVE_PATH=/
+ARG JAR_NAME=keycloak-theme-for-kc-all-other-versions.jar
 
 ENV KC_DB=${KC_DB}
 ENV KC_FEATURES=${KC_FEATURES}
@@ -26,11 +27,13 @@ ENV KC_HEALTH_ENABLED=${KC_HEALTH_ENABLED}
 ENV KC_METRICS_ENABLED=${KC_METRICS_ENABLED}
 ENV KC_HTTP_RELATIVE_PATH=${KC_HTTP_RELATIVE_PATH}
 
+# We have to copy the jar file to the providers directory
+# before building Keycloak so that the timestamp of the jar file
+# is older than the Keycloak build timestamp.
+COPY --from=theme-builder /keycloak-theme/dist_keycloak/${JAR_NAME} /opt/keycloak/providers
+
 RUN /opt/keycloak/bin/kc.sh build
 
 FROM quay.io/keycloak/keycloak:${KC_VERSION}
 
-ARG JAR_NAME=keycloak-theme-for-kc-all-other-versions.jar
-
 COPY --from=builder /opt/keycloak/ /opt/keycloak/
-COPY --from=theme-builder /keycloak-theme/dist_keycloak/${JAR_NAME} /opt/keycloak/providers

--- a/image_registry.yaml
+++ b/image_registry.yaml
@@ -282,6 +282,8 @@ karpenter:
 keycloak:
   name: ghcr.io/batteries-included/keycloak
   default_tag: 26.3.0
+  blacklisted_tags:
+    - 26.3.0-3a3a040
   tags:
     - 26.3.0
     - 26.2.5
@@ -513,6 +515,7 @@ ollama:
   name: docker.io/ollama/ollama
   default_tag: 0.9.5
   tags:
+    - 0.9.6
     - 0.9.5
     - 0.9.4
     - 0.9.3


### PR DESCRIPTION
Description:
- Add a new registy-tool feature to blacklist a tag to never be added to the registry
- Blacklist the bad release that flaps forever
- Fix the dockerfile to inlclude the jar from the theme before compiling.

Test Plan:
- The image_registry changes are me doing the updates
- For the keycloak, I'll test after this is in master.