### PR TITLE
fix(ml): don't allocate GPU nodes unnecessarily

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/util/map.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/util/map.ex
@@ -3,8 +3,10 @@ defmodule CommonCore.Util.Map do
   Utility functions for working with maps
   """
 
+  @considered_empty ["", %{}, 0, "0"]
+
   @doc """
-  Put `key` in `map` with `value` if `value` is not an empty string or empty map.
+  Put `key` in `map` with `value` if `value` is not an empty string or empty map or zero.
   Returns the original map if `value` is an empty string or empty map.
 
   ### Examples
@@ -23,16 +25,11 @@ defmodule CommonCore.Util.Map do
   """
 
   @spec maybe_put(map(), String.t(), integer() | list(any()) | String.t() | map() | nil) :: map()
-  def maybe_put(map, _key, value) when value == "", do: map
-  def maybe_put(map, _key, value) when value == %{}, do: map
-  def maybe_put(map, key, _value) when key == "", do: map
+  def maybe_put(map, _key, value) when value in @considered_empty, do: map
+  def maybe_put(map, key, _value) when key in @considered_empty, do: map
 
   def maybe_put(map, key, value) do
-    if value do
-      Map.put(map, key, value)
-    else
-      map
-    end
+    if value, do: Map.put(map, key, value), else: map
   end
 
   @doc ~S"""

--- a/platform_umbrella/apps/common_core/test/common_core/util/map_utils_test.exs
+++ b/platform_umbrella/apps/common_core/test/common_core/util/map_utils_test.exs
@@ -5,6 +5,32 @@ defmodule CommonCore.Util.MapTest do
 
   doctest CommonCore.Util.Map
 
+  describe "maybe_put/3" do
+    test "doesn't update the map if value is \"empty\"" do
+      assert %{} = maybe_put(%{}, "a", "")
+      assert %{} = maybe_put(%{}, "a", "0")
+      assert %{} = maybe_put(%{}, "a", %{})
+      assert %{} = maybe_put(%{}, "a", 0)
+    end
+
+    test "doesn't update the map if key is \"empty\"" do
+      assert %{} = maybe_put(%{}, "", :a)
+      assert %{} = maybe_put(%{}, "0", :a)
+      assert %{} = maybe_put(%{}, %{}, :a)
+      assert %{} = maybe_put(%{}, 0, :a)
+    end
+
+    test "doesn't update the map if value is nil" do
+      assert %{} = maybe_put(%{}, "a", nil)
+    end
+
+    test "updates the map" do
+      assert %{"a" => "b"} = maybe_put(%{}, "a", "b")
+      assert %{"a" => %{x: :y}} = maybe_put(%{}, "a", %{x: :y})
+      assert %{"a" => "false"} = maybe_put(%{}, "a", "false")
+    end
+  end
+
   describe "maybe_put/4" do
     test "updates the map when predicate is `true`" do
       assert %{"a" => "b"} = maybe_put(%{}, true, "a", "b")


### PR DESCRIPTION
By setting the `nvidia.com/gpu` limit to "0", karpenter was still assigning e.g. ollama to a GPU node. This changes the utility function to not put if the value or key is "0" or 0.