### PR TITLE
fix: wait for metallb to be stable on bootstrap

### DIFF
--- a/platform_umbrella/apps/kube_bootstrap/lib/kube_bootstrap.ex
+++ b/platform_umbrella/apps/kube_bootstrap/lib/kube_bootstrap.ex
@@ -52,7 +52,15 @@ defmodule KubeBootstrap do
       if length(with_control_server) == length(resources) do
         Logger.info("No Control Server found to wait for")
       else
+        Logger.info("Waiting for Control Server to be ready")
         :ok = KubeBootstrap.ControlServer.wait_for_control_server(conn, summary)
+        Logger.info("Control Server is ready")
+        Logger.debug("Waiting for MetalLB to be ready")
+        # Sometimes metallb's speaker pod can take a while.
+        # There are 4 containers and they each take a second.
+        # So rather than get un-explained network errors
+        # we'll take our time here.
+        :ok = KubeBootstrap.MetalLB.wait_for_metallb(conn, summary)
       end
 
       Logger.info("Bootstrap complete")

--- a/platform_umbrella/apps/kube_bootstrap/lib/kube_bootstrap/control_server.ex
+++ b/platform_umbrella/apps/kube_bootstrap/lib/kube_bootstrap/control_server.ex
@@ -42,7 +42,7 @@ defmodule KubeBootstrap.ControlServer do
                false
            end,
            eval: true,
-           timeout: 300
+           timeout: 600
          ) do
       {:ok, _} ->
         :ok
@@ -71,7 +71,7 @@ defmodule KubeBootstrap.ControlServer do
                false
            end,
            eval: true,
-           timeout: 300
+           timeout: 600
          ) do
       {:ok, _} ->
         :ok
@@ -94,6 +94,7 @@ defmodule KubeBootstrap.ControlServer do
     case K8s.Client.wait_until(conn, endpoint_operation,
            find: fn
              %{"items" => items} ->
+               Logger.info("Found #{Enum.count(items)} endpoint(s) for control server")
                # We should find a single endpoint
                # with a single subset
                # with a single address
@@ -110,7 +111,7 @@ defmodule KubeBootstrap.ControlServer do
                false
            end,
            eval: true,
-           timeout: 300
+           timeout: 600
          ) do
       {:ok, _} ->
         :ok

--- a/platform_umbrella/apps/kube_bootstrap/lib/kube_bootstrap/metallb.ex
+++ b/platform_umbrella/apps/kube_bootstrap/lib/kube_bootstrap/metallb.ex
@@ -1,0 +1,52 @@
+defmodule KubeBootstrap.MetalLB do
+  @moduledoc false
+
+  alias CommonCore.Resources.FieldAccessors
+
+  def wait_for_metallb(conn, summary) do
+    # If metallb is not installed, then just return ok
+    if CommonCore.StateSummary.Batteries.batteries_installed?(summary, :metallb) do
+      namespace = CommonCore.StateSummary.Namespaces.base_namespace(summary)
+
+      wait_for_pods(conn, namespace)
+    else
+      :ok
+    end
+  end
+
+  defp wait_for_pods(conn, namespace) do
+    pod_operation =
+      "v1"
+      |> K8s.Client.list("Pod", namespace: namespace)
+      |> K8s.Selector.label(%{"battery/app" => "metallb"})
+      |> K8s.Selector.field({"status.phase", "Running"})
+
+    case K8s.Client.wait_until(conn, pod_operation,
+           find: fn
+             %{"items" => items} when is_list(items) ->
+               all_containers_running =
+                 Enum.filter(items, fn item ->
+                   containers =
+                     item
+                     |> FieldAccessors.status()
+                     |> Map.get("containerStatuses", [])
+
+                   Enum.all?(containers, fn c -> c["ready"] == true end)
+                 end)
+
+               !Enum.empty?(all_containers_running)
+
+             _ ->
+               false
+           end,
+           eval: true,
+           timeout: 600
+         ) do
+      {:ok, _} ->
+        :ok
+
+      {:error, _reason} ->
+        {:error, :timeout}
+    end
+  end
+end

--- a/platform_umbrella/apps/verify/test/support/test_case.ex
+++ b/platform_umbrella/apps/verify/test/support/test_case.ex
@@ -110,7 +110,7 @@ defmodule Verify.TestCase do
         on_exit(fn -> Wallaby.end_session(session) end)
 
         tested_version = CommonCore.Defaults.Images.batteries_included_version()
-        Logger.info("Testing version: #{tested_version} of batteries included: #{url}")
+        Logger.info("Testing version: #{tested_version} of batteries included: #{url} for #{slug}")
 
         {:ok,
          [


### PR DESCRIPTION
Summary:
MetalLB does the load balancing. I have seen the speaker take a while.
Looking at the timing the controller comes up and assigns an ip before
the speaker is 100% started. So there's a window where the control
server could be up and the ip connections are not ready yet. I think
this could be some of the network disconnected/refused errors we have
seen.

Test Plan:
- CI
- seat of my pants
