### PR TITLE
refactor(tesla): streamline client setup and middleware configuration

### DIFF
--- a/platform_umbrella/apps/common_core/lib/common_core/dashboard_client.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/dashboard_client.ex
@@ -1,14 +1,22 @@
 defmodule CommonCore.GrafanaDashboardClient do
   @moduledoc false
 
-  use Tesla
+  def client do
+    Tesla.client(middleware(), adapter())
+  end
 
-  plug(Tesla.Middleware.JSON)
+  defp middleware do
+    [Tesla.Middleware.JSON]
+  end
+
+  defp adapter do
+    Finch
+  end
 
   def dashboard(id) do
     url = "https://grafana.com/api/dashboards/#{id}"
 
-    case get(url) do
+    case Tesla.get(client(), url) do
       {:ok, %{status: 200, body: body}} -> {:ok, body}
       {:error, exception} -> {:error, exception}
       err -> {:error, {:unknown_error, err}}

--- a/platform_umbrella/config/config.exs
+++ b/platform_umbrella/config/config.exs
@@ -128,8 +128,7 @@ config :phoenix, :json_library, Jason
 config :swoosh, api_client: Swoosh.ApiClient.Finch, finch_name: CommonCore.Finch
 
 config :tesla,
-  adapter: {Finch, [timeout: 30_000, name: CommonCore.Finch]},
-  disable_deprecated_builder_warning: true
+  adapter: {Finch, [timeout: 30_000, name: CommonCore.Finch]}
 
 config :verify, :bi_bin_override, System.get_env("BI_BIN_OVERRIDE", nil)
 


### PR DESCRIPTION
Summary:
This fixes: #2087

Remove the deprocated Tesla macros.

Test Plan:
Existing tests should cover this. Verified that the client makes dashboads appead in Grafana.
