### PR TITLE
feat: automatically share gpus to node on kind cluster

### DIFF
--- a/.github/workflows/bix_registry.yml
+++ b/.github/workflows/bix_registry.yml
@@ -21,7 +21,7 @@ env: ${{ vars }}
 jobs:
   update-registry:
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:

--- a/bi/pkg/cluster/cluster.go
+++ b/bi/pkg/cluster/cluster.go
@@ -25,4 +25,6 @@ type Provider interface {
 	// WriteWireGuardConfig returns the WireGuard configuration for the cluster.
 	// The return value indicates if the cluster has WireGuard enabled.
 	WriteWireGuardConfig(ctx context.Context, w io.Writer) (hasConfig bool, err error)
+	// HasNvidiaRuntimeInstalled returns true if NVIDIA runtime was installed during cluster creation.
+	HasNvidiaRuntimeInstalled() bool
 }

--- a/bi/pkg/cluster/kind/gpu.go
+++ b/bi/pkg/cluster/kind/gpu.go
@@ -1,0 +1,386 @@
+package kind
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/docker/docker/api/types/container"
+	"sigs.k8s.io/kind/pkg/cluster"
+	"sigs.k8s.io/kind/pkg/cluster/nodes"
+)
+
+//go:embed scripts/install-nvidia-toolkit.sh
+var installNvidiaToolkitScript string
+
+//go:embed scripts/configure-containerd.sh
+var configureContainerdScript string
+
+//go:embed scripts/patch-nvidia-params.sh
+var patchNvidiaParamsScript string
+
+var ubuntuImage = "ubuntu:24.04"
+
+// detectGPUs checks if NVIDIA GPUs are available on the host
+func (c *KindClusterProvider) detectGPUs(ctx context.Context) error {
+	// Check if GPU support is explicitly disabled
+	if os.Getenv("BI_DISABLE_GPU") == "1" || os.Getenv("BI_DISABLE_GPU") == "true" {
+		c.logger.Info("GPU support disabled via environment variable BI_DISABLE_GPU")
+		c.gpuAvailable = false
+		c.gpuCount = 0
+		return nil
+	}
+
+	// Try to get GPU information using nvidia-smi locally first
+	output, err := c.tryNvidiaSmiLocal(ctx)
+	if err != nil {
+		c.logger.Debug("Local nvidia-smi failed, trying Docker fallback", slog.String("error", err.Error()))
+
+		// Fallback to running nvidia-smi in Docker container
+		output, err = c.tryNvidiaSmiDocker(ctx)
+		if err != nil {
+			c.logger.Debug("Docker nvidia-smi also failed, no GPUs available", slog.String("error", err.Error()))
+			c.gpuAvailable = false
+			c.gpuCount = 0
+			return nil
+		}
+		c.logger.Debug("GPU detection successful using Docker fallback")
+	} else {
+		c.logger.Debug("GPU detection successful using local nvidia-smi")
+	}
+
+	// Count GPUs from nvidia-smi output
+	gpuCount := c.countGPUsFromOutput(output)
+
+	c.gpuAvailable = gpuCount > 0
+	c.gpuCount = gpuCount
+
+	if c.gpuAvailable {
+		c.logger.Info("NVIDIA GPUs detected", slog.Int("count", c.gpuCount))
+	} else {
+		c.logger.Debug("No NVIDIA GPUs detected")
+	}
+
+	return nil
+}
+
+// tryNvidiaSmiLocal attempts to run nvidia-smi locally on the host
+func (c *KindClusterProvider) tryNvidiaSmiLocal(ctx context.Context) (string, error) {
+	cmd := exec.CommandContext(ctx, "nvidia-smi", "-L")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("local nvidia-smi failed: %w", err)
+	}
+	return string(output), nil
+}
+
+// tryNvidiaSmiDocker attempts to run nvidia-smi inside a Docker container
+func (c *KindClusterProvider) tryNvidiaSmiDocker(ctx context.Context) (string, error) {
+	if c.dockerClient == nil {
+		// Fallback to command execution if Docker client is not available
+		return c.tryNvidiaSmiDockerCommand(ctx)
+	}
+
+	// Try with nvidia runtime first
+	output, err := c.runNvidiaSmiContainer(ctx, true, false)
+	if err != nil {
+		c.logger.Debug("Docker with nvidia runtime failed, trying volume mount approach", slog.String("error", err.Error()))
+
+		// Fallback to volume mount approach as mentioned in nvkind README
+		output, err = c.runNvidiaSmiContainer(ctx, false, true)
+		if err != nil {
+			return "", fmt.Errorf("docker nvidia-smi failed: %w", err)
+		}
+	}
+	return output, nil
+}
+
+// tryNvidiaSmiDockerCommand is a fallback function that uses command execution
+func (c *KindClusterProvider) tryNvidiaSmiDockerCommand(ctx context.Context) (string, error) {
+	// Try with nvidia runtime first
+	cmd := exec.CommandContext(ctx, "docker", "run", "--rm", "--runtime=nvidia",
+		"-e", "NVIDIA_VISIBLE_DEVICES=all", ubuntuImage, "nvidia-smi", "-L")
+	output, err := cmd.Output()
+	if err != nil {
+		c.logger.Debug("Docker with nvidia runtime failed, trying volume mount approach", slog.String("error", err.Error()))
+
+		// Fallback to volume mount approach as mentioned in nvkind README
+		cmd = exec.CommandContext(ctx, "docker", "run", "--rm",
+			"-v", "/dev/null:/var/run/nvidia-container-devices/all",
+			ubuntuImage, "nvidia-smi", "-L")
+		output, err = cmd.Output()
+		if err != nil {
+			return "", fmt.Errorf("docker nvidia-smi failed: %w", err)
+		}
+	}
+	return string(output), nil
+}
+
+// runNvidiaSmiContainer runs nvidia-smi in a Docker container using the Docker client API
+func (c *KindClusterProvider) runNvidiaSmiContainer(ctx context.Context, useNvidiaRuntime, useVolumeMount bool) (string, error) {
+	var hostConfig *container.HostConfig
+
+	if useNvidiaRuntime {
+		hostConfig = &container.HostConfig{
+			AutoRemove: true,
+			Runtime:    "nvidia",
+		}
+	} else if useVolumeMount {
+		hostConfig = &container.HostConfig{
+			AutoRemove: true,
+			Binds: []string{
+				"/dev/null:/var/run/nvidia-container-devices/all",
+			},
+		}
+	} else {
+		return "", fmt.Errorf("invalid container configuration")
+	}
+
+	// Container configuration
+	containerConfig := &container.Config{
+		Image: ubuntuImage,
+		Cmd:   []string{"nvidia-smi", "-L"},
+	}
+
+	if useNvidiaRuntime {
+		containerConfig.Env = []string{"NVIDIA_VISIBLE_DEVICES=all"}
+	}
+
+	// Create container
+	resp, err := c.dockerClient.ContainerCreate(ctx, containerConfig, hostConfig, nil, nil, "")
+	if err != nil {
+		return "", fmt.Errorf("failed to create container: %w", err)
+	}
+
+	// Start container
+	if err := c.dockerClient.ContainerStart(ctx, resp.ID, container.StartOptions{}); err != nil {
+		return "", fmt.Errorf("failed to start container: %w", err)
+	}
+
+	// Wait for container to finish
+	statusCh, errCh := c.dockerClient.ContainerWait(ctx, resp.ID, container.WaitConditionNotRunning)
+	select {
+	case err := <-errCh:
+		if err != nil {
+			return "", fmt.Errorf("error waiting for container: %w", err)
+		}
+	case status := <-statusCh:
+		if status.StatusCode != 0 {
+			// Get logs for error details
+			logs, _ := c.dockerClient.ContainerLogs(ctx, resp.ID, container.LogsOptions{
+				ShowStdout: true,
+				ShowStderr: true,
+			})
+			if logs != nil {
+				logData, _ := io.ReadAll(logs)
+				logs.Close()
+				return "", fmt.Errorf("container exited with code %d: %s", status.StatusCode, string(logData))
+			}
+			return "", fmt.Errorf("container exited with code %d", status.StatusCode)
+		}
+	}
+
+	// Get container logs (output)
+	logs, err := c.dockerClient.ContainerLogs(ctx, resp.ID, container.LogsOptions{
+		ShowStdout: true,
+		ShowStderr: false,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to get container logs: %w", err)
+	}
+	defer logs.Close()
+
+	logData, err := io.ReadAll(logs)
+	if err != nil {
+		return "", fmt.Errorf("failed to read container logs: %w", err)
+	}
+
+	return string(logData), nil
+}
+
+// countGPUsFromOutput parses nvidia-smi output and counts the number of GPUs
+func (c *KindClusterProvider) countGPUsFromOutput(output string) int {
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	gpuCount := 0
+	for _, line := range lines {
+		if strings.HasPrefix(line, "GPU ") && strings.Contains(line, ":") {
+			gpuCount++
+		}
+	}
+	return gpuCount
+}
+
+// setupGPUNodes configures GPU support on the cluster nodes after creation
+func (c *KindClusterProvider) setupGPUNodes(ctx context.Context, kindProvider *cluster.Provider, clusterName string) error {
+	if !c.gpuAvailable {
+		return nil
+	}
+
+	c.logger.Info("Setting up GPU support on cluster nodes")
+
+	// Get all nodes in the cluster
+	nodeList, err := kindProvider.ListInternalNodes(clusterName)
+	if err != nil {
+		return fmt.Errorf("failed to list nodes: %w", err)
+	}
+
+	// Setup GPU support on all nodes (both control plane and worker nodes may need GPU support)
+	for _, node := range nodeList {
+		if err := c.setupGPUNode(ctx, node); err != nil {
+			return fmt.Errorf("failed to setup GPU support on node %s: %w", node.String(), err)
+		}
+	}
+
+	return nil
+}
+
+// setupGPUNode configures GPU support on a single node
+func (c *KindClusterProvider) setupGPUNode(ctx context.Context, node nodes.Node) error {
+	c.logger.Info("Setting up GPU support on node", slog.String("node", node.String()))
+
+	// Install nvidia-container-toolkit
+	c.logger.Debug("Installing nvidia-container-toolkit", slog.String("node", node.String()))
+	if err := c.installContainerToolkit(ctx, node); err != nil {
+		return fmt.Errorf("failed to install container toolkit: %w", err)
+	}
+
+	// Configure containerd runtime
+	c.logger.Debug("Configuring containerd runtime", slog.String("node", node.String()))
+	if err := c.configureContainerRuntime(ctx, node); err != nil {
+		return fmt.Errorf("failed to configure container runtime: %w", err)
+	}
+
+	// Patch /proc/driver/nvidia
+	c.logger.Debug("Patching /proc/driver/nvidia", slog.String("node", node.String()))
+	if err := c.patchProcDriverNvidia(ctx, node); err != nil {
+		return fmt.Errorf("failed to patch /proc/driver/nvidia: %w", err)
+	}
+
+	c.logger.Info("GPU support setup completed on node", slog.String("node", node.String()))
+	return nil
+}
+
+// installContainerToolkit installs the NVIDIA container toolkit in the node
+func (c *KindClusterProvider) installContainerToolkit(ctx context.Context, node nodes.Node) error {
+	return c.runScriptOnNode(ctx, node, installNvidiaToolkitScript)
+}
+
+// configureContainerRuntime configures containerd to use the NVIDIA runtime
+func (c *KindClusterProvider) configureContainerRuntime(ctx context.Context, node nodes.Node) error {
+	return c.runScriptOnNode(ctx, node, configureContainerdScript)
+}
+
+// patchProcDriverNvidia patches /proc/driver/nvidia to allow GPU access
+func (c *KindClusterProvider) patchProcDriverNvidia(ctx context.Context, node nodes.Node) error {
+	// Unmount the masked /proc/driver/nvidia to allow dynamically generated
+	// MIG devices to be discovered. The || true ensures the script continues even if unmount fails
+	script1 := `umount -R /proc/driver/nvidia || true`
+	if err := c.runScriptOnNode(ctx, node, script1); err != nil {
+		return fmt.Errorf("failed to unmount /proc/driver/nvidia: %w", err)
+	}
+
+	// Make it so that calls into nvidia-smi / libnvidia-ml.so do not attempt
+	// to recreate device nodes or reset their permissions if tampered with
+	if err := c.runScriptOnNode(ctx, node, patchNvidiaParamsScript); err != nil {
+		return fmt.Errorf("failed to patch nvidia params: %w", err)
+	}
+	c.logger.Debug("GPU device nodes configured for all GPU access")
+	return nil
+}
+
+// runScriptOnNode executes a script on the given node using Docker client API
+func (c *KindClusterProvider) runScriptOnNode(ctx context.Context, node nodes.Node, script string) error {
+	if c.dockerClient == nil {
+		// Fallback to command execution if Docker client is not available
+		return c.runScriptOnNodeCommand(ctx, node, script)
+	}
+
+	return c.runScriptOnNodeWithDockerClient(ctx, node, script)
+}
+
+// runScriptOnNodeCommand is a fallback function that uses command execution
+func (c *KindClusterProvider) runScriptOnNodeCommand(ctx context.Context, node nodes.Node, script string) error {
+	if c.dockerClient != nil {
+		// If we have a Docker client, use it directly instead of exec commands
+		return c.runScriptOnNodeWithDockerClient(ctx, node, script)
+	}
+
+	// Ultimate fallback to command execution if no Docker client is available
+	cmd := exec.CommandContext(ctx, "docker", "exec", node.String(), "bash", "-c", script)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		c.logger.Error("Failed to run script on node",
+			slog.String("node", node.String()),
+			slog.String("script", script),
+			slog.String("output", string(output)),
+			slog.String("error", err.Error()))
+		return err
+	}
+
+	c.logger.Debug("Script executed successfully on node",
+		slog.String("node", node.String()),
+		slog.String("output", string(output)))
+
+	return nil
+}
+
+// runScriptOnNodeWithDockerClient executes a script using the Docker client API
+func (c *KindClusterProvider) runScriptOnNodeWithDockerClient(ctx context.Context, node nodes.Node, script string) error {
+	// Create exec configuration
+	execConfig := container.ExecOptions{
+		Cmd:          []string{"bash", "-c", script},
+		AttachStdout: true,
+		AttachStderr: true,
+	}
+
+	// Create exec instance
+	execIDResp, err := c.dockerClient.ContainerExecCreate(ctx, node.String(), execConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create exec instance: %w", err)
+	}
+
+	// Start the exec instance
+	execStartConfig := container.ExecStartOptions{
+		Detach: false,
+	}
+
+	hijackedResp, err := c.dockerClient.ContainerExecAttach(ctx, execIDResp.ID, execStartConfig)
+	if err != nil {
+		return fmt.Errorf("failed to attach to exec instance: %w", err)
+	}
+	defer hijackedResp.Close()
+
+	// Read the output
+	var outputBuf strings.Builder
+	_, err = io.Copy(&outputBuf, hijackedResp.Reader)
+	if err != nil {
+		return fmt.Errorf("failed to read exec output: %w", err)
+	}
+
+	// Check exec exit code
+	execInspect, err := c.dockerClient.ContainerExecInspect(ctx, execIDResp.ID)
+	if err != nil {
+		return fmt.Errorf("failed to inspect exec instance: %w", err)
+	}
+
+	output := outputBuf.String()
+	if execInspect.ExitCode != 0 {
+		c.logger.Error("Failed to run script on node",
+			slog.String("node", node.String()),
+			slog.String("script", script),
+			slog.String("output", output),
+			slog.Int("exit_code", execInspect.ExitCode))
+		return fmt.Errorf("script execution failed with exit code %d", execInspect.ExitCode)
+	}
+
+	c.logger.Debug("Script executed successfully on node",
+		slog.String("node", node.String()),
+		slog.String("output", output))
+
+	return nil
+}

--- a/bi/pkg/cluster/kind/scripts/configure-containerd.sh
+++ b/bi/pkg/cluster/kind/scripts/configure-containerd.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+# Tell containerd that nvidia-container-runtime is available
+echo "Configuring containerd to use nvidia-container-runtime..."
+nvidia-ctk runtime configure --runtime=containerd --config-source=command --cdi.enabled
+echo "Configuring containerd to use devices through volume mounts..."
+nvidia-ctk config --set accept-nvidia-visible-devices-as-volume-mounts=true --in-place
+
+# Follow Microsoft's lead and fix everything by turning it off and on again
+echo "Restarting containerd..."
+systemctl restart containerd

--- a/bi/pkg/cluster/kind/scripts/install-nvidia-toolkit.sh
+++ b/bi/pkg/cluster/kind/scripts/install-nvidia-toolkit.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+apt-get update
+# gpg to sign things
+# curl to reach the interwebs
+apt-get install -y gpg curl
+
+# Secure
+curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+# Add the new Source
+curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list |
+    sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' |
+    tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+
+# Fetch what can be installed now. It should include the
+# NVIDIA container toolkit
+apt-get update
+
+# Yep
+apt-get install -y nvidia-container-toolkit \
+    nvidia-container-toolkit-base \
+    libnvidia-container-tools \
+    libnvidia-container1

--- a/bi/pkg/cluster/kind/scripts/patch-nvidia-params.sh
+++ b/bi/pkg/cluster/kind/scripts/patch-nvidia-params.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+# Patch NVIDIA driver parameters if they exist
+if [ -f /proc/driver/nvidia/params ]; then
+    cp /proc/driver/nvidia/params root/gpu-params
+    sed -i 's/^ModifyDeviceFiles: 1$/ModifyDeviceFiles: 0/' root/gpu-params
+    mount --bind root/gpu-params /proc/driver/nvidia/params
+else
+    echo "NVIDIA driver params not found, skipping"
+fi

--- a/bi/pkg/cluster/pulumi.go
+++ b/bi/pkg/cluster/pulumi.go
@@ -200,3 +200,8 @@ func (p *pulumiProvider) toEKSConfig() *eks.Config {
 		EnvVars:    p.envVars,
 	}
 }
+
+// HasNvidiaRuntimeInstalled returns false for EKS clusters since they don't need runtime class registration
+func (p *pulumiProvider) HasNvidiaRuntimeInstalled() bool {
+	return false
+}

--- a/bi/pkg/installs/env.go
+++ b/bi/pkg/installs/env.go
@@ -26,6 +26,10 @@ type InstallEnv struct {
 	source          string
 }
 
+func (env *InstallEnv) ClusterProvider() cluster.Provider {
+	return env.clusterProvider
+}
+
 type envBuilder struct {
 	slugOrURL               string
 	additionalInsecureHosts []string

--- a/bi/pkg/specs/specs.go
+++ b/bi/pkg/specs/specs.go
@@ -1,5 +1,7 @@
 package specs
 
+import "log/slog"
+
 type KubeClusterSpec struct {
 	Provider string         `json:"provider"`
 	Config   map[string]any `json:"config"`
@@ -44,4 +46,23 @@ type InstallSpec struct {
 	InitialResources map[string]map[string]interface{} `json:"initial_resources"`
 	KubeCluster      KubeClusterSpec                   `json:"kube_cluster"`
 	TargetSummary    StateSummarySpec                  `json:"target_summary"`
+}
+
+func (s *InstallSpec) AddBattery(batterySpec BatterySpec) {
+	// First check if a battery of the same type already exists
+	if s.HasBatteryType(batterySpec.Type) {
+		slog.Warn("Battery of this type already exists", "type", batterySpec.Type)
+		return
+	}
+
+	s.TargetSummary.Batteries = append(s.TargetSummary.Batteries, batterySpec)
+}
+
+func (s *InstallSpec) HasBatteryType(batteryType string) bool {
+	for _, battery := range s.TargetSummary.Batteries {
+		if battery.Type == batteryType {
+			return true
+		}
+	}
+	return false
 }

--- a/bin/bi-registry
+++ b/bin/bi-registry
@@ -93,7 +93,7 @@ do_create_pr() {
     local update_exit_code=0
     log "Running registry updates"
     update_exit_code=$(
-        go run registry-tool update-tags ../image_registry.yaml
+        go run registry-tool update-tags --delay 500ms --jitter 250ms ../image_registry.yaml
         echo $?
     )
     local advance_exit_code=0

--- a/image_registry.yaml
+++ b/image_registry.yaml
@@ -704,8 +704,9 @@ promtail:
   tag_regex: ^\d+\.\d+\.\d+$
 redis:
   name: quay.io/opstree/redis
-  default_tag: v8.0.3
+  default_tag: v8.2.0
   tags:
+    - v8.2.0
     - v8.0.3
     - v8.0.2
     - v7.4.5
@@ -716,8 +717,13 @@ redis:
   tag_regex: ^v\d+\.\d+\.\d+$
 redis_exporter:
   name: quay.io/opstree/redis-exporter
-  default_tag: v1.48.0
+  default_tag: v1.75.0
   tags:
+    - v1.75.0
+    - v1.74.0
+    - v1.73.0
+    - v1.72.1
+    - v1.72.0
     - v1.48.0
     - v1.45.0
   tag_regex: ^v\d+\.\d+\.\d+$
@@ -763,8 +769,9 @@ trust_manager_init:
   tag_regex: ^\d{8}\.\d+$
 vm_agent:
   name: docker.io/victoriametrics/vmagent
-  default_tag: v1.123.0
+  default_tag: v1.124.0
   tags:
+    - v1.124.0
     - v1.123.0
     - v1.122.0
     - v1.121.0
@@ -814,8 +821,9 @@ vm_agent:
   tag_regex: ^v\d+\.\d+\.\d+$
 vm_insert:
   name: docker.io/victoriametrics/vminsert
-  default_tag: v1.123.0-cluster
+  default_tag: v1.124.0-cluster
   tags:
+    - v1.124.0-cluster
     - v1.123.0-cluster
     - v1.122.0-cluster
     - v1.121.0-cluster
@@ -893,8 +901,9 @@ vm_operator:
   tag_regex: ^v\d+\.\d+\.\d+$
 vm_select:
   name: docker.io/victoriametrics/vmselect
-  default_tag: v1.123.0-cluster
+  default_tag: v1.124.0-cluster
   tags:
+    - v1.124.0-cluster
     - v1.123.0-cluster
     - v1.122.0-cluster
     - v1.121.0-cluster
@@ -925,8 +934,9 @@ vm_select:
   tag_regex: ^v\d+\.\d+\.\d+-cluster$
 vm_storage:
   name: docker.io/victoriametrics/vmstorage
-  default_tag: v1.123.0-cluster
+  default_tag: v1.124.0-cluster
   tags:
+    - v1.124.0-cluster
     - v1.123.0-cluster
     - v1.122.0-cluster
     - v1.121.0-cluster

--- a/platform_umbrella/apps/common_core/lib/common_core/batteries/catalog.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/batteries/catalog.ex
@@ -189,10 +189,9 @@ defmodule CommonCore.Batteries.Catalog do
     %CatalogBattery{
       group: :ai,
       type: :nvidia_device_plugin,
-      dependencies: [:battery_core],
       name: "Nvidia Device Plugin",
       description: "The Nvidia Device Plugin for Kubernetes. This exposes the nvidia device details to kubernetes.",
-      allowed_usages: ~w(internal_dev internal_int_test)a
+      dependencies: [:battery_core, :node_feature_discovery]
     },
     %CatalogBattery{
       group: :ai,

--- a/platform_umbrella/apps/common_core/lib/common_core/resources/ml/nvidia_device_plugin.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/resources/ml/nvidia_device_plugin.ex
@@ -5,9 +5,59 @@ defmodule CommonCore.Resources.NvidiaDevicePlugin do
   import CommonCore.StateSummary.Namespaces
 
   alias CommonCore.Resources.Builder, as: B
+  alias CommonCore.StateSummary.Core
+
+  defp nvidia_gpu_affinity do
+    %{
+      "nodeAffinity" => %{
+        "requiredDuringSchedulingIgnoredDuringExecution" => %{
+          "nodeSelectorTerms" => [
+            %{
+              "matchExpressions" => [
+                %{
+                  "key" => "feature.node.kubernetes.io/pci-10de.present",
+                  "operator" => "In",
+                  "values" => ["true"]
+                }
+              ]
+            },
+            %{
+              "matchExpressions" => [
+                %{
+                  "key" => "feature.node.kubernetes.io/cpu-model.vendor_id",
+                  "operator" => "In",
+                  "values" => ["NVIDIA"]
+                }
+              ]
+            },
+            %{
+              "matchExpressions" => [
+                %{"key" => "nvidia.com/gpu.present", "operator" => "In", "values" => ["true"]}
+              ]
+            }
+          ]
+        }
+      }
+    }
+  end
+
+  defp maybe_add_runtime(template, false = _is_kind_provider) do
+    template
+  end
+
+  defp maybe_add_runtime(template, true = _is_kind_provider) do
+    update_in(template, ["spec"], fn spec -> Map.put(spec, "runtimeClassName", "nvidia") end)
+  end
+
+  defp nvidia_tolerations do
+    [
+      %{"key" => "CriticalAddonsOnly", "operator" => "Exists"},
+      %{"effect" => "NoSchedule", "key" => "nvidia.com/gpu", "operator" => "Exists"}
+    ]
+  end
 
   resource(:nvidia_device_plugin, battery, state) do
-    namespace = core_namespace(state)
+    namespace = ai_namespace(state)
 
     template =
       %{}
@@ -15,42 +65,14 @@ defmodule CommonCore.Resources.NvidiaDevicePlugin do
       |> Map.put(
         "spec",
         %{
-          "affinity" => %{
-            "nodeAffinity" => %{
-              "requiredDuringSchedulingIgnoredDuringExecution" => %{
-                "nodeSelectorTerms" => [
-                  %{
-                    "matchExpressions" => [
-                      %{"key" => "feature.node.kubernetes.io/pci-10de.present", "operator" => "In", "values" => ["true"]}
-                    ]
-                  },
-                  %{
-                    "matchExpressions" => [
-                      %{
-                        "key" => "feature.node.kubernetes.io/cpu-model.vendor_id",
-                        "operator" => "In",
-                        "values" => ["NVIDIA"]
-                      }
-                    ]
-                  },
-                  %{
-                    "matchExpressions" => [%{"key" => "nvidia.com/gpu.present", "operator" => "In", "values" => ["true"]}]
-                  }
-                ]
-              }
-            }
-          },
+          "affinity" => nvidia_gpu_affinity(),
           "containers" => [
             %{
               "command" => ["nvidia-device-plugin"],
-              "env" => [
-                %{"name" => "MPS_ROOT", "value" => "/run/nvidia/mps"},
-                %{"name" => "NVIDIA_VISIBLE_DEVICES", "value" => "all"},
-                %{"name" => "NVIDIA_DRIVER_CAPABILITIES", "value" => "compute,utility"}
-              ],
+              "env" => nvdp_env(Core.kind_cluster?(state)),
               "image" => battery.config.image,
               "name" => "nvidia-device-plugin-ctr",
-              "securityContext" => %{"allowPrivilegeEscalation" => false, "capabilities" => %{"drop" => ["ALL"]}},
+              "securityContext" => nvdp_security_context(Core.kind_cluster?(state)),
               "volumeMounts" => [
                 %{"mountPath" => "/var/lib/kubelet/device-plugins", "name" => "device-plugin"},
                 %{"mountPath" => "/dev/shm", "name" => "mps-shm"},
@@ -59,10 +81,7 @@ defmodule CommonCore.Resources.NvidiaDevicePlugin do
               ]
             }
           ],
-          "tolerations" => [
-            %{"key" => "CriticalAddonsOnly", "operator" => "Exists"},
-            %{"effect" => "NoSchedule", "key" => "nvidia.com/gpu", "operator" => "Exists"}
-          ],
+          "tolerations" => nvidia_tolerations(),
           "volumes" => [
             %{"hostPath" => %{"path" => "/var/lib/kubelet/device-plugins"}, "name" => "device-plugin"},
             %{"hostPath" => %{"path" => "/run/nvidia/mps", "type" => "DirectoryOrCreate"}, "name" => "mps-root"},
@@ -74,6 +93,7 @@ defmodule CommonCore.Resources.NvidiaDevicePlugin do
       |> B.app_labels(@app_name)
       |> B.add_owner(battery)
       |> B.component_labels("nvidia-device-plugin")
+      |> maybe_add_runtime(Core.kind_cluster?(state))
 
     spec =
       %{}
@@ -92,48 +112,39 @@ defmodule CommonCore.Resources.NvidiaDevicePlugin do
     |> B.spec(spec)
   end
 
+  # This is the security context for the NVIDIA device plugin container
+  defp nvdp_security_context(false = _is_kind_provider),
+    do: %{"allowPrivilegeEscalation" => false, "capabilities" => %{"drop" => ["ALL"]}}
+
+  defp nvdp_security_context(true = _is_kind_provider), do: %{"capabilities" => %{"add" => ["SYS_ADMIN"]}}
+
+  defp nvdp_env(false = _is_kind_provider) do
+    [
+      %{"name" => "MPS_ROOT", "value" => "/run/nvidia/mps"},
+      %{"name" => "NVIDIA_VISIBLE_DEVICES", "value" => "all"},
+      %{"name" => "NVIDIA_DRIVER_CAPABILITIES", "value" => "compute,utility"}
+    ]
+  end
+
+  defp nvdp_env(true = _is_kind_provider) do
+    [
+      %{"name" => "MPS_ROOT", "value" => "/run/nvidia/mps"},
+      %{"name" => "NVIDIA_VISIBLE_DEVICES", "value" => "all"},
+      %{"name" => "DEVICE_LIST_STRATEGY", "value" => "volume-mounts"},
+      %{"name" => "NVIDIA_DRIVER_CAPABILITIES", "value" => "compute,utility"}
+    ]
+  end
+
   resource(:mps_control, battery, state) do
-    namespace = core_namespace(state)
+    namespace = ai_namespace(state)
 
     template =
       %{}
-      |> Map.put(
-        "metadata",
-        %{
-          "annotations" => %{},
-          "labels" => %{
-            "battery/managed" => "true"
-          }
-        }
-      )
+      |> Map.put("metadata", %{"labels" => %{"battery/managed" => "true"}})
       |> Map.put(
         "spec",
         %{
-          "affinity" => %{
-            "nodeAffinity" => %{
-              "requiredDuringSchedulingIgnoredDuringExecution" => %{
-                "nodeSelectorTerms" => [
-                  %{
-                    "matchExpressions" => [
-                      %{"key" => "feature.node.kubernetes.io/pci-10de.present", "operator" => "In", "values" => ["true"]}
-                    ]
-                  },
-                  %{
-                    "matchExpressions" => [
-                      %{
-                        "key" => "feature.node.kubernetes.io/cpu-model.vendor_id",
-                        "operator" => "In",
-                        "values" => ["NVIDIA"]
-                      }
-                    ]
-                  },
-                  %{
-                    "matchExpressions" => [%{"key" => "nvidia.com/gpu.present", "operator" => "In", "values" => ["true"]}]
-                  }
-                ]
-              }
-            }
-          },
+          "affinity" => nvidia_gpu_affinity(),
           "containers" => [
             %{
               "command" => ["mps-control-daemon"],
@@ -166,10 +177,7 @@ defmodule CommonCore.Resources.NvidiaDevicePlugin do
           "nodeSelector" => %{"nvidia.com/mps.capable" => "true"},
           "priorityClassName" => "system-node-critical",
           "securityContext" => %{},
-          "tolerations" => [
-            %{"key" => "CriticalAddonsOnly", "operator" => "Exists"},
-            %{"effect" => "NoSchedule", "key" => "nvidia.com/gpu", "operator" => "Exists"}
-          ],
+          "tolerations" => nvidia_tolerations(),
           "volumes" => [
             %{"hostPath" => %{"path" => "/run/nvidia/mps", "type" => "DirectoryOrCreate"}, "name" => "mps-root"},
             %{"hostPath" => %{"path" => "/run/nvidia/mps/shm"}, "name" => "mps-shm"}
@@ -179,6 +187,7 @@ defmodule CommonCore.Resources.NvidiaDevicePlugin do
       |> B.app_labels(@app_name)
       |> B.add_owner(battery)
       |> B.component_labels("mps-control-daemon")
+      |> maybe_add_runtime(Core.kind_cluster?(state))
 
     spec =
       %{}
@@ -194,6 +203,82 @@ defmodule CommonCore.Resources.NvidiaDevicePlugin do
     |> B.name("nvdp-mps-control-daemon")
     |> B.component_labels("mps-control-daemon")
     |> B.namespace(namespace)
+    |> B.spec(spec)
+  end
+
+  resource(:gpu_feature, battery, state) do
+    namespace = ai_namespace(state)
+
+    template =
+      %{}
+      |> Map.put("metadata", %{"labels" => %{"battery/managed" => "true"}})
+      |> Map.put("spec", %{
+        "affinity" => nvidia_gpu_affinity(),
+        "containers" => [
+          %{
+            "command" => ["gpu-feature-discovery"],
+            "env" => [
+              %{
+                "name" => "NODE_NAME",
+                "valueFrom" => %{"fieldRef" => %{"fieldPath" => "spec.nodeName"}}
+              },
+              %{
+                "name" => "NAMESPACE",
+                "valueFrom" => %{"fieldRef" => %{"fieldPath" => "metadata.namespace"}}
+              },
+              %{"name" => "GFD_USE_NODE_FEATURE_API", "value" => "false"},
+              %{"name" => "DEVICE_DISCOVERY_STRATEGY", "value" => "nvml"}
+            ],
+            "image" => battery.config.image,
+            "imagePullPolicy" => "IfNotPresent",
+            "name" => "gpu-feature-discovery-ctr",
+            "securityContext" => %{"privileged" => true},
+            "volumeMounts" => [
+              %{
+                "mountPath" => "/etc/kubernetes/node-feature-discovery/features.d",
+                "name" => "output-dir"
+              },
+              %{"mountPath" => "/sys", "name" => "host-sys"},
+              %{"mountPath" => "/config", "name" => "config"}
+            ]
+          }
+        ],
+        "initContainers" => nil,
+        "priorityClassName" => "system-node-critical",
+        "runtimeClassName" => "nvidia",
+        "securityContext" => %{},
+        "tolerations" => nvidia_tolerations(),
+        "volumes" => [
+          %{
+            "hostPath" => %{"path" => "/etc/kubernetes/node-feature-discovery/features.d"},
+            "name" => "output-dir"
+          },
+          %{"hostPath" => %{"path" => "/sys"}, "name" => "host-sys"},
+          %{"hostPath" => %{"path" => "/", "type" => "Directory"}, "name" => "driver-root"},
+          %{"emptyDir" => %{}, "name" => "config"}
+        ]
+      })
+      |> B.app_labels(@app_name)
+      |> B.add_owner(battery)
+      |> B.component_labels("gpu-feature-discovery")
+      |> maybe_add_runtime(Core.kind_cluster?(state))
+
+    spec =
+      %{}
+      |> Map.put("selector", %{
+        "matchLabels" => %{
+          "battery/app" => @app_name,
+          "battery/component" => "gpu-feature-discovery"
+        }
+      })
+      |> Map.put("updateStrategy", %{"type" => "RollingUpdate"})
+      |> B.template(template)
+
+    :daemon_set
+    |> B.build_resource()
+    |> B.name("nvdp-gpu-feature-discovery")
+    |> B.namespace(namespace)
+    |> B.component_labels("gpu-feature-discovery")
     |> B.spec(spec)
   end
 end

--- a/platform_umbrella/apps/common_core/lib/common_core/resources/resource_generator/copy_down.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/resources/resource_generator/copy_down.ex
@@ -5,7 +5,11 @@ defmodule CommonCore.Resources.CopyDown do
   @banned_labels ["battery/managed.direct"]
   @banned_annotations ["battery/hash"]
 
-  @default_labels %{"battery/managed" => "true", "battery/managed.indirect" => "true"}
+  @default_labels %{
+    "battery/managed" => "true",
+    "app.kubernetes.io/managed-by" => "batteries-included",
+    "battery/managed.indirect" => "true"
+  }
 
   def indirect_labels, do: @default_labels
 

--- a/platform_umbrella/apps/common_core/lib/common_core/state_summary/batteries.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/state_summary/batteries.ex
@@ -65,4 +65,5 @@ defmodule CommonCore.StateSummary.Batteries do
 
   def sso_installed?(%StateSummary{} = state), do: batteries_installed?(state, [:sso])
   def keycloak_installed?(%StateSummary{} = state), do: batteries_installed?(state, [:keycloak])
+  def victoria_metrics_installed?(%StateSummary{} = state), do: batteries_installed?(state, [:victoria_metrics])
 end

--- a/platform_umbrella/apps/common_core/lib/common_core/state_summary/core.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/state_summary/core.ex
@@ -66,4 +66,11 @@ defmodule CommonCore.StateSummary.Core do
     config = battery_core_config(summary)
     Enum.zip(~w(monday tuesday wednesday thursday friday saturday sunday)a, config.upgrade_days_of_week)
   end
+
+  def kind_cluster?(%StateSummary{} = summary) do
+    case battery_core_config(summary) do
+      %BatteryCoreConfig{cluster_type: :kind} -> true
+      _ -> false
+    end
+  end
 end

--- a/platform_umbrella/apps/common_core/lib/common_core/util/images.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/util/images.ex
@@ -1,0 +1,206 @@
+defmodule CommonCore.Util.Images do
+  @moduledoc """
+  Utilities for parsing and extracting components from container image strings.
+
+  This module provides functions to parse container image strings and extract
+  their components (repository, image name, and version/tag).
+
+  ## Image Format
+
+  Container images follow the format: `[registry/]namespace/image:tag`
+
+  Examples:
+  - `nginx:1.21`
+  - `docker.io/library/nginx:1.21`
+  - `nvcr.io/nvidia/cuda:12.8.1-base-ubi9`
+  - `registry.k8s.io/autoscaling/addon-resizer:1.8.23`
+
+  ## Functions
+
+  - `repository/1` - Extracts the repository (registry + namespace) part
+  - `image/1` - Extracts just the image name (last path component before tag)
+  - `version/1` - Extracts the version/tag part after the colon
+  """
+
+  @doc """
+  Extracts the repository portion from a container image string.
+
+  The repository includes the registry and namespace parts, but excludes
+  the image name and tag.
+
+  ## Examples
+
+      iex> CommonCore.Util.Images.repository("nginx:1.21")
+      ""
+
+      iex> CommonCore.Util.Images.repository("docker.io/library/nginx:1.21")
+      "docker.io/library"
+
+      iex> CommonCore.Util.Images.repository("nvcr.io/nvidia/cuda:12.8.1-base-ubi9")
+      "nvcr.io/nvidia"
+
+      iex> CommonCore.Util.Images.repository("registry.k8s.io/autoscaling/addon-resizer:1.8.23")
+      "registry.k8s.io/autoscaling"
+
+      iex> CommonCore.Util.Images.repository("gcr.io/project/image:tag")
+      "gcr.io/project"
+
+      iex> CommonCore.Util.Images.repository("localhost:5000/team/myapp:v1.0")
+      "localhost:5000/team"
+
+  ## Edge Cases
+
+      iex> CommonCore.Util.Images.repository("image")
+      ""
+
+      iex> CommonCore.Util.Images.repository("image:tag")
+      ""
+
+      iex> CommonCore.Util.Images.repository("namespace/image")
+      "namespace"
+
+  """
+  @spec repository(String.t()) :: String.t()
+  def repository(image_string) when is_binary(image_string) do
+    {image_without_tag, _tag} = split_image_and_tag(image_string)
+
+    parts = String.split(image_without_tag, "/")
+
+    case parts do
+      [_single] -> ""
+      parts -> parts |> Enum.drop(-1) |> Enum.join("/")
+    end
+  end
+
+  @doc """
+  Extracts the image name from a container image string.
+
+  The image name is the last path component before the tag (if present).
+
+  ## Examples
+
+      iex> CommonCore.Util.Images.image("nginx:1.21")
+      "nginx"
+
+      iex> CommonCore.Util.Images.image("docker.io/library/nginx:1.21")
+      "nginx"
+
+      iex> CommonCore.Util.Images.image("nvcr.io/nvidia/cuda:12.8.1-base-ubi9")
+      "cuda"
+
+      iex> CommonCore.Util.Images.image("registry.k8s.io/autoscaling/addon-resizer:1.8.23")
+      "addon-resizer"
+
+      iex> CommonCore.Util.Images.image("gcr.io/project/my-app:v1.0.0")
+      "my-app"
+
+      iex> CommonCore.Util.Images.image("localhost:5000/team/myapp:v1.0")
+      "myapp"
+
+  ## Edge Cases
+
+      iex> CommonCore.Util.Images.image("image")
+      "image"
+
+      iex> CommonCore.Util.Images.image("namespace/image")
+      "image"
+
+      iex> CommonCore.Util.Images.image("deep/nested/namespace/image:tag")
+      "image"
+
+  """
+  @spec image(String.t()) :: String.t()
+  def image(image_string) when is_binary(image_string) do
+    {image_without_tag, _tag} = split_image_and_tag(image_string)
+
+    image_without_tag
+    |> String.split("/")
+    |> List.last()
+  end
+
+  @doc """
+  Extracts the version/tag from a container image string.
+
+  If no tag is specified, returns "latest" as the default.
+
+  ## Examples
+
+      iex> CommonCore.Util.Images.version("nginx:1.21")
+      "1.21"
+
+      iex> CommonCore.Util.Images.version("docker.io/library/nginx:1.21")
+      "1.21"
+
+      iex> CommonCore.Util.Images.version("nvcr.io/nvidia/cuda:12.8.1-base-ubi9")
+      "12.8.1-base-ubi9"
+
+      iex> CommonCore.Util.Images.version("registry.k8s.io/autoscaling/addon-resizer:1.8.23")
+      "1.8.23"
+
+      iex> CommonCore.Util.Images.version("gcr.io/project/my-app:v1.0.0")
+      "v1.0.0"
+
+      iex> CommonCore.Util.Images.version("localhost:5000/team/myapp:v1.0")
+      "v1.0"
+
+  ## Default Tag
+
+      iex> CommonCore.Util.Images.version("nginx")
+      "latest"
+
+      iex> CommonCore.Util.Images.version("docker.io/library/nginx")
+      "latest"
+
+      iex> CommonCore.Util.Images.version("gcr.io/project/my-app")
+      "latest"
+
+  """
+  @spec version(String.t()) :: String.t()
+  def version(image_string) when is_binary(image_string) do
+    {_image_without_tag, tag} = split_image_and_tag(image_string)
+    tag
+  end
+
+  # Private helper function to split image string into image part and tag part
+  # This correctly handles registries with ports (like localhost:5000)
+  @spec split_image_and_tag(String.t()) :: {String.t(), String.t()}
+  defp split_image_and_tag(image_string) do
+    # Find the last colon that's followed by a tag (not part of a registry port)
+    # We do this by finding all parts separated by colons and determining
+    # if the last part looks like a tag vs part of a registry
+
+    parts = String.split(image_string, ":")
+
+    case parts do
+      # No colons - no tag specified
+      [image] ->
+        {image, "latest"}
+
+      # One colon - could be registry:port or image:tag
+      [first, second] ->
+        # If the second part contains a slash, it's likely registry:port/path
+        # If it doesn't contain a slash and looks like a tag, it's image:tag
+        if String.contains?(second, "/") do
+          # This is registry:port/path - no tag specified
+          {image_string, "latest"}
+        else
+          # This is image:tag
+          {first, second}
+        end
+
+      # Multiple colons - need to find the tag
+      _ ->
+        # The tag is the last part, unless it contains a slash (then it's part of path)
+        tag_candidate = List.last(parts)
+
+        if String.contains?(tag_candidate, "/") do
+          # Last part contains slash, so no tag specified
+          {image_string, "latest"}
+        else
+          # Last part is the tag
+          image_part = parts |> Enum.drop(-1) |> Enum.join(":")
+          {image_part, tag_candidate}
+        end
+    end
+  end
+end

--- a/platform_umbrella/apps/common_core/test/common_core/util/images_test.exs
+++ b/platform_umbrella/apps/common_core/test/common_core/util/images_test.exs
@@ -1,0 +1,182 @@
+defmodule CommonCore.Util.ImagesTest do
+  use ExUnit.Case, async: true
+
+  alias CommonCore.Util.Images
+
+  doctest Images
+
+  describe "repository/1" do
+    test "extracts repository from full image string" do
+      assert Images.repository("nvcr.io/nvidia/cuda:12.8.1-base-ubi9") == "nvcr.io/nvidia"
+      assert Images.repository("docker.io/library/nginx:1.21") == "docker.io/library"
+      assert Images.repository("registry.k8s.io/autoscaling/addon-resizer:1.8.23") == "registry.k8s.io/autoscaling"
+      assert Images.repository("gcr.io/my-project/my-app:v1.0.0") == "gcr.io/my-project"
+    end
+
+    test "handles images with namespace but no registry" do
+      assert Images.repository("library/nginx:1.21") == "library"
+      assert Images.repository("nvidia/cuda:latest") == "nvidia"
+      assert Images.repository("company/internal/app:dev") == "company/internal"
+    end
+
+    test "handles simple image names without repository" do
+      assert Images.repository("nginx:1.21") == ""
+      assert Images.repository("redis:6.2") == ""
+      assert Images.repository("postgres:13") == ""
+    end
+
+    test "handles images without tags" do
+      assert Images.repository("nvcr.io/nvidia/cuda") == "nvcr.io/nvidia"
+      assert Images.repository("docker.io/library/nginx") == "docker.io/library"
+      assert Images.repository("nginx") == ""
+    end
+
+    test "handles deep namespaces" do
+      assert Images.repository("registry.company.com/team/project/service/app:v1.0") ==
+               "registry.company.com/team/project/service"
+
+      assert Images.repository("localhost:5000/dev/test/image:latest") == "localhost:5000/dev/test"
+    end
+
+    test "handles edge cases" do
+      assert Images.repository("") == ""
+      assert Images.repository("single") == ""
+      assert Images.repository("single:tag") == ""
+    end
+  end
+
+  describe "image/1" do
+    test "extracts image name from full image string" do
+      assert Images.image("nvcr.io/nvidia/cuda:12.8.1-base-ubi9") == "cuda"
+      assert Images.image("docker.io/library/nginx:1.21") == "nginx"
+      assert Images.image("registry.k8s.io/autoscaling/addon-resizer:1.8.23") == "addon-resizer"
+      assert Images.image("gcr.io/my-project/my-app:v1.0.0") == "my-app"
+    end
+
+    test "handles images with namespace but no registry" do
+      assert Images.image("library/nginx:1.21") == "nginx"
+      assert Images.image("nvidia/cuda:latest") == "cuda"
+      assert Images.image("company/app:dev") == "app"
+    end
+
+    test "handles simple image names without repository" do
+      assert Images.image("nginx:1.21") == "nginx"
+      assert Images.image("redis:6.2") == "redis"
+      assert Images.image("postgres:13") == "postgres"
+    end
+
+    test "handles images without tags" do
+      assert Images.image("nvcr.io/nvidia/cuda") == "cuda"
+      assert Images.image("docker.io/library/nginx") == "nginx"
+      assert Images.image("nginx") == "nginx"
+    end
+
+    test "handles hyphenated and special character image names" do
+      assert Images.image("registry.k8s.io/autoscaling/addon-resizer:1.8.23") == "addon-resizer"
+      assert Images.image("gcr.io/project/my_app:latest") == "my_app"
+      assert Images.image("registry.com/team/app.service:v1") == "app.service"
+    end
+
+    test "handles deep namespaces" do
+      assert Images.image("registry.company.com/team/project/service/final-app:v1.0") == "final-app"
+      assert Images.image("localhost:5000/dev/test/nested/image:latest") == "image"
+    end
+
+    test "handles edge cases" do
+      assert Images.image("") == ""
+      assert Images.image("single") == "single"
+      assert Images.image("single:tag") == "single"
+    end
+  end
+
+  describe "version/1" do
+    test "extracts version from full image string" do
+      assert Images.version("nvcr.io/nvidia/cuda:12.8.1-base-ubi9") == "12.8.1-base-ubi9"
+      assert Images.version("docker.io/library/nginx:1.21") == "1.21"
+      assert Images.version("registry.k8s.io/autoscaling/addon-resizer:1.8.23") == "1.8.23"
+      assert Images.version("gcr.io/my-project/my-app:v1.0.0") == "v1.0.0"
+    end
+
+    test "handles complex version strings" do
+      assert Images.version("nginx:1.21.3-alpine") == "1.21.3-alpine"
+      assert Images.version("postgres:13.4-bullseye") == "13.4-bullseye"
+      assert Images.version("node:16.14.0-alpine3.15") == "16.14.0-alpine3.15"
+      assert Images.version("mysql:8.0.28-debian") == "8.0.28-debian"
+    end
+
+    test "handles semantic versioning" do
+      assert Images.version("myapp:v1.2.3") == "v1.2.3"
+      assert Images.version("service:v2.0.0-rc.1") == "v2.0.0-rc.1"
+      assert Images.version("api:1.0.0-beta.5") == "1.0.0-beta.5"
+    end
+
+    test "returns 'latest' for images without explicit tags" do
+      assert Images.version("nginx") == "latest"
+      assert Images.version("docker.io/library/nginx") == "latest"
+      assert Images.version("nvcr.io/nvidia/cuda") == "latest"
+      assert Images.version("gcr.io/project/app") == "latest"
+    end
+
+    test "handles special tags" do
+      assert Images.version("nginx:latest") == "latest"
+      assert Images.version("app:dev") == "dev"
+      assert Images.version("service:staging") == "staging"
+      assert Images.version("api:main") == "main"
+    end
+
+    test "handles versions with multiple colons" do
+      # Only splits on the first colon, so port numbers in registries work correctly
+      assert Images.version("localhost:5000/app:v1.0") == "v1.0"
+      assert Images.version("registry.com:8080/project/service:latest") == "latest"
+    end
+
+    test "handles edge cases" do
+      assert Images.version("") == "latest"
+      assert Images.version("app:") == ""
+      assert Images.version(":tag") == "tag"
+    end
+  end
+
+  describe "integration tests" do
+    test "all functions work together on real-world examples" do
+      # NVIDIA GPU Operator images
+      gpu_operator_image = "nvcr.io/nvidia/gpu-operator:v25.3.2"
+      assert Images.repository(gpu_operator_image) == "nvcr.io/nvidia"
+      assert Images.image(gpu_operator_image) == "gpu-operator"
+      assert Images.version(gpu_operator_image) == "v25.3.2"
+
+      # Kubernetes system images
+      k8s_image = "registry.k8s.io/autoscaling/addon-resizer:1.8.23"
+      assert Images.repository(k8s_image) == "registry.k8s.io/autoscaling"
+      assert Images.image(k8s_image) == "addon-resizer"
+      assert Images.version(k8s_image) == "1.8.23"
+
+      # Simple Docker Hub images
+      simple_image = "nginx:1.21.3-alpine"
+      assert Images.repository(simple_image) == ""
+      assert Images.image(simple_image) == "nginx"
+      assert Images.version(simple_image) == "1.21.3-alpine"
+
+      # Private registry with port
+      private_image = "localhost:5000/team/myapp:v2.0.0"
+      assert Images.repository(private_image) == "localhost:5000/team"
+      assert Images.image(private_image) == "myapp"
+      assert Images.version(private_image) == "v2.0.0"
+    end
+
+    test "reconstructing image strings" do
+      original = "nvcr.io/nvidia/k8s-device-plugin:v0.17.3"
+      repo = Images.repository(original)
+      image = Images.image(original)
+      version = Images.version(original)
+
+      reconstructed =
+        case repo do
+          "" -> "#{image}:#{version}"
+          _ -> "#{repo}/#{image}:#{version}"
+        end
+
+      assert reconstructed == original
+    end
+  end
+end

--- a/registry-tool/cmd/advance_defaults.go
+++ b/registry-tool/cmd/advance_defaults.go
@@ -33,7 +33,7 @@ This is useful for ensuring that the default tag always points to the latest ver
 			return fmt.Errorf("failed to read registry file: %w", err)
 		}
 
-		updater := registry.NewRegistryUpdater(reg, advanceDefaultsCmdFlags.ignoredImages)
+		updater := registry.NewRegistryUpdater(reg, advanceDefaultsCmdFlags.ignoredImages, 0)
 		if err := updater.UpdateDefaultTags(); err != nil {
 			return fmt.Errorf("failed to advance default tags: %w", err)
 		}

--- a/registry-tool/cmd/flags.go
+++ b/registry-tool/cmd/flags.go
@@ -1,8 +1,13 @@
 package cmd
 
+import "time"
+
 type SharedRegistryFlags struct {
 	ignoredImages []string
 	dryRun        bool
+	delay         time.Duration
+	jitter        time.Duration
+	maxFailures   int
 }
 
 var DefaultIgnoredImages = []string{
@@ -21,4 +26,7 @@ var DefaultIgnoredImages = []string{
 	//  Uncaught TypeError: Cannot read properties of undefined (reading 'keys')
 	// ```
 	"docker.io/grafana/grafana",
+
+	// No Users are not ready for Cuda versions to be automatically updated
+	"docker.io/nvidia/cuda",
 }

--- a/registry-tool/cmd/inspect.go
+++ b/registry-tool/cmd/inspect.go
@@ -1,0 +1,160 @@
+/*
+Copyright © 2025 Elliott Clark
+*/
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"registry-tool/pkg/registry"
+	"slices"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// inspectCmd represents the inspect command
+var inspectCmd = &cobra.Command{
+	Use:     "inspect <registry-file> <image-id>",
+	Example: "registry-tool inspect registry.yaml my-image",
+	Args:    cobra.ExactArgs(2), // Ensure exactly two arguments are provided
+	Short:   "Inspect local and remote registry information for an image",
+	Long: `Inspect displays detailed information about an image including:
+- Local registry information (current tags, default tag, etc.)
+- Remote registry information equivalent to 'docker image inspect' for all remote tags`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		registryFile := args[0]
+		imageId := args[1]
+
+		reg, err := registry.Read(registryFile)
+		if err != nil {
+			return fmt.Errorf("failed to read registry file %q: %w", registryFile, err)
+		}
+
+		record, found := reg.Get(imageId)
+		if !found {
+			return fmt.Errorf("image %q not found in registry file %q", imageId, registryFile)
+		}
+
+		return inspectImage(record)
+	},
+}
+
+type LocalImageInfo struct {
+	Name            string   `json:"name"`
+	DefaultTag      string   `json:"default_tag"`
+	CurrentTags     []string `json:"current_tags"`
+	BlacklistedTags []string `json:"blacklisted_tags,omitempty"`
+	TagRegex        string   `json:"tag_regex,omitempty"`
+	MaxTag          string   `json:"max_tag"`
+}
+
+type InspectOutput struct {
+	Local  LocalImageInfo           `json:"local"`
+	Remote []registry.RemoteTagInfo `json:"remote"`
+}
+
+func inspectImage(record registry.ImageRecord) error {
+	// Print local information
+	fmt.Println("=== LOCAL REGISTRY INFORMATION ===")
+	localInfo := LocalImageInfo{
+		Name:            record.Name,
+		DefaultTag:      record.DefaultTag,
+		CurrentTags:     record.Tags,
+		BlacklistedTags: record.BlacklistedTags,
+		TagRegex:        record.TagRegex,
+		MaxTag:          record.MaxTag(),
+	}
+
+	localJSON, err := json.MarshalIndent(localInfo, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal local info: %w", err)
+	}
+	fmt.Println(string(localJSON))
+
+	fmt.Println("\n=== REMOTE REGISTRY INFORMATION ===")
+
+	// Get remote information for all tags
+	remoteInfo, err := getRemoteTagsInfo(record)
+	if err != nil {
+		return fmt.Errorf("failed to get remote information: %w", err)
+	}
+
+	if len(remoteInfo) == 0 {
+		fmt.Println("No remote tags found or accessible")
+		return nil
+	}
+
+	// Print detailed remote information
+	for _, tagInfo := range remoteInfo {
+		fmt.Printf("\n--- Tag: %s ---\n", tagInfo.Tag)
+		tagJSON, err := json.MarshalIndent(tagInfo, "", "  ")
+		if err != nil {
+			slog.Warn("failed to marshal tag info", "tag", tagInfo.Tag, "error", err)
+			continue
+		}
+		fmt.Println(string(tagJSON))
+	}
+
+	// Also print combined output for programmatic use
+	fmt.Println("\n=== COMBINED OUTPUT ===")
+	output := InspectOutput{
+		Local:  localInfo,
+		Remote: remoteInfo,
+	}
+
+	combinedJSON, err := json.MarshalIndent(output, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal combined output: %w", err)
+	}
+	fmt.Println(string(combinedJSON))
+
+	return nil
+}
+
+func getRemoteTagsInfo(record registry.ImageRecord) ([]registry.RemoteTagInfo, error) {
+	// Create a remote repository with default retry settings
+	remoteRepo, err := registry.NewBatteryRemoteRepositoryFromString(record.Name, 3, 1*time.Second, 500*time.Millisecond)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create remote repository for %q: %w", record.Name, err)
+	}
+
+	// Get all available tags from remote
+	remoteTags, err := remoteRepo.ListTags()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list remote tags for %q: %w", record.Name, err)
+	}
+
+	// Filter to only the tags we're interested in (those in our local registry plus any that match our regex)
+	var tagsToInspect []string
+
+	// Add all tags from our local registry
+	tagsToInspect = append(tagsToInspect, record.Tags...)
+
+	// Add the default tag if not already included
+	if !slices.Contains(tagsToInspect, record.DefaultTag) {
+		tagsToInspect = append(tagsToInspect, record.DefaultTag)
+	}
+
+	// Also include any remote tags that match our filter criteria
+	if record.TagRegex != "" {
+		filteredTags, err := record.FilterTags(remoteTags)
+		if err != nil {
+			slog.Warn("failed to filter remote tags", "error", err)
+		} else {
+			for _, tag := range filteredTags {
+				if !slices.Contains(tagsToInspect, tag) {
+					tagsToInspect = append(tagsToInspect, tag)
+				}
+			}
+		}
+	}
+
+	// Get detailed information for all tags
+	return remoteRepo.GetTagsInfo(tagsToInspect)
+}
+
+func init() {
+	RootCmd.AddCommand(inspectCmd)
+}

--- a/registry-tool/go.mod
+++ b/registry-tool/go.mod
@@ -10,6 +10,7 @@ require (
 )
 
 require (
+	github.com/avast/retry-go/v4 v4.6.1 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.16.3 // indirect
 	github.com/docker/cli v28.2.2+incompatible // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect

--- a/registry-tool/go.sum
+++ b/registry-tool/go.sum
@@ -1,3 +1,5 @@
+github.com/avast/retry-go/v4 v4.6.1 h1:VkOLRubHdisGrHnTu89g08aQEWEgRU7LVEop3GbIcMk=
+github.com/avast/retry-go/v4 v4.6.1/go.mod h1:V6oF8njAwxJ5gRo1Q7Cxab24xs5NCWZBeaHHBklR8mA=
 github.com/containerd/stargz-snapshotter/estargz v0.16.3 h1:7evrXtoh1mSbGj/pfRccTampEyKpjpOnS3CyiV1Ebr8=
 github.com/containerd/stargz-snapshotter/estargz v0.16.3/go.mod h1:uyr4BfYfOj3G9WBVE8cOlQmXAbPN9VEQpBBeJIuOipU=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/registry-tool/pkg/registry/registry_updater_test.go
+++ b/registry-tool/pkg/registry/registry_updater_test.go
@@ -1,0 +1,103 @@
+package registry
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCalculateDelay(t *testing.T) {
+	tests := []struct {
+		name        string
+		delay       time.Duration
+		jitter      time.Duration
+		expectedMin time.Duration
+		expectedMax time.Duration
+	}{
+		{
+			name:        "no delay",
+			delay:       0,
+			jitter:      0,
+			expectedMin: 0,
+			expectedMax: 0,
+		},
+		{
+			name:        "delay without jitter",
+			delay:       1 * time.Second,
+			jitter:      0,
+			expectedMin: 1 * time.Second,
+			expectedMax: 1 * time.Second,
+		},
+		{
+			name:        "delay with jitter",
+			delay:       1 * time.Second,
+			jitter:      200 * time.Millisecond,
+			expectedMin: 0, // Could be reduced to 0 due to negative jitter
+			expectedMax: 1200 * time.Millisecond,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			updater := &RegistryUpdater{
+				delay:  tt.delay,
+				jitter: tt.jitter,
+			}
+
+			// Test multiple times to account for randomness
+			for i := 0; i < 10; i++ {
+				result := updater.calculateDelay()
+
+				if result < tt.expectedMin {
+					t.Errorf("calculateDelay() = %v, expected >= %v", result, tt.expectedMin)
+				}
+				if result > tt.expectedMax {
+					t.Errorf("calculateDelay() = %v, expected <= %v", result, tt.expectedMax)
+				}
+			}
+		})
+	}
+}
+
+func TestNewRegistryUpdaterWithDelay(t *testing.T) {
+	registry := NewRegistry()
+	ignoredImages := []string{"test/image"}
+	delay := 1 * time.Second
+	jitter := 200 * time.Millisecond
+	maxFailures := 5
+
+	updater := NewRegistryUpdaterWithDelay(registry, ignoredImages, delay, jitter, maxFailures)
+
+	if updater.delay != delay {
+		t.Errorf("expected delay %v, got %v", delay, updater.delay)
+	}
+	if updater.jitter != jitter {
+		t.Errorf("expected jitter %v, got %v", jitter, updater.jitter)
+	}
+	if updater.maxFailures != maxFailures {
+		t.Errorf("expected maxFailures %v, got %v", maxFailures, updater.maxFailures)
+	}
+	if len(updater.ignoredList) != 1 || updater.ignoredList[0] != "test/image" {
+		t.Errorf("expected ignoredList [test/image], got %v", updater.ignoredList)
+	}
+}
+
+func TestNewRegistryUpdater(t *testing.T) {
+	registry := NewRegistry()
+	ignoredImages := []string{"test/image"}
+	maxFailures := 3
+
+	updater := NewRegistryUpdater(registry, ignoredImages, maxFailures)
+
+	if updater.delay != 0 {
+		t.Errorf("expected delay 0, got %v", updater.delay)
+	}
+	if updater.jitter != 0 {
+		t.Errorf("expected jitter 0, got %v", updater.jitter)
+	}
+	if updater.maxFailures != maxFailures {
+		t.Errorf("expected maxFailures %v, got %v", maxFailures, updater.maxFailures)
+	}
+	if len(updater.ignoredList) != 1 || updater.ignoredList[0] != "test/image" {
+		t.Errorf("expected ignoredList [test/image], got %v", updater.ignoredList)
+	}
+}

--- a/registry-tool/pkg/registry/remote_repository.go
+++ b/registry-tool/pkg/registry/remote_repository.go
@@ -1,0 +1,221 @@
+package registry
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/avast/retry-go/v4"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+)
+
+// BatteryRemoteRepository provides methods to interact with remote container registries
+// with configurable retry logic and authentication
+type BatteryRemoteRepository struct {
+	repository name.Repository
+	keychain   authn.Keychain
+	attempts   uint
+	delay      time.Duration
+	jitter     time.Duration
+}
+
+// NewBatteryRemoteRepository creates a new remote repository handler
+func NewBatteryRemoteRepository(repo name.Repository, attempts uint, delay, jitter time.Duration) *BatteryRemoteRepository {
+	// If delay or jitter are 0 then use the defaults of 128 ms
+	if delay <= 0 {
+		delay = 128 * time.Millisecond
+	}
+	if jitter <= 0 {
+		jitter = 128 * time.Millisecond
+	}
+
+	return &BatteryRemoteRepository{
+		repository: repo,
+		keychain:   authn.DefaultKeychain,
+		attempts:   attempts,
+		delay:      delay,
+		jitter:     jitter,
+	}
+}
+
+// NewBatteryRemoteRepositoryFromString creates a new remote repository handler from a string reference
+func NewBatteryRemoteRepositoryFromString(repoName string, attempts uint, delay, jitter time.Duration) (*BatteryRemoteRepository, error) {
+	ref, err := name.ParseReference(repoName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse repository reference %q: %w", repoName, err)
+	}
+
+	return NewBatteryRemoteRepository(ref.Context(), attempts, delay, jitter), nil
+}
+
+// ListTags returns all tags available in the remote repository
+func (b *BatteryRemoteRepository) ListTags() ([]string, error) {
+	var tags []string
+
+	err := retry.Do(
+		func() error {
+			var listErr error
+			tags, listErr = remote.List(b.repository, remote.WithAuthFromKeychain(b.keychain))
+			if listErr != nil {
+				slog.Warn("failed to list tags, retrying",
+					"repository", b.repository.Name(),
+					"error", listErr)
+			}
+			return listErr
+		},
+		retry.Attempts(b.attempts),
+		retry.Delay(b.delay),
+		retry.DelayType(retry.BackOffDelay),
+		retry.MaxJitter(b.jitter),
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to list tags for repository %q after %d attempts: %w",
+			b.repository.Name(), b.attempts, err)
+	}
+
+	slog.Debug("successfully listed tags",
+		"repository", b.repository.Name(),
+		"tag_count", len(tags))
+
+	return tags, nil
+}
+
+// GetRepository returns the underlying repository reference
+func (b *BatteryRemoteRepository) GetRepository() name.Repository {
+	return b.repository
+}
+
+// GetRepositoryName returns the repository name as a string
+func (b *BatteryRemoteRepository) GetRepositoryName() string {
+	return b.repository.Name()
+}
+
+// SetKeychain allows setting a custom keychain for authentication
+func (b *BatteryRemoteRepository) SetKeychain(keychain authn.Keychain) {
+	b.keychain = keychain
+}
+
+// GetImage returns a remote image reference for a specific tag
+func (b *BatteryRemoteRepository) GetImage(tag string) (name.Reference, error) {
+	return name.ParseReference(fmt.Sprintf("%s:%s", b.repository.Name(), tag))
+}
+
+// RemoteTagInfo contains detailed information about a remote tag
+type RemoteTagInfo struct {
+	Tag      string                 `json:"tag"`
+	Digest   string                 `json:"digest"`
+	Manifest map[string]interface{} `json:"manifest"`
+	Config   map[string]interface{} `json:"config"`
+}
+
+// GetTagInfo returns detailed information about a specific tag
+func (b *BatteryRemoteRepository) GetTagInfo(tag string) (*RemoteTagInfo, error) {
+	tagRef, err := b.GetImage(tag)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse tag reference: %w", err)
+	}
+
+	var tagInfo *RemoteTagInfo
+	err = retry.Do(
+		func() error {
+			// Get image manifest
+			image, err := remote.Image(tagRef, remote.WithAuthFromKeychain(b.keychain))
+			if err != nil {
+				slog.Warn("failed to get image for tag, retrying", "tag", tag, "error", err)
+				return err
+			}
+
+			// Get manifest
+			manifest, err := image.Manifest()
+			if err != nil {
+				slog.Warn("failed to get manifest for tag, retrying", "tag", tag, "error", err)
+				return err
+			}
+
+			// Get config
+			config, err := image.ConfigFile()
+			if err != nil {
+				slog.Warn("failed to get config for tag, retrying", "tag", tag, "error", err)
+				return err
+			}
+
+			// Get digest
+			digest, err := image.Digest()
+			if err != nil {
+				slog.Warn("failed to get digest for tag, retrying", "tag", tag, "error", err)
+				return err
+			}
+
+			// Convert manifest and config to maps for JSON output
+			manifestMap := make(map[string]interface{})
+			configMap := make(map[string]interface{})
+
+			manifestJSON, _ := json.Marshal(manifest)
+			configJSON, _ := json.Marshal(config)
+
+			json.Unmarshal(manifestJSON, &manifestMap)
+			json.Unmarshal(configJSON, &configMap)
+
+			tagInfo = &RemoteTagInfo{
+				Tag:      tag,
+				Digest:   digest.String(),
+				Manifest: manifestMap,
+				Config:   configMap,
+			}
+
+			return nil
+		},
+		retry.Attempts(b.attempts),
+		retry.Delay(b.delay),
+		retry.DelayType(retry.BackOffDelay),
+		retry.MaxJitter(b.jitter),
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to get tag info for %q after %d attempts: %w", tag, b.attempts, err)
+	}
+
+	slog.Debug("retrieved remote info for tag", "tag", tag, "digest", tagInfo.Digest)
+	return tagInfo, nil
+}
+
+// GetTagsInfo returns detailed information for multiple tags
+func (b *BatteryRemoteRepository) GetTagsInfo(tags []string) ([]RemoteTagInfo, error) {
+	var remoteInfo []RemoteTagInfo
+
+	// Get all available tags from remote to validate
+	remoteTags, err := b.ListTags()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list remote tags: %w", err)
+	}
+
+	for _, tag := range tags {
+		// Check if this tag exists in remote
+		found := false
+		for _, remoteTag := range remoteTags {
+			if remoteTag == tag {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			slog.Warn("tag not found in remote registry", "tag", tag, "repository", b.repository.Name())
+			continue
+		}
+
+		tagInfo, err := b.GetTagInfo(tag)
+		if err != nil {
+			slog.Warn("failed to get tag info", "tag", tag, "error", err)
+			continue
+		}
+
+		remoteInfo = append(remoteInfo, *tagInfo)
+	}
+
+	return remoteInfo, nil
+}


### PR DESCRIPTION
Summary:
- This adds code similar to nvkind (we go directly to kind go rather
  than generating cluster templates).
- When nvidia-smi tells us about working cards we do this
- Try nvidia-smi locally and in docker
- This changed nvidia-device-plugin to use the local mount device
  listing method when we're running on kind.
- This adds a delay between fetching image tags to keep some reg's happy

Test Plan:
- It works locally
- go run . -v=debug start ../bootstrap/local.spec.json 2>&1
- https://gist.github.com/elliottneilclark/10dbe113d243a2c8f76bbabe0e88e9cb
- labels are added on my nvidia computer
<img width="1689" height="1302" alt="image" src="https://github.com/user-attachments/assets/99d59043-b8e9-4e76-aa81-b2e06fa2e1c5" />
