### PR TITLE
ci: handle registry update job failures mo better

### DIFF
--- a/bin/bi-registry
+++ b/bin/bi-registry
@@ -99,16 +99,19 @@ do_create_pr() {
         go run registry-tool update-tags ${TRACE:+-v=debug} --delay 500ms --jitter 250ms ../image_registry.yaml
         echo $?
     )
+    [[ $update_exit_code -gt 1 ]] && die "Error updating tags"
+
     local advance_exit_code=0
     log "Running registry advances"
     advance_exit_code=$(
         go run registry-tool advance-defaults ${TRACE:+-v=debug} ../image_registry.yaml
         echo $?
     )
+    [[ $advance_exit_code -gt 1 ]] && die "Error advancing tags"
 
     set -e
 
-    if [[ $update_exit_code -ne 0 && $advance_exit_code -ne 0 ]]; then
+    if [[ $update_exit_code -eq 1 && $advance_exit_code -eq 1 ]]; then
         log "No changes to the registry, skipping PR creation"
         bi_popd
         return 0

--- a/registry-tool/cmd/root.go
+++ b/registry-tool/cmd/root.go
@@ -4,11 +4,14 @@ Copyright © 2025 Elliott Clark
 package cmd
 
 import (
+	"errors"
 	"os"
 
-	"github.com/spf13/cobra"
 	"log/slog"
 	"registry-tool/pkg/log"
+	"registry-tool/pkg/registry"
+
+	"github.com/spf13/cobra"
 )
 
 var verbosity string
@@ -28,8 +31,13 @@ list of images and information about them.`,
 
 func Execute() {
 	err := RootCmd.Execute()
-	if err != nil {
+	switch {
+	case err == nil:
+		return
+	case errors.Is(err, registry.ErrNoChanges):
 		os.Exit(1)
+	default:
+		os.Exit(2)
 	}
 }
 

--- a/registry-tool/pkg/registry/error.go
+++ b/registry-tool/pkg/registry/error.go
@@ -1,0 +1,5 @@
+package registry
+
+import "errors"
+
+var ErrNoChanges = errors.New("no changes found")

--- a/registry-tool/pkg/registry/registry_updater.go
+++ b/registry-tool/pkg/registry/registry_updater.go
@@ -51,7 +51,7 @@ func (u *RegistryUpdater) Write(path string) error {
 		slog.Info("no changes to write")
 		// Return an error when there's no changes to
 		// show that the pr process should be skipped.
-		return fmt.Errorf("no changes to write")
+		return fmt.Errorf("no changes to write: %w", ErrNoChanges)
 	}
 
 	if err := u.registry.Write(path); err != nil {


### PR DESCRIPTION
Exit 1 from registry update jobs don't have an update. Exit > 1 for failures.