### PR TITLE
chore: up the timeout for int tests

### DIFF
--- a/.github/workflows/bix.yml
+++ b/.github/workflows/bix.yml
@@ -15,7 +15,7 @@ permissions: {}
 jobs:
   check-fmt:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -31,7 +31,7 @@ jobs:
 
   misc-lint:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/bix_elixir.yml
+++ b/.github/workflows/bix_elixir.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 45
     services:
       postgres:
-        image: postgres:16
+        image: postgres:17
         env:
           POSTGRES_USER: battery-local-user
           POSTGRES_PASSWORD: 'batterypasswd'

--- a/.github/workflows/bix_go.yml
+++ b/.github/workflows/bix_go.yml
@@ -45,7 +45,7 @@ jobs:
 
   bi-build:
     runs-on: ubuntu-latest-m
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/bix_registry.yml
+++ b/.github/workflows/bix_registry.yml
@@ -21,7 +21,7 @@ env: ${{ vars }}
 jobs:
   update-registry:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -66,7 +66,7 @@ jobs:
   elixir-int-test:
     runs-on: ubuntu-latest-l
     needs: save-images
-    timeout-minutes: 25
+    timeout-minutes: 45
     permissions:
       contents: read
     strategy:

--- a/.github/workflows/keycloak.yml
+++ b/.github/workflows/keycloak.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest-m
-    timeout-minutes: 45
+    timeout-minutes: 65
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         # See: https://goreleaser.com/errors/no-history/


### PR DESCRIPTION
Summary:
I would much prefer a stable test that risks a few minutes of extra runtime if it ever gets stuck, to a flakey one. So this commit adds a lot of time onto the integration test timeouts.

Test:
- int-test
