### PR TITLE
ci: do use elixir cache for registry update

### DIFF
--- a/.github/workflows/bix_registry.yml
+++ b/.github/workflows/bix_registry.yml
@@ -33,7 +33,6 @@ jobs:
       - name: Setup CI
         uses: ./.github/actions/setup-ci
         with:
-          elixir_cache: false
           reg_tool_cache: true
 
       - name: Login to GHCR


### PR DESCRIPTION
We generate static specs so having the elixir cache here is valuable.