### PR TITLE
test: add the ability to use a specified bi in the start and start local scripts

### DIFF
--- a/platform_umbrella/apps/home_base/priv/raw_files/common.sh
+++ b/platform_umbrella/apps/home_base/priv/raw_files/common.sh
@@ -26,6 +26,13 @@ log() {
 }
 
 check_bi_version() {
+    # If there's a BI_OVERRIDE_LOC, then assume the
+    # user knows what they're doing
+    #
+    # (hey that's me and that's not always true)
+    if [ -n "${BI_OVERRIDE_LOC:-""}" ]; then
+        return 0
+    fi
     test -f "${VERSION_LOC}"
 }
 

--- a/platform_umbrella/apps/home_base/priv/raw_files/start_install.sh
+++ b/platform_umbrella/apps/home_base/priv/raw_files/start_install.sh
@@ -10,8 +10,12 @@ INSTALL_SPEC_URL="<%= spec_url %>"
 # install bi if needed first
 check_bi_version || install_bi
 
+# The location of the bi binary
+# This is usually VERSION_LOC but can be overridden with BI_OVERRIDE_LOC
+BI_INSTALL_LOC="${BI_OVERRIDE_LOC:-$VERSION_LOC}"
+
 # start install
-"${VERSION_LOC}" start \
+"${BI_INSTALL_LOC}" start \
     ${TRACE:+-v=debug} \
     ${BI_ADDITIONAL_HOSTS:+--additional-insecure-hosts=$BI_ADDITIONAL_HOSTS} \
     ${BI_DISABLE_GPU:+--nvidia-auto-discovery=false} \

--- a/platform_umbrella/apps/home_base/priv/raw_files/start_local.sh
+++ b/platform_umbrella/apps/home_base/priv/raw_files/start_local.sh
@@ -7,7 +7,11 @@
 # install bi if needed first
 check_bi_version || install_bi
 
+# The location of the bi binary
+# This is usually VERSION_LOC but can be overridden with BI_OVERRIDE_LOC
+BI_INSTALL_LOC="${BI_OVERRIDE_LOC:-$VERSION_LOC}"
+
 # start install
-"${VERSION_LOC}" start-local \
+"${BI_INSTALL_LOC}" start-local \
     ${TRACE:+-v=debug} \
     ${BI_DISABLE_GPU:+--nvidia-auto-discovery=false}

--- a/platform_umbrella/apps/verify/test/support/kind_install_worker.ex
+++ b/platform_umbrella/apps/verify/test/support/kind_install_worker.ex
@@ -75,21 +75,11 @@ defmodule Verify.KindInstallWorker do
   defp do_start({:cmd, cmd, slug, host}, state) do
     Logger.debug("Running #{cmd}")
 
-    latest_release =
-      [{Tesla.Middleware.FollowRedirects, max_redirects: 3}]
-      |> Tesla.client()
-      |> Tesla.get!("https://api.github.com/repos/batteries-included/batteries-included/releases/latest")
-      |> Map.get(:body)
-      |> Jason.decode!()
-      |> Map.get("name")
-
-    Logger.debug("Using latest release: #{latest_release}")
-
     env = [
-      {"BI_VERSION_TAG", latest_release},
       {"BI_ADDITIONAL_HOSTS", host},
       {"BI_NVIDIA_AUTO_DISCOVERY", "false"},
       {"BI_ALLOW_TEST_KEYS", "true"},
+      {"BI_OVERRIDE_LOC", state.bi_binary},
       {"BI_IMAGE_TAR", System.get_env("BI_IMAGE_TAR", "")},
       {"VERSION_OVERRIDE", System.get_env("VERSION_OVERRIDE", "")}
     ]


### PR DESCRIPTION
Summary:
This should allow home base int-test to work with changes to bootstrap, like the one we just had. BI_OVERRIDE_LOC was a hard enough to find env variable that I picked it. Users won't think they need to set it. But it should allow this to work.

Test Plan:
/ shrug
