### PR TITLE
fix(bootstrap): start controlserver after pg pod status.phase is running

### DIFF
--- a/platform_umbrella/apps/control_server/lib/control_server/batteries/fixup.ex
+++ b/platform_umbrella/apps/control_server/lib/control_server/batteries/fixup.ex
@@ -6,7 +6,7 @@ defmodule ControlServer.Batteries.Fixup do
     # Any that are not installed will be installed with the ControlServer.Batteries.Installer module.
 
     Enum.each(ControlServer.Batteries.list_system_batteries(), fn system_battery ->
-      _ = ControlServer.Batteries.Installer.install(system_battery.type)
+      {:ok, _} = ControlServer.Batteries.Installer.install(system_battery.type)
     end)
 
     :ok

--- a/platform_umbrella/apps/kube_bootstrap/lib/kube_bootstrap.ex
+++ b/platform_umbrella/apps/kube_bootstrap/lib/kube_bootstrap.ex
@@ -47,7 +47,8 @@ defmodule KubeBootstrap do
          # Create the second group of resources with the control server
          # This allows the user and passwords to be set before trying to boot.
          {:ok, _} <-
-           KubeBootstrap.Kube.ensure_exists(conn, with_control_server) do
+           KubeBootstrap.Kube.ensure_exists(conn, with_control_server),
+         :ok <- KubeBootstrap.ControlServer.wait_for_control_server(conn, summary) do
       Logger.info("Bootstrap complete")
       :ok
     end

--- a/platform_umbrella/apps/kube_bootstrap/lib/kube_bootstrap/control_server.ex
+++ b/platform_umbrella/apps/kube_bootstrap/lib/kube_bootstrap/control_server.ex
@@ -1,0 +1,33 @@
+defmodule KubeBootstrap.ControlServer do
+  @moduledoc false
+
+  def wait_for_control_server(conn, summary) do
+    namespace = CommonCore.StateSummary.Namespaces.core_namespace(summary)
+
+    pod_operation =
+      "v1"
+      |> K8s.Client.list(:pod, namespace: namespace)
+      |> K8s.Selector.label(%{
+        "battery/app" => "battery-control-server"
+      })
+      |> K8s.Selector.field({"status.phase", "Running"})
+
+    case K8s.Client.wait_until(conn, pod_operation,
+           find: fn
+             %{"items" => items} ->
+               !Enum.empty?(items)
+
+             _ ->
+               false
+           end,
+           eval: true,
+           timeout: 300
+         ) do
+      {:ok, _} ->
+        :ok
+
+      {:error, _reason} ->
+        {:error, :timeout}
+    end
+  end
+end

--- a/platform_umbrella/apps/kube_bootstrap/lib/kube_bootstrap/postgres.ex
+++ b/platform_umbrella/apps/kube_bootstrap/lib/kube_bootstrap/postgres.ex
@@ -36,6 +36,7 @@ defmodule KubeBootstrap.Postgres do
         "role" => "primary",
         "cnpg.io/cluster" => "pg-#{cluster.name}"
       })
+      |> K8s.Selector.field({"status.phase", "Running"})
 
     Logger.info("Waiting for Postgres service and pods", cluster: cluster.name)
 
@@ -49,7 +50,7 @@ defmodule KubeBootstrap.Postgres do
                  false
              end,
              eval: true,
-             timeout: 300
+             timeout: 600
            ) do
       {:ok, cluster}
     end

--- a/platform_umbrella/apps/verify/test/support/test_case.ex
+++ b/platform_umbrella/apps/verify/test/support/test_case.ex
@@ -77,6 +77,9 @@ defmodule Verify.TestCase do
         # check that we have all of the pre-pulled images before installing batteries
         :ok = wait_for_images(image_pid, @images)
 
+        # double check that control server is available
+        {:ok, _} = url |> build_retryable_get() |> retry()
+
         # install any requested batteries
         {:ok, session} = start_session(url)
 


### PR DESCRIPTION
Summary:
I've noticed some controlservers going into wait because the init fails.
That could slow things down. So try this

Test Plan:
- CI
- int-test
