### PR TITLE
fix(sso): handle upgraded installations with existing flow definitions

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/actions/sso.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/actions/sso.ex
@@ -33,7 +33,11 @@ defmodule CommonCore.Actions.SSO do
       action: :sync,
       type: :flow_execution,
       realm: Keycloak.realm_name(),
-      value: %{flow_alias: "browser", display_name: "Browser - Conditional 2FA", requirement: requirement}
+      value: %{
+        flow_alias: "browser",
+        display_names: ["Browser - Conditional 2FA", "Browser - Conditional OTP"],
+        requirement: requirement
+      }
     }
   end
 

--- a/platform_umbrella/apps/kube_services/lib/kube_services/snapshot_apply/apply_action.ex
+++ b/platform_umbrella/apps/kube_services/lib/kube_services/snapshot_apply/apply_action.ex
@@ -105,15 +105,15 @@ defmodule KubeServices.SnapshotApply.ApplyAction do
         type: :flow_execution,
         realm: realm,
         document: %Document{
-          value: %{"flow_alias" => flow_alias, "display_name" => display_name, "requirement" => requirement}
+          value: %{"flow_alias" => flow_alias, "display_names" => display_names, "requirement" => requirement}
         }
       }) do
     with {:ok, executions} <- AdminClient.flow_executions(realm, flow_alias) do
       execution =
         Enum.find(
           executions,
-          {:err, "execution not found with display name: #{display_name}"},
-          &(&1.displayName == display_name)
+          {:error, "execution not found with display name: #{inspect(display_names)}"},
+          &(&1.displayName in display_names)
         )
 
       case require_flow_execution(realm, flow_alias, execution, requirement) do


### PR DESCRIPTION
The existing, built-in aliases aren't updated so e.g. in prod, the flow is still `Browser - Conditional OTP` and new installs would be `Browser - Conditional 2FA`.

Handle both conditions.