### PR TITLE
chore(deps): bump actions/download-artifact from 4.3.0 to 5.0.0 in the actions-deps group

### DIFF
--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -95,8 +95,7 @@ jobs:
       - name: Run integration tests
         env:
           MIX_TEST_PARTITION: ${{ matrix.partition }}
-          BI_IMAGE_TAR: |-
-            ${{ runner.temp }}/${{ needs.save-images.outputs.artifact-name }}/images.tar
+          BI_IMAGE_TAR: ${{ runner.temp }}/images.tar
         run: |
           bin/bix go ensure-bi
           bin/bix elixir int-test --partitions=${{ matrix.num_partitions }}


### PR DESCRIPTION
Updated dep and fixed output path so tests work.