### PR TITLE
test: attempt to make the robo sre tests not flakey on gh

### DIFF
--- a/platform_umbrella/apps/kube_services/lib/kube_services/robo_sre/executors/delete_resource_executor.ex
+++ b/platform_umbrella/apps/kube_services/lib/kube_services/robo_sre/executors/delete_resource_executor.ex
@@ -38,11 +38,13 @@ defmodule KubeServices.RoboSRE.DeleteResourceExecutor do
 
   @impl KubeServices.RoboSRE.Executor
   @spec execute(Action.t()) :: {:ok, any()} | {:error, any()}
-  def execute(%Action{action_type: :delete_resource} = action) do
-    GenServer.call(@me, {:execute, action})
+  def execute(target \\ @me, action)
+
+  def execute(target, %Action{action_type: :delete_resource} = action) do
+    GenServer.call(target, {:execute, action})
   end
 
-  def execute(%Action{action_type: other}) do
+  def execute(_, %Action{action_type: other}) do
     {:error, {:unsupported_action_type, other}}
   end
 

--- a/platform_umbrella/apps/kube_services/lib/kube_services/robo_sre/executors/restart_kube_state_executor.ex
+++ b/platform_umbrella/apps/kube_services/lib/kube_services/robo_sre/executors/restart_kube_state_executor.ex
@@ -33,12 +33,14 @@ defmodule KubeServices.RoboSRE.RestartKubeStateExecutor do
   end
 
   @impl KubeServices.RoboSRE.Executor
-  @spec execute(Action.t()) :: {:ok, any()} | {:error, any()}
-  def execute(%Action{action_type: :restart_kube_state} = action) do
-    GenServer.call(@me, {:execute, action})
+  @spec execute(GenServer.server(), Action.t()) :: {:ok, any()} | {:error, any()}
+  def execute(target \\ @me, action)
+
+  def execute(target, %Action{action_type: :restart_kube_state} = action) do
+    GenServer.call(target, {:execute, action})
   end
 
-  def execute(%Action{action_type: other}) do
+  def execute(_, %Action{action_type: other}) do
     {:error, {:unsupported_action_type, other}}
   end
 

--- a/platform_umbrella/config/test.exs
+++ b/platform_umbrella/config/test.exs
@@ -44,7 +44,7 @@ config :home_base_web, HomeBaseWeb.Endpoint,
 config :kube_services, start_services: false, cluster_type: :dev
 
 # Print only warnings and errors during test
-config :logger, level: "TEST_LOG_LEVEL" |> System.get_env("error") |> String.to_existing_atom()
+config :logger, level: "TEST_LOG_LEVEL" |> System.get_env("critical") |> String.to_existing_atom()
 
 config :wallaby,
   screenshot_on_failure: true,


### PR DESCRIPTION
Summary:
- Seems like there are other pids. I don't know how that could be
  possible, but this changes it so that DeleteResourceExecutorTest
  starts a process with a name and then uses the pid from then on.
- RestartKubeStateExecutorTest got the same treatment
- Both got some tests trimmed
- Changed the log levels for tests to get sanity back.

Test Plan:
- This is a test only PR
