### PR TITLE
feat: add node information to rage report

### DIFF
--- a/bi/pkg/installs/rage.go
+++ b/bi/pkg/installs/rage.go
@@ -44,6 +44,14 @@ func (env *InstallEnv) NewRage(ctx context.Context) (*rage.RageReport, error) {
 		return nil, err
 	}
 
+	// Add node information
+	nodes, err := kubeClient.ListNodesRage(ctx)
+	if err != nil {
+		slog.Error("unable to list nodes for rage", "error", err)
+	} else {
+		report.Nodes = nodes
+	}
+
 	err = env.addHttpRoutes(ctx, kubeClient, report)
 	if err != nil {
 		slog.Error("unable to add HTTP routes to the rage report", "error", err)

--- a/bi/pkg/kube/kube.go
+++ b/bi/pkg/kube/kube.go
@@ -46,6 +46,7 @@ type KubeClient interface {
 	GetPostgresAccessInfo(ctx context.Context, namespace string, clusterName string, userName string) (*access.PostgresAccessSpec, error)
 	ListPodsRage(ctx context.Context) ([]rage.PodRageInfo, error)
 	ListHttpRoutesRage(ctx context.Context) ([]rage.HttpRouteRageInfo, error)
+	ListNodesRage(ctx context.Context) ([]rage.NodeRageInfo, error)
 	GetDialContext() func(ctx context.Context, network, address string) (net.Conn, error)
 }
 

--- a/bi/pkg/rage/rage.go
+++ b/bi/pkg/rage/rage.go
@@ -15,6 +15,7 @@ type RageReport struct {
 	AccessSpec  *access.AccessSpec
 	KindIPs     *string
 	BILogs      map[string][]interface{}
+	Nodes       []NodeRageInfo
 }
 
 type ContainerRageInfo struct {
@@ -43,6 +44,20 @@ type HttpRouteRageInfo struct {
 	Name       string
 	Hostnames  []string
 	Conditions []HttpRouteConditionRageInfo
+}
+
+type NodeConditionRageInfo struct {
+	Type    string
+	Status  string
+	Message string
+}
+
+type NodeRageInfo struct {
+	Name              string
+	Cores             int32
+	MemoryBytes       int64
+	Conditions        []NodeConditionRageInfo
+	KubernetesVersion string
 }
 
 func (report *RageReport) Write(w io.Writer) error {


### PR DESCRIPTION
Summary:
- Added functionality to gather and include node information in the rage report.

Test Plan:
- CI is failing everywhere so this will get run.
- I ran it locally and it had nodes in the report.
