### PR TITLE
fix: ensure state summary uses kitchen sink for upgrade tests

### DIFF
--- a/platform_umbrella/apps/common_core/test/common_core/state_summary/upgrade_test.exs
+++ b/platform_umbrella/apps/common_core/test/common_core/state_summary/upgrade_test.exs
@@ -11,27 +11,30 @@ defmodule CommonCore.StateSummary.UpgradeTest do
     # engineers there to fix it. Set that as our defaults.
     test "sunday isn't an upgrade day" do
       captured_at = DateTime.new!(Date.new!(2024, 7, 28), Time.new!(19, 42, 0, 0), "Etc/UTC")
-      state_summary = build(:state_summary, captured_at: captured_at)
+
+      # Notice that we use kitchen sink here since by default for development we turn all
+      # upgrades off. So we pick something explicitly that has upgrades on.
+      state_summary = build(:state_summary, captured_at: captured_at, usage: :kitchen_sink)
       refute Core.upgrade_time?(state_summary)
     end
 
     test "monday is an upgrade day" do
       captured_at = DateTime.new!(Date.new!(2024, 7, 29), Time.new!(19, 20, 0, 0), "Etc/UTC")
-      state_summary = build(:state_summary, captured_at: captured_at)
+      state_summary = build(:state_summary, captured_at: captured_at, usage: :kitchen_sink)
       assert Core.upgrade_time?(state_summary)
     end
   end
 
   test "gives the stable image on upgrade day" do
     captured_at = DateTime.new!(Date.new!(2024, 7, 29), Time.new!(19, 20, 0, 0), "Etc/UTC")
-    state_summary = build(:state_summary, captured_at: captured_at)
+    state_summary = build(:state_summary, captured_at: captured_at, usage: :kitchen_sink)
 
     assert Core.controlserver_image(state_summary) ==
              "ghcr.io/batteries-included/control-server:v100.0.0"
   end
 
   test "gives the default image with a nil captured_at" do
-    state_summary = build(:state_summary, captured_at: nil)
+    state_summary = build(:state_summary, captured_at: nil, usage: :kitchen_sink)
 
     assert Core.controlserver_image(state_summary) ==
              Images.control_server_image()
@@ -40,7 +43,7 @@ defmodule CommonCore.StateSummary.UpgradeTest do
   test "give the default image when not in the upgrade window" do
     # Correct day but not the correct time yet.
     captured_at = DateTime.new!(Date.new!(2024, 7, 29), Time.new!(17, 20, 0, 0), "Etc/UTC")
-    state_summary = build(:state_summary, captured_at: captured_at)
+    state_summary = build(:state_summary, captured_at: captured_at, usage: :kitchen_sink)
 
     assert Core.controlserver_image(state_summary) ==
              Images.control_server_image()


### PR DESCRIPTION
Summary:

In the upgrade tests for state summaries, ensure that the state summary is built with the :kitchen_sink usage option. This make sure that upgrade days and times are turned on.

Test Plan:
Tests pass. They continue to pass and are stable.
