### PR TITLE
style: group by team for dashboard and restyle show page

### DIFF
--- a/platform_umbrella/apps/home_base_web/lib/home_base_web/router.ex
+++ b/platform_umbrella/apps/home_base_web/lib/home_base_web/router.ex
@@ -84,6 +84,7 @@ defmodule HomeBaseWeb.Router do
       live "/installations/", InstallationLive
       live "/installations/new", InstallationNewLive
       live "/installations/:id", InstallationShowLive, :show
+      live "/installations/:id/usage", InstallationShowLive, :usage
       live "/installations/:id/success", InstallationShowLive, :success
       live "/installations/:id/edit", InstallationEditLive
 
@@ -113,7 +114,9 @@ defmodule HomeBaseWeb.Router do
     scope "/installations/:installation_id" do
       resources "/usage_reports", StoredUsageReportController, only: [:create]
       resources "/host_reports", StoredHostReportController, only: [:create]
+
       resources "/project_snapshots", StoredProjectSnapshotController, only: [:create, :index, :show]
+
       get "/status", InstallationStatusContoller, :show
       get "/spec", InstallSpecController, :show
       get "/script", InstallScriptController, :show


### PR DESCRIPTION
Description:
- Which recent install was on what team has been a pain. So this makes it even more clear.
- Restyle the show page to have a right menu
- Add a small usage page for the menu

Test Plan:
- Visual

<img width="1689" height="1302" alt="image" src="https://github.com/user-attachments/assets/7115ede0-603c-4db0-a3d2-2435c810ffb5" />
<img width="1689" height="1302" alt="image" src="https://github.com/user-attachments/assets/5541b788-7a32-4df8-a3d4-6e90d09fec36" />
