### PR TITLE
chore: Revert "chore: prepare for 1.3.0 (#2499)"

### DIFF
--- a/bin/lib/common-functions.sh
+++ b/bin/lib/common-functions.sh
@@ -4,7 +4,7 @@ TRACE=${TRACE-""}
 
 # If you are changing this also change the
 # version in mix.exs for all the apps in platform_umbrella
-export BASE_VERSION="1.3.0"
+export BASE_VERSION="1.2.0"
 
 export REGISTRY="ghcr.io/batteries-included"
 

--- a/keycloak-theme/vite.config.ts
+++ b/keycloak-theme/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
       // This line needs to always be here
       // It is set by the bi-source script
       // to the current version of the batteries-included platform
-      themeVersion: '1.3.0',
+      themeVersion: '1.2.0',
     }),
   ],
 });

--- a/platform_umbrella/apps/common_core/lib/common_core/defaults/versions.ex
+++ b/platform_umbrella/apps/common_core/lib/common_core/defaults/versions.ex
@@ -1,7 +1,7 @@
 defmodule CommonCore.Defaults.Versions do
   @moduledoc false
 
-  @stable_version "1.3.0"
+  @stable_version "1.2.0"
 
   @spec bi_stable_version() :: String.t()
   def bi_stable_version, do: @stable_version

--- a/platform_umbrella/apps/common_core/mix.exs
+++ b/platform_umbrella/apps/common_core/mix.exs
@@ -4,7 +4,7 @@ defmodule CommonCore.MixProject do
   def project do
     [
       app: :common_core,
-      version: "1.3.0",
+      version: "1.2.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/platform_umbrella/apps/common_ui/mix.exs
+++ b/platform_umbrella/apps/common_ui/mix.exs
@@ -4,7 +4,7 @@ defmodule CommonUI.MixProject do
   def project do
     [
       app: :common_ui,
-      version: "1.3.0",
+      version: "1.2.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/platform_umbrella/apps/control_server/mix.exs
+++ b/platform_umbrella/apps/control_server/mix.exs
@@ -4,7 +4,7 @@ defmodule ControlServer.MixProject do
   def project do
     [
       app: :control_server,
-      version: "1.3.0",
+      version: "1.2.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/platform_umbrella/apps/control_server_web/mix.exs
+++ b/platform_umbrella/apps/control_server_web/mix.exs
@@ -4,7 +4,7 @@ defmodule ControlServerWeb.MixProject do
   def project do
     [
       app: :control_server_web,
-      version: "1.3.0",
+      version: "1.2.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/platform_umbrella/apps/event_center/mix.exs
+++ b/platform_umbrella/apps/event_center/mix.exs
@@ -4,7 +4,7 @@ defmodule EventCenter.MixProject do
   def project do
     [
       app: :event_center,
-      version: "1.3.0",
+      version: "1.2.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/platform_umbrella/apps/home_base/mix.exs
+++ b/platform_umbrella/apps/home_base/mix.exs
@@ -4,7 +4,7 @@ defmodule HomeBase.MixProject do
   def project do
     [
       app: :home_base,
-      version: "1.3.0",
+      version: "1.2.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/platform_umbrella/apps/home_base_web/mix.exs
+++ b/platform_umbrella/apps/home_base_web/mix.exs
@@ -4,7 +4,7 @@ defmodule HomeBaseWeb.MixProject do
   def project do
     [
       app: :home_base_web,
-      version: "1.3.0",
+      version: "1.2.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/platform_umbrella/apps/kube_bootstrap/mix.exs
+++ b/platform_umbrella/apps/kube_bootstrap/mix.exs
@@ -4,7 +4,7 @@ defmodule KubeBootstrap.MixProject do
   def project do
     [
       app: :kube_bootstrap,
-      version: "1.3.0",
+      version: "1.2.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/platform_umbrella/apps/kube_services/mix.exs
+++ b/platform_umbrella/apps/kube_services/mix.exs
@@ -4,7 +4,7 @@ defmodule KubeServices.MixProject do
   def project do
     [
       app: :kube_services,
-      version: "1.3.0",
+      version: "1.2.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/platform_umbrella/apps/verify/mix.exs
+++ b/platform_umbrella/apps/verify/mix.exs
@@ -4,7 +4,7 @@ defmodule Verify.MixProject do
   def project do
     [
       app: :verify,
-      version: "1.3.0",
+      version: "1.2.0",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",

--- a/platform_umbrella/mix.exs
+++ b/platform_umbrella/mix.exs
@@ -4,7 +4,7 @@ defmodule ControlServer.Umbrella.MixProject do
   def project do
     [
       apps_path: "apps",
-      version: "1.3.0",
+      version: "1.2.0",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       releases: releases(),


### PR DESCRIPTION
This reverts commit 6444a07b870244e647fca33af347cfcfcc010145.

When I was planning on stamping a 1.2.0 quickly, I thought the tests
were just flakey. I think they are broken, and we can't currently run
two batteries included clusters on the same machine.
