### PR TITLE
fix(deps): allow dependabot updates

### DIFF
--- a/platform_umbrella/apps/control_server_web/mix.exs
+++ b/platform_umbrella/apps/control_server_web/mix.exs
@@ -16,7 +16,7 @@ defmodule ControlServerWeb.MixProject do
       aliases: aliases(),
       deps: deps(),
       compilers: [:phoenix_live_view] ++ Mix.compilers(),
-      listeners: [Phoenix.CodeReloader]
+      listeners: listeners()
     ]
   end
 
@@ -92,5 +92,13 @@ defmodule ControlServerWeb.MixProject do
       test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"],
       "ecto.reset": []
     ]
+  end
+
+  defp listeners do
+    if dependabot?(), do: [], else: [Phoenix.CodeReloader]
+  end
+
+  defp dependabot? do
+    Enum.any?(System.get_env(), fn {key, _value} -> String.starts_with?(key, "DEPENDABOT") end)
   end
 end

--- a/platform_umbrella/apps/home_base_web/mix.exs
+++ b/platform_umbrella/apps/home_base_web/mix.exs
@@ -16,7 +16,7 @@ defmodule HomeBaseWeb.MixProject do
       aliases: aliases(),
       deps: deps(),
       compilers: [:phoenix_live_view] ++ Mix.compilers(),
-      listeners: [Phoenix.CodeReloader]
+      listeners: listeners()
     ]
   end
 
@@ -68,5 +68,13 @@ defmodule HomeBaseWeb.MixProject do
       test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"],
       "ecto.reset": []
     ]
+  end
+
+  defp listeners do
+    if dependabot?(), do: [], else: [Phoenix.CodeReloader]
+  end
+
+  defp dependabot? do
+    Enum.any?(System.get_env(), fn {key, _value} -> String.starts_with?(key, "DEPENDABOT") end)
   end
 end

--- a/platform_umbrella/mix.exs
+++ b/platform_umbrella/mix.exs
@@ -20,7 +20,7 @@ defmodule ControlServer.Umbrella.MixProject do
         plt_local_path: ".dialyzer",
         plt_core_path: ".dialyzer"
       ],
-      listeners: [Phoenix.CodeReloader]
+      listeners: listeners()
     ]
   end
 
@@ -82,5 +82,13 @@ defmodule ControlServer.Umbrella.MixProject do
       File.cp!("apps/#{proj}/config/runtime.exs", Path.join(release_path, "app_config.exs"))
       release
     end
+  end
+
+  defp listeners do
+    if dependabot?(), do: [], else: [Phoenix.CodeReloader]
+  end
+
+  defp dependabot? do
+    Enum.any?(System.get_env(), fn {key, _value} -> String.starts_with?(key, "DEPENDABOT") end)
   end
 end


### PR DESCRIPTION
Dependabot updates for elixir [aren't working](https://github.com/batteries-included/batteries-included/actions/runs/17998106894/job/51201392803).

Due to:
phoenixframework/phoenix#6401
elixir-lang/elixir#14570


We'll be able to revert this after:
dependabot/dependabot-core#13143