### PR TITLE
fix(verify): try to prevent / understand errors

### DIFF
--- a/platform_umbrella/apps/verify/test/support/kind_install_worker.ex
+++ b/platform_umbrella/apps/verify/test/support/kind_install_worker.ex
@@ -67,6 +67,11 @@ defmodule Verify.KindInstallWorker do
 
   def handle_info({:EXIT, _, _}, state), do: {:noreply, state}
 
+  def handle_info(msg, state) do
+    Logger.error("Caught unhandled message: #{inspect(msg)}")
+    {:noreply, state}
+  end
+
   defp do_start({:cmd, cmd, slug, host}, state) do
     Logger.debug("Running #{cmd}")
 


### PR DESCRIPTION
There's errors that show up in the int tests about the worker getting terminated abnormally.
Try to understand those?