### PR TITLE
refactor(build): pull versions from existing registries

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,7 +1,7 @@
 actionlint 1.7.7
 awscli     2.28.16
-elixir     1.18.4-otp-27
-erlang     27.3.4
+elixir     1.18.4-otp-28
+erlang     28.0.2
 golang     1.25.0
 goreleaser 2.11.2
 java       adoptopenjdk-21.0.7+6.0.LTS

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,7 +1,7 @@
 actionlint 1.7.7
 awscli     2.28.16
-elixir     1.18.4-otp-28
-erlang     28.0.2
+elixir     1.18.4-otp-27
+erlang     27.3.4.2
 golang     1.25.0
 goreleaser 2.11.2
 java       adoptopenjdk-21.0.7+6.0.LTS

--- a/bin/bi-docker
+++ b/bin/bi-docker
@@ -12,6 +12,7 @@ source "${ROOT_DIR}/bin/lib/docker-functions.sh"
 
 do_build_base_images() {
     local tag
+    local ubuntu_version
     tag=$(docker_hash)
 
     declare -a ci_args
@@ -19,11 +20,17 @@ do_build_base_images() {
         ci_args+=(--progress=plain)
     fi
 
+    ubuntu_version=$(default_tag_for_registry_image ubuntu)
+    elixir_version=$(tool_version elixir | cut -d'-' -f 1)
+    erlang_version=$(tool_version erlang)
     for base in build deploy; do
         docker build \
             --load \
             -t "${REGISTRY}/${base}-base:${tag}" \
             -f docker/${base}-base.dockerfile \
+            --build-arg UBUNTU_VERSION="${ubuntu_version}" \
+            --build-arg ELIXIR_VERSION="${elixir_version}" \
+            --build-arg ERLANG_VERSION="${erlang_version}" \
             ${TRACE:+--progress=plain} \
             "${ci_args[@]}" \
             .
@@ -210,8 +217,8 @@ do_trigger_missing_upstream() {
     local clean_tags
     clean_tags=$(strip_version_hash "${our_tags}")
 
-    log "Upstream tags: ${upstream_tags}"
-    log "Our tags (clean): ${clean_tags}"
+    log "Upstream tags:\n${upstream_tags}"
+    log "Our tags (clean):\n${clean_tags}"
 
     # Find missing tags (in either direction)
     local missing_tags

--- a/bin/lib/docker-functions.sh
+++ b/bin/lib/docker-functions.sh
@@ -47,6 +47,40 @@ tags_for_registry_image() {
     echo "$tags"
 }
 
+default_tag_for_registry_image() {
+    # name of the image to look up in the registry
+    local name="$1"
+    local registry_file="${ROOT_DIR}/image_registry.yaml"
+    local tag
+    local query
+    query=$(printf ".%s.default_tag" "${name}")
+
+    if [[ ! -f "${registry_file}" ]]; then
+        die "Registry file not found at ${registry_file}"
+    fi
+
+    log "Reading registry data for ${CYAN}${name}${NOFORMAT}"
+
+    tag=$(yq "${query}" "${registry_file}")
+    if [[ -z "${tag}" ]]; then
+        log "No default tag found in registry file for #{name}"
+    fi
+    echo "$tag"
+}
+
+tool_version() {
+    local name="$1"
+
+    local tool_version_file="${ROOT_DIR}/.tool-versions"
+    [[ -f "${tool_version_file}" ]] || die ".tool_version file not found at ${tool_version_file}"
+
+    local version
+    version=$(yq --input-format props --output-format yaml ".${name}" "${tool_version_file}")
+    [[ -z "${version}" ]] && log "no version found for ${name} in ${tool_version_file}"
+
+    echo "${version}"
+}
+
 # Strip version hash from tags (e.g., 26.3.0-16b3adf7c -> 26.3.0)
 strip_version_hash() {
     local tags="$1"

--- a/docker/build-base.dockerfile
+++ b/docker/build-base.dockerfile
@@ -1,8 +1,9 @@
 # syntax=docker/dockerfile:1
 
-ARG ELIXIR_VERSION=1.18.4
-ARG ERLANG_VERSION=27.3.4
-ARG UBUNTU_VERSION=noble-20250415.1
+ARG UBUNTU_VERSION=use_version_from_tool-versions
+ARG ELIXIR_VERSION=use_version_from_tool-versions
+ARG ERLANG_VERSION=use_version_from_tool-versions
+
 
 ARG BUILD_IMAGE_NAME=hexpm/elixir
 ARG BUILD_IMAGE_TAG=${ELIXIR_VERSION}-erlang-${ERLANG_VERSION}-ubuntu-${UBUNTU_VERSION}

--- a/docker/deploy-base.dockerfile
+++ b/docker/deploy-base.dockerfile
@@ -4,7 +4,7 @@
 # The container image used as the final image that we use to deploy
 #
 
-ARG UBUNTU_VERSION=noble-20250127
+ARG UBUNTU_VERSION=use_version_from_tool-versions
 ARG LANGUAGE=en_US:en
 ARG LANG=en_US.UTF-8
 

--- a/image_registry.yaml
+++ b/image_registry.yaml
@@ -784,6 +784,12 @@ trust_manager_init:
   tags:
     - '20210119.0'
   tag_regex: ^\d{8}\.\d+$
+ubuntu:
+  name: docker.io/library/ubuntu
+  default_tag: noble-20250716
+  tags:
+    - noble-20250716
+  tag_regex: ^noble-\d{8}(\.\d)?$
 vm_agent:
   name: docker.io/victoriametrics/vmagent
   default_tag: v1.124.0


### PR DESCRIPTION
We keep track of versions and images in a few place but are consolidating to single repos/registries. This continues that work by moving base image version definitions to the registries.