### PR TITLE
Revert "chore(deps): bump actions/download-artifact from 4.3.0 to 5.0.0 in the actions-deps group (#2424)"

### DIFF
--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -80,7 +80,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           artifact-ids: ${{ needs.save-images.outputs.artifact-id }}
           path: ${{ runner.temp }}


### PR DESCRIPTION
This reverts commit e54037d6c5c81444fdd76c06d8d11167a9c26ac5.
