### PR TITLE
feat: add cli flag to disable nvidia gpu auto-detection

### DIFF
--- a/bi/cmd/start.go
+++ b/bi/cmd/start.go
@@ -52,9 +52,15 @@ complete displaying a url for running control server.`,
 			return err
 		}
 
+		nvidiaAutoDiscovery, err := cmd.Flags().GetBool("nvidia-auto-discovery")
+		if err != nil {
+			return err
+		}
+
 		eb := installs.NewEnvBuilder(
 			installs.WithSlugOrURL(installURL),
 			installs.WithAdditionalInsecureHosts(additionalHosts),
+			installs.WithNvidiaAutoDiscovery(nvidiaAutoDiscovery),
 		)
 		env, err := eb.Build(ctx)
 		if err != nil {
@@ -82,6 +88,7 @@ complete displaying a url for running control server.`,
 func init() {
 	RootCmd.AddCommand(startCmd)
 	startCmd.Flags().Bool("skip-bootstrap", false, "Skip bootstrapping the cluster")
+	startCmd.Flags().Bool("nvidia-auto-discovery", true, "Enable NVIDIA GPU auto-discovery for Kind clusters")
 	startCmd.Flags().StringSlice("additional-insecure-hosts", []string{}, "Additional hosts that will be allowed to be insecure - HTTP")
 	_ = startCmd.Flags().MarkHidden("additional-insecure-hosts")
 }

--- a/bi/cmd/start_local.go
+++ b/bi/cmd/start_local.go
@@ -27,6 +27,11 @@ It will create a local kubernetes cluster and start the installation process.`,
 			return fmt.Errorf("failed to get home-base flag: %w", err)
 		}
 
+		nvidiaAutoDiscovery, err := cmd.Flags().GetBool("nvidia-auto-discovery")
+		if err != nil {
+			return fmt.Errorf("failed to get nvidia-auto-discovery flag: %w", err)
+		}
+
 		ctx := cmd.Context()
 
 		install, err := local.CreateNewLocalInstall(ctx, baseURL)
@@ -35,7 +40,7 @@ It will create a local kubernetes cluster and start the installation process.`,
 		}
 
 		slog.Debug("Created new local installation ", slog.Any("ID", install.ID))
-		env, err := local.InitLocalInstallEnv(ctx, install, baseURL)
+		env, err := local.InitLocalInstallEnv(ctx, install, baseURL, nvidiaAutoDiscovery)
 		if err != nil {
 			return fmt.Errorf("failed to initialize local install environment: %w", err)
 		}
@@ -55,4 +60,5 @@ func init() {
 
 	// Flag for where to talk to home base
 	startLocalCmd.Flags().String("home-base", "https://home.batteriesincl.com", "The URL of the home base to use for the local installation")
+	startLocalCmd.Flags().Bool("nvidia-auto-discovery", true, "Enable NVIDIA GPU auto-discovery for Kind clusters")
 }

--- a/bi/pkg/cluster/kind/gpu.go
+++ b/bi/pkg/cluster/kind/gpu.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"os"
 	"os/exec"
 	"strings"
 
@@ -28,9 +27,9 @@ var ubuntuImage = "ubuntu:24.04"
 
 // detectGPUs checks if NVIDIA GPUs are available on the host
 func (c *KindClusterProvider) detectGPUs(ctx context.Context) error {
-	// Check if GPU support is explicitly disabled
-	if os.Getenv("BI_DISABLE_GPU") == "1" || os.Getenv("BI_DISABLE_GPU") == "true" {
-		c.logger.Info("GPU support disabled via environment variable BI_DISABLE_GPU")
+	// Check if GPU auto-discovery is disabled via flag
+	if !c.nvidiaAutoDiscovery {
+		c.logger.Info("GPU auto-discovery disabled via --nvidia-auto-discovery=false flag")
 		c.gpuAvailable = false
 		c.gpuCount = 0
 		return nil

--- a/bi/pkg/cluster/kind/kind.go
+++ b/bi/pkg/cluster/kind/kind.go
@@ -30,23 +30,25 @@ const (
 )
 
 type KindClusterProvider struct {
-	logger         *slog.Logger
-	nodeProvider   cluster.ProviderOption
-	name           string
-	dockerClient   *dockerclient.Client
-	gatewayEnabled bool
-	wgGateway      *wireguard.Gateway
-	wgClient       *wireguard.Client
+	logger              *slog.Logger
+	nodeProvider        cluster.ProviderOption
+	name                string
+	dockerClient        *dockerclient.Client
+	gatewayEnabled      bool
+	wgGateway           *wireguard.Gateway
+	wgClient            *wireguard.Client
 	// GPU support fields
-	gpuAvailable bool
-	gpuCount     int
+	gpuAvailable        bool
+	gpuCount            int
+	nvidiaAutoDiscovery bool
 }
 
-func NewClusterProvider(logger *slog.Logger, name string, gatewayEnabled bool) *KindClusterProvider {
+func NewClusterProvider(logger *slog.Logger, name string, gatewayEnabled bool, nvidiaAutoDiscovery bool) *KindClusterProvider {
 	return &KindClusterProvider{
-		logger:         logger,
-		name:           name,
-		gatewayEnabled: gatewayEnabled,
+		logger:              logger,
+		name:                name,
+		gatewayEnabled:      gatewayEnabled,
+		nvidiaAutoDiscovery: nvidiaAutoDiscovery,
 	}
 }
 

--- a/bi/pkg/cluster/kind/kind_test.go
+++ b/bi/pkg/cluster/kind/kind_test.go
@@ -17,7 +17,7 @@ func TestKindClusterProvider(t *testing.T) {
 	testutil.IntegrationTest(t)
 
 	t.Log("Creating kind cluster")
-	clusterProvider := kind.NewClusterProvider(slogt.New(t), "bi-test", true)
+	clusterProvider := kind.NewClusterProvider(slogt.New(t), "bi-test", true, true)
 
 	ctx := context.Background()
 	require.NoError(t, clusterProvider.Init(ctx))

--- a/bi/pkg/local/init.go
+++ b/bi/pkg/local/init.go
@@ -6,10 +6,13 @@ import (
 	"fmt"
 )
 
-func InitLocalInstallEnv(ctx context.Context, install *Installation, baseURL string) (*installs.InstallEnv, error) {
+func InitLocalInstallEnv(ctx context.Context, install *Installation, baseURL string, nvidiaAutoDiscovery bool) (*installs.InstallEnv, error) {
 	url := fmt.Sprintf("%s/api/v1/installations/%s/spec", baseURL, install.ID)
 
-	eb := installs.NewEnvBuilder(installs.WithSlugOrURL(url))
+	eb := installs.NewEnvBuilder(
+		installs.WithSlugOrURL(url),
+		installs.WithNvidiaAutoDiscovery(nvidiaAutoDiscovery),
+	)
 	env, err := eb.Build(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error creating new install env: %w", err)

--- a/bin/bi-local
+++ b/bin/bi-local
@@ -38,7 +38,10 @@ do_start() {
 
     spec_path=$(realpath "${spec_path}")
     log "${GREEN}Starting${NOFORMAT} ${CYAN}${spec_path}${NOFORMAT}"
-    run_bi start ${TRACE:+-v=debug} "${spec_path}"
+    run_bi start \
+        ${TRACE:+-v=debug} \
+        ${BI_DISABLE_GPU:+--nvidia-auto-discovery=false} \
+        "${spec_path}"
 }
 
 ## Stop a running installation

--- a/platform_umbrella/apps/home_base/priv/raw_files/start_install.sh
+++ b/platform_umbrella/apps/home_base/priv/raw_files/start_install.sh
@@ -14,4 +14,5 @@ check_bi_version || install_bi
 "${VERSION_LOC}" start \
     ${TRACE:+-v=debug} \
     ${BI_ADDITIONAL_HOSTS:+--additional-insecure-hosts=$BI_ADDITIONAL_HOSTS} \
+    ${BI_DISABLE_GPU:+--nvidia-auto-discovery=false} \
     "${INSTALL_SPEC_URL}"

--- a/platform_umbrella/apps/home_base/priv/raw_files/start_local.sh
+++ b/platform_umbrella/apps/home_base/priv/raw_files/start_local.sh
@@ -8,4 +8,6 @@
 check_bi_version || install_bi
 
 # start install
-"${VERSION_LOC}" start-local ${TRACE:+-v=debug}
+"${VERSION_LOC}" start-local \
+    ${TRACE:+-v=debug} \
+    ${BI_DISABLE_GPU:+--nvidia-auto-discovery=false}


### PR DESCRIPTION
Summary:
- Adds `--nvidia-auto-discovery` flag to start and start local
- Hooks an env flag BI_DISABLE_GPU up to that flag for the convenience
  wrappers

Test Plan:
- Used it locally and it didn't start nvidia
