### PR TITLE
ci: set GH_TOKEN env var to allow using gh cli

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -22,6 +22,8 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4
         with:


### PR DESCRIPTION
Needed for building the new postgres image as we get the url for the extensions using the `gh` cli.