### PR TITLE
ci: fix up failure logging / output

### DIFF
--- a/.github/workflows/int_test.yml
+++ b/.github/workflows/int_test.yml
@@ -104,7 +104,9 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: int-test-${{ github.run_id }}-${{ github.run_attempt }}
+          name:
+            int-test-${{ matrix.partition }}-${{ github.run_id }}-${{
+            github.run_attempt }}
           retention-days: 5
           path: |
             /tmp/bi-int-test/

--- a/platform_umbrella/apps/verify/lib/verify/application.ex
+++ b/platform_umbrella/apps/verify/lib/verify/application.ex
@@ -7,8 +7,6 @@ defmodule Verify.Application do
 
   @impl Application
   def start(_type, _args) do
-    Application.put_env(:wallaby, :screenshot_dir, Path.join(Verify.PathHelper.tmp_dir!(), "bi-int-test"))
-
     children = [
       Verify.SessionURLAgent,
       {Task.Supervisor, [name: Verify.TaskSupervisor]},

--- a/platform_umbrella/apps/verify/test/support/battery_install_worker.ex
+++ b/platform_umbrella/apps/verify/test/support/battery_install_worker.ex
@@ -13,9 +13,11 @@ defmodule Verify.BatteryInstallWorker do
 
   typedstruct module: State do
     field :session, Wallaby.Session.t()
+    field :rage_output, String.t()
+    field :kind_worker_pid, GenServer.name()
   end
 
-  @state_opts ~w(session)a
+  @state_opts ~w(session rage_output kind_worker_pid)a
 
   def start_link(opts \\ []) do
     {state_opts, gen_opts} =
@@ -61,7 +63,8 @@ defmodule Verify.BatteryInstallWorker do
     rescue
       e ->
         # grab a screenshot if we've failed to install the battery
-        take_screenshot(session, name: "battery-install-worker-failure-#{battery.type}")
+        take_screenshot(session, name: "battery-install-worker-failure-#{battery.type}", log: true)
+        Verify.KindInstallWorker.rage(state.kind_worker_pid, state.rage_output)
 
         reraise(e, __STACKTRACE__)
     end

--- a/platform_umbrella/apps/verify/test/support/test_case.ex
+++ b/platform_umbrella/apps/verify/test/support/test_case.ex
@@ -64,6 +64,8 @@ defmodule Verify.TestCase do
         Logger.debug("Starting Kind for spec: #{install_spec}")
         tmp_dir = get_tmp_dir(__MODULE__)
 
+        Application.put_env(:wallaby, :screenshot_dir, tmp_dir, persistent: true)
+
         kind_pid =
           start_supervised!({
             # the kind_install_worker cleans up after itself as it is stopped
@@ -88,7 +90,9 @@ defmodule Verify.TestCase do
             Verify.BatteryInstallWorker,
             [
               name: {:via, Registry, {Verify.Registry, __MODULE__.BatteryInstallWorker, Verify.BatteryInstallWorker}},
-              session: session
+              session: session,
+              rage_output: tmp_dir,
+              kind_worker_pid: kind_pid
             ]
           })
 


### PR DESCRIPTION
I put in a raise on battery install and got rage output and screenshot:

```
/tmp/bi-int-test
└── Elixir.Verify.ForgejoTest
    ├── 1758140504_elixir-verify-forgejotest.json
    └── battery-install-worker-failure-forgejo.png
```