### PR TITLE
fix: allow test keys when using the latest release cli int-test

### DIFF
--- a/platform_umbrella/apps/verify/test/support/kind_install_worker.ex
+++ b/platform_umbrella/apps/verify/test/support/kind_install_worker.ex
@@ -88,6 +88,7 @@ defmodule Verify.KindInstallWorker do
     env = [
       {"BI_VERSION_TAG", latest_release},
       {"BI_ADDITIONAL_HOSTS", host},
+      {"BI_ALLOW_TEST_KEYS", "true"},
       {"BI_IMAGE_TAR", System.get_env("BI_IMAGE_TAR", "")},
       {"VERSION_OVERRIDE", System.get_env("VERSION_OVERRIDE", "")}
     ]


### PR DESCRIPTION
Summary:
- Home base tests use the latest cli. once that release built the tests
  stopped working. This fixes it

Test Plan:
- int-test
